### PR TITLE
fix(dvc): repair silently-broken list_files in the Python plugin

### DIFF
--- a/dvc-cargoship/dvc_cargoship/cli.py
+++ b/dvc-cargoship/dvc_cargoship/cli.py
@@ -218,19 +218,16 @@ class CargoShipCLI:
 
         Returns an empty list when the remote has no uploads or the command
         fails so that callers can treat a missing remote as an empty cache.
+
+        Implemented on top of ``cargoship info --json``: that command takes the
+        S3 URL as a positional argument and emits the full manifest as JSON
+        (whose ``files`` array holds the file entries). The ``cargoship list``
+        command, by contrast, requires ``--bucket``/``--upload-id`` flags and
+        prints human-readable text, not JSON.
         """
-        args: List[str] = ["list", destination, "--json"]
-        if upload_id is not None:
-            args += ["--upload-id", upload_id]
-        try:
-            result = self.run(*args)
-        except CargoShipCLIError:
-            return []
-        try:
-            data = json.loads(result.stdout)
-            return data if isinstance(data, list) else []
-        except json.JSONDecodeError:
-            return []
+        manifest = self.info(destination, upload_id=upload_id)
+        files = manifest.get("files", [])
+        return files if isinstance(files, list) else []
 
     def info(
         self,

--- a/dvc-cargoship/tests/test_cli.py
+++ b/dvc-cargoship/tests/test_cli.py
@@ -146,16 +146,24 @@ class TestUpload:
 
 
 class TestListFiles:
-    def _cli(self, stdout: str = "[]", returncode: int = 0):
+    # list_files() is implemented on top of `cargoship info --json`: it returns
+    # the manifest's "files" array. (The `cargoship list` command takes
+    # --bucket/--upload-id flags and prints human-readable text, not JSON, so it
+    # is not usable here.)
+    def _cli(self, stdout: str = "{}", returncode: int = 0):
         cli = CargoShipCLI(binary="cargoship")
         cli.run = MagicMock(return_value=_make_completed(returncode=returncode, stdout=stdout))
         return cli
 
-    def test_returns_parsed_list(self):
+    def test_returns_files_from_manifest(self):
         entries = [{"path": "a.txt", "size": 100, "content_hash": "abc"}]
-        cli = self._cli(stdout=json.dumps(entries))
+        cli = self._cli(stdout=json.dumps({"upload_id": "u-1", "files": entries}))
         result = cli.list_files("s3://b/p")
         assert result == entries
+
+    def test_returns_empty_list_when_no_files_key(self):
+        cli = self._cli(stdout=json.dumps({"upload_id": "u-1"}))
+        assert cli.list_files("s3://b/p") == []
 
     def test_returns_empty_list_on_cli_error(self):
         cli = CargoShipCLI(binary="cargoship")
@@ -166,8 +174,8 @@ class TestListFiles:
         cli = self._cli(stdout="not-json")
         assert cli.list_files("s3://b/p") == []
 
-    def test_returns_empty_list_when_json_not_list(self):
-        cli = self._cli(stdout='{"key": "value"}')
+    def test_returns_empty_list_when_files_not_list(self):
+        cli = self._cli(stdout='{"files": {"key": "value"}}')
         assert cli.list_files("s3://b/p") == []
 
     def test_includes_upload_id(self):
@@ -178,10 +186,11 @@ class TestListFiles:
         assert "u-123" in args
 
     def test_basic_args(self):
+        # Delegates to `info`: positional S3 URL + --json.
         cli = self._cli()
         cli.list_files("s3://b/p")
         args = cli.run.call_args[0]
-        assert args == ("list", "s3://b/p", "--json")
+        assert args == ("info", "s3://b/p", "--json")
 
 
 # ---------------------------------------------------------------------------

--- a/dvc-cargoship/tests/test_integration.py
+++ b/dvc-cargoship/tests/test_integration.py
@@ -8,7 +8,7 @@ the actual ``cargoship`` binary.
 The mock binary supports the subset of commands used by CargoShipCLI:
 - ``upload <source_dir> <dest_url> [flags...]``
 - ``restore <dest_url> <staging_dir> [--file <path>]``
-- ``list <dest_url> --json``
+- ``info <dest_url> --json`` (manifest with a ``files`` array; backs list_files)
 """
 
 from __future__ import annotations
@@ -82,8 +82,11 @@ def mock_cargoship(tmp_path) -> Tuple[str, str]:
                 shutil.copy2(src, dst)
 
 
-        def cmd_list(_argv):
+        def cmd_info(argv):
             # argv: <s3://...> --json [--upload-id <id>]
+            # Emit the manifest as JSON, matching the real binary's
+            # `cargoship info --json` (manifest.ToJSON): an object whose "files"
+            # array holds the file entries.
             entries = []
             for root, _dirs, files in os.walk(STORE):
                 for fname in files:
@@ -94,10 +97,14 @@ def mock_cargoship(tmp_path) -> Tuple[str, str]:
                         "size": os.path.getsize(full),
                         "content_hash": "",
                     }})
-            print(json.dumps(entries))
+            print(json.dumps({{
+                "version": "2.0",
+                "total_files": len(entries),
+                "files": entries,
+            }}))
 
 
-        COMMANDS = {{"upload": cmd_upload, "restore": cmd_restore, "list": cmd_list}}
+        COMMANDS = {{"upload": cmd_upload, "restore": cmd_restore, "info": cmd_info}}
         cmd = sys.argv[1] if len(sys.argv) > 1 else ""
         handler = COMMANDS.get(cmd)
         if handler is None:


### PR DESCRIPTION
## The bug

`CargoShipCLI.list_files()` (dvc-cargoship Python plugin) shelled out:

```
cargoship list <s3-url> --json
```

But the real `cargoship list` command takes `--bucket` + `--upload-id` **flags**
(no positional S3 URL, no `--json`) and prints **human-readable text**, not JSON.
So every call either errored or failed to parse — and because `list_files`
catches both and returns `[]`, it **silently returned an empty list every time**.

Impact: `remote.py`'s `ls()` (line 240) and `find()` (line 422) always saw an
empty cache. It hid because the unit tests mocked `run`, and the integration
test's mock binary implemented the *same fictional* `list` contract — so neither
layer exercised the real CLI.

## The fix

Reimplement `list_files()` on top of `cargoship info --json`, which **does** take
a positional S3 URL and emits the manifest as JSON (via `manifest.ToJSON()`). The
manifest's `files` array is exactly the list of entries callers want. The
plugin's own `info()` method already used this working contract.

- `cli.py`: `list_files` now delegates to `info` and returns `manifest["files"]`.
- `tests/test_cli.py`: `TestListFiles` updated to the `info --json` contract
  (asserts `("info", "s3://b/p", "--json")`, reads the `files` key).
- `tests/test_integration.py`: the mock binary now implements `info --json`
  (manifest object with a `files` array) instead of the bogus `list`.

## Verification

- Full Python suite: **190 passed** (`uv run pytest`).
- No behavior change for callers that already got `[]` from an unreachable remote
  (both paths still return `[]`); the difference is that a *populated* remote now
  actually returns its files.

Found during the docs follow-up (#217); flagged there, fixed here.