### PR TITLE
docs: sync governance files + add project maturity matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,13 @@ Thank you for your interest in contributing to CargoShip! This project builds up
 
 ### Prerequisites
 
-- **Go 1.21+** - CargoShip is written in Go
-- **Docker** - For integration testing with LocalStack
-- **AWS CLI** (optional) - For real AWS testing
-- **Pre-commit hooks** - Automatic code quality checks
+- **Go 1.26+** - CargoShip is written in Go (see `go.mod`)
+- **AWS CLI** (optional) - Only for opt-in real-AWS testing
+- **Pre-commit hooks** - Automatic code quality/security checks
+
+> Integration tests run against an **in-process Substrate emulator** — no Docker
+> or LocalStack required (this replaced the old Docker/LocalStack setup in
+> v0.13.1).
 
 ### Development Setup
 
@@ -38,10 +41,10 @@ Thank you for your interest in contributing to CargoShip! This project builds up
    make test
    go test -race ./...
    ```
-
-5. **Start Development Environment**
+   Integration tests use an in-process emulator, so no external services are
+   needed:
    ```bash
-   docker-compose -f docker/development/docker-compose.yml up -d
+   go test -tags integration ./...
    ```
 
 ## 📋 Development Process
@@ -84,7 +87,7 @@ Our pre-commit hook automatically runs:
    go test -short ./...
    ```
 
-2. **Integration Tests** - LocalStack S3 testing
+2. **Integration Tests** - in-process Substrate S3 emulator (no Docker)
    ```bash
    go test -tags integration ./...
    ```
@@ -105,7 +108,8 @@ Our pre-commit hook automatically runs:
 - **Bug fixes**: Must include regression tests
 - **Performance features**: Must include benchmarks
 
-Current coverage: **95%+** across all modules
+The pre-commit hook enforces a project-wide coverage floor (currently 56%) and a
+code-quality score; check the current number with `make test-coverage`.
 
 ### Test Patterns
 
@@ -183,9 +187,9 @@ func TestFeature(t *testing.T) {
 ### Bug Report Template
 
 ```markdown
-**CargoShip Version**: v0.4.0
-**Go Version**: 1.21.5
-**OS**: Ubuntu 22.04
+**CargoShip Version**: (output of `cargoship --version`)
+**Go Version**: (output of `go version`)
+**OS**: e.g. Ubuntu 22.04
 
 **Description**
 Clear description of the bug.

--- a/README.md
+++ b/README.md
@@ -54,13 +54,9 @@ See the [Installation Guide](https://cargoship.app/start/install) for more optio
 # 1. Estimate costs before uploading
 cargoship estimate /data/project-2024 --storage-class deep-archive
 
-# 2. Upload with streaming pipeline (NEW in v0.5.1+)
-cargoship create upload /data/completed-analysis \
-  --bucket my-bucket \
-  --prefix project-2024 \
-  --storage-class INTELLIGENT_TIERING \
-  --shards 8 \
-  --workers 4
+# 2. Upload a directory to S3 (canonical command)
+cargoship upload /data/completed-analysis s3://my-bucket/project-2024 \
+  --storage-class INTELLIGENT_TIERING
 
 # Real-time progress display:
 # 🚢 Uploading: 1234 files | 5.67 GB | 89 chunks | 123.4 MB/s | 1m30s elapsed
@@ -99,7 +95,7 @@ $ cargoship estimate ./genomics-analysis --show-breakdown
 Total annual savings: $3,170/year with 8x upload performance
 
 ✅ Available Now:
-• `cargoship create upload` - High-performance streaming uploads
+• `cargoship upload` - Sharded, compressed, verifiable uploads
 • `cargoship lifecycle` - Automated lifecycle policy management
 • `cargoship budget` - Project-based cost and volume quota tracking
 • Real-time progress tracking with TUI
@@ -374,7 +370,9 @@ CargoShip uses a modern streaming pipeline architecture for maximum performance:
 
 ### Performance Tuning
 
-Optimize CargoShip for your workload:
+For fine-grained pipeline control, the advanced `cargoship create upload` variant
+exposes explicit worker/chunk/shard tuning (most users should use the canonical
+`cargoship upload` — see [upload vs. create upload](https://cargoship.app/guides/upload-vs-create-upload)):
 
 ```bash
 # For many small files (<1MB):
@@ -472,6 +470,7 @@ Full documentation lives at **[cargoship.app](https://cargoship.app)**.
 ### Architecture & Format
 - **[Archive & Manifest Format Spec](https://cargoship.app/reference/format/)** - Open, portable format for data portability
 - **[Architecture](https://cargoship.app/project/architecture)** - System design
+- **[Project Maturity & Compatibility](https://cargoship.app/project/maturity)** - What's stable vs. beta, and what's guaranteed
 - **[Manifest System](pkg/manifest/README.md)** - File indexing and fast query API
 
 ### Cost & Budget

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,23 +1,36 @@
 # CargoShip Release Roadmap
 
-**Last Updated**: February 2026
-**Current Version**: v0.12.0 (Released)
-**Next Release**: v0.13.0 (In Development)
+**Last Updated**: July 2026
+**Current Version**: v0.13.2 (Released 2026-07-07)
+**Next Release**: v0.14.0 (Planning)
 
 This document outlines the planned feature releases for CargoShip, organized by version with clear deliverables and timelines.
 
 ---
 
-## 🚧 **v0.13.0 - DVC Pipeline Auto-Discovery** (In Development)
-**Status**: In Development — closes the gap where `FileEntry.DVCMetadata.Stage` was never populated during real uploads
+## ✅ **v0.13.2 - CI Repair & Security Hardening** (RELEASED July 2026)
+**Status**: Complete
 
-### Planned Features:
-- 🚧 **`BuildFileStageIndex`** — parse `dvc.yaml` → map of output path → stage name
-- 🚧 **`AnnotateFilesWithDVCStages`** — walk `[]FileEntry` and set `DVCMetadata.Stage` via stage index
-- 🚧 **`cargoship upload --dvc-auto`** — auto-discover DVC stages from `dvc.yaml` and annotate each file entry; re-uploads manifest so stage-aware commands function in production
-- 🚧 **`cargoship dvc stages <S3_URL>`** — list pipeline stages and file counts from manifest
-- 🚧 **`cargoship dvc status <LOCAL_PATH> <S3_URL>`** — compare local files against manifest (unchanged / modified / missing), with optional `--stage` filter
-- 🚧 **`cargoship dvc export <S3_URL> [OUTPUT_DIR]`** — generate `.dvc` sidecar files from manifest `ContentHash` entries
+- ✅ Repaired CI (broken since February); Substrate emulator import fixes, `go.sum`/dependency reconciliation
+- ✅ Multi-scanner security workflow: govulncheck, gitleaks, Trivy, Semgrep — all SHA-pinned
+- ✅ Dependency CVE fixes (go-git, aws-sdk-go-v2, x/text, grpc); same-origin WebSocket checks; non-root containers
+- ✅ New VitePress documentation site at cargoship.app; stub pages expanded
+
+## ✅ **v0.13.1 - Substrate Test Migration** (RELEASED 2026-03-18)
+**Status**: Complete
+
+- ✅ Migrated all integration tests from LocalStack to an in-process Substrate emulator (no Docker required)
+- ✅ Removed LocalStack endpoint hard-codes; real-AWS path retained via `CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS=1`
+
+## ✅ **v0.13.0 - DVC Pipeline Auto-Discovery** (RELEASED 2026-02)
+**Status**: Complete — populates `FileEntry.DVCMetadata.Stage` during real uploads
+
+- ✅ **`BuildFileStageIndex`** — parse `dvc.yaml` → map of output path → stage name
+- ✅ **`AnnotateFilesWithDVCStages`** — walk `[]FileEntry` and set `DVCMetadata.Stage` via stage index
+- ✅ **`cargoship upload --dvc-auto`** — auto-discover DVC stages from `dvc.yaml` and annotate each file entry; re-uploads manifest so stage-aware commands function in production
+- ✅ **`cargoship dvc stages <S3_URL>`** — list pipeline stages and file counts from manifest
+- ✅ **`cargoship dvc status <LOCAL_PATH> <S3_URL>`** — compare local files against manifest (unchanged / modified / missing), with optional `--stage` filter
+- ✅ **`cargoship dvc export <S3_URL> [OUTPUT_DIR]`** — generate `.dvc` sidecar files from manifest `ContentHash` entries
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,181 +1,77 @@
 # Security Policy
 
-## Overview
-
-CargoShip takes security seriously. This document outlines our security practices, vulnerability reporting process, and supported versions for security updates.
-
 ## Supported Versions
 
-We provide security updates for the following versions of CargoShip:
+CargoShip is in the `0.x` series and ships fixes on the latest release line.
+Security updates are provided for the current minor release; older lines are not
+backported.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.3.x   | :white_check_mark: |
-| 0.2.x   | :x:                |
-| < 0.2   | :x:                |
+| Version | Supported |
+| ------- | --------- |
+| 0.13.x  | :white_check_mark: |
+| < 0.13  | :x: |
 
-## Security Scanning and Monitoring
-
-CargoShip implements comprehensive security measures:
-
-### Automated Security Scanning
-- **Daily vulnerability scans** using `govulncheck`
-- **Static security analysis** with `gosec` 
-- **Dependency vulnerability monitoring** with Nancy and Trivy
-- **CodeQL security analysis** for advanced threat detection
-- **Semgrep security patterns** for additional vulnerability detection
-- **License compliance checking** with go-licenses
-- **Supply chain security** with SBOM generation and scanning
-
-### Pre-commit Security Validation
-- **Vulnerability scanning** before every commit
-- **Security linting** with gosec rules
-- **Zero-tolerance policy** for known vulnerabilities
-- **Dependency verification** and consistency checks
-
-### Dependency Management
-- **Automated dependency updates** via Dependabot
-- **Weekly security updates** for all dependencies
-- **Grouped security patches** for immediate deployment
-- **Vulnerability alerts** for critical issues
-
-## Security Features
-
-### Data Protection
-- **End-to-end encryption** using OpenPGP (ProtonMail/gopenpgp)
-- **Secure key management** with gpg integration
-- **TLS encryption** for all network communications
-- **Secure credential handling** with AWS SDK best practices
-
-### Access Controls
-- **Bearer token authentication** for agent connections
-- **Role-based access control** in multi-agent environments
-- **Secure WebSocket connections** with authentication
-- **Environment-based configuration** to prevent credential exposure
-
-### Audit and Monitoring
-- **Comprehensive logging** of all security events
-- **Activity tracking** for agent connections and operations
-- **Error reporting** without sensitive data exposure
-- **Performance monitoring** with security metrics
+Always run the [latest release](https://github.com/scttfrdmn/cargoship/releases/latest).
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in CargoShip, please follow these steps:
-
-### 1. Do Not Create Public Issues
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-### 2. Contact Information
-Send detailed vulnerability reports to: **security@cargoship.dev**
+Report privately via GitHub Security Advisories:
+**[Report a vulnerability](https://github.com/scttfrdmn/cargoship/security/advisories/new)**
 
-### 3. Required Information
-Please include the following information:
-- **Description** of the vulnerability
-- **Steps to reproduce** the issue
-- **Potential impact** assessment
-- **Suggested remediation** (if available)
-- **Your contact information** for follow-up
+Include what you can: a description, reproduction steps, the affected
+version/commit, and impact. As a small open-source project we triage reports on a
+best-effort basis — there is no contractual response-time SLA. We aim to
+acknowledge reports promptly, agree on a disclosure timeline with the reporter,
+and credit reporters who wish to be named.
 
-### 4. Response Timeline
-- **Initial acknowledgment**: Within 24 hours
-- **Initial assessment**: Within 72 hours
-- **Regular updates**: Every 5 business days
-- **Resolution target**: Based on severity (see below)
+## How the project is secured
 
-## Vulnerability Severity and Response Times
+Security scanning runs in CI (`.github/workflows/security.yml`) on every push,
+pull request, and weekly:
 
-| Severity | Description | Response Time | Patch Timeline |
-|----------|-------------|---------------|----------------|
-| **Critical** | Remote code execution, privilege escalation | 24 hours | 7 days |
-| **High** | Data exposure, authentication bypass | 72 hours | 14 days |
-| **Medium** | Limited data exposure, DoS vulnerabilities | 5 days | 30 days |
-| **Low** | Information disclosure, minor security issues | 10 days | 60 days |
+- **govulncheck** — Go vulnerability database scanning (pinned to a working
+  version), across the root module and every nested `go.mod`.
+- **gitleaks** — full-history secret scanning.
+- **Trivy** — filesystem vulnerability + secret scanning and IaC misconfiguration
+  scanning.
+- **Semgrep** — static analysis (`--config=auto`), failing the build on findings.
 
-## Security Best Practices for Users
+All GitHub Actions are pinned to commit SHAs. On the repository itself,
+**Dependabot** alerts and security updates, **secret scanning**, and **push
+protection** are enabled. The pre-commit hook additionally runs `govulncheck`
+with a zero-known-vulnerability policy, so dependency CVEs are caught before they
+land.
 
-### Installation and Updates
-- Always use the latest supported version
-- Enable automatic security updates where possible
-- Verify package signatures and checksums
-- Download only from official sources
+## Security model
 
-### Configuration Security
-- Use strong, unique authentication tokens
-- Enable TLS for all network communications
-- Regularly rotate credentials and keys
-- Follow principle of least privilege for permissions
+CargoShip's data-protection model has two distinct layers — see the
+[Security model](https://cargoship.app/project/security) and the
+[Encryption metadata spec](https://cargoship.app/reference/format/encryption) for
+detail:
 
-### Operational Security
-- Monitor logs for suspicious activity
-- Implement network segmentation
-- Use dedicated service accounts
-- Regular security assessments
+- **Archive chunks** are encrypted server-side by S3. With `--kms-key-id`,
+  objects use SSE-KMS; otherwise standard server-side encryption applies.
+- **The manifest** can additionally be **client-side envelope-encrypted**
+  (`--encrypt-manifest`): a KMS-generated data key encrypts the manifest with
+  AES-256-GCM, and the KMS-wrapped data key is stored alongside it.
+- **GPG** key generation is available (`cargoship create keys`) for workflows that
+  sign or encrypt with OpenPGP, but it is not the primary data-protection
+  mechanism.
 
-### Data Protection
-- Encrypt sensitive data at rest
-- Use secure backup practices
-- Implement proper data retention policies
-- Regular access reviews
+Operational controls: uploads use the standard AWS credential chain (CargoShip
+stores no credentials of its own); distributed agent/controller connections
+require an auth token and support TLS; browser-facing WebSocket upgraders enforce
+a same-origin check. Grant only the S3 (and optional KMS) permissions the
+workflow needs — see [AWS setup](https://cargoship.app/start/aws-setup).
 
-## Security Hardening
+## User best practices
 
-### Environment Setup
-```bash
-# Enable comprehensive security scanning
-export CARGOSHIP_SECURITY_MODE=strict
-
-# Use TLS for all connections
-export CARGOSHIP_TLS_REQUIRED=true
-
-# Enable audit logging
-export CARGOSHIP_AUDIT_LOG=enabled
-```
-
-### Agent Configuration
-```yaml
-# Secure agent configuration
-security:
-  tls_enabled: true
-  auth_required: true
-  audit_logging: true
-  strict_mode: true
-```
-
-## Third-Party Security Tools
-
-CargoShip integrates with industry-standard security tools:
-
-- **govulncheck**: Go vulnerability database scanning
-- **gosec**: Static security analysis for Go
-- **Nancy**: Dependency vulnerability scanning
-- **Trivy**: Container and filesystem vulnerability scanning
-- **CodeQL**: Semantic code analysis
-- **Semgrep**: Static analysis security patterns
-
-## Compliance and Standards
-
-CargoShip follows security best practices including:
-
-- **OWASP Top 10** mitigation strategies
-- **CIS Security Benchmarks** where applicable
-- **NIST Cybersecurity Framework** principles
-- **Supply Chain Security** best practices
-
-## Security Resources
-
-- [Go Security Guidelines](https://golang.org/security/)
-- [AWS Security Best Practices](https://aws.amazon.com/architecture/security-identity-compliance/)
-- [OWASP Go Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Go_SCP_Cheat_Sheet.html)
-
-## Contact
-
-For general security questions or concerns:
-- **Email**: security@cargoship.dev
-- **GitHub**: Create a private security advisory
-- **Documentation**: Check our security documentation
-
----
-
-**Last Updated**: December 2024
-**Next Review**: Quarterly
+- Run the latest release; let Dependabot keep dependencies current.
+- Scope IAM to the exact bucket/prefix you archive to; add KMS permissions only
+  if you use `--kms-key-id`.
+- Use `--kms-key-id` and `--encrypt-manifest` for sensitive datasets.
+- Prefer the credential chain (profiles, roles, SSO) over long-lived access keys.
+- For distributed mode, set an explicit auth token and enable TLS whenever the
+  controller is reachable beyond localhost.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -161,6 +161,7 @@ const sidebar = {
       collapsed: true,
       items: [
         { text: 'Architecture', link: '/project/architecture' },
+        { text: 'Project maturity & compatibility', link: '/project/maturity' },
         { text: 'Security model', link: '/project/security' },
         { text: 'API stability & versioning', link: '/project/versioning' },
         { text: 'Attribution & license', link: '/project/attribution' },

--- a/docs/project/maturity.md
+++ b/docs/project/maturity.md
@@ -1,0 +1,50 @@
+# Project maturity & compatibility
+
+CargoShip is production-oriented software, but it is still in the `v0.x` series
+and maintained by a small open-source team. This page states plainly what is
+stable, what is still evolving, and what guarantees you can (and can't) rely on —
+so you can judge it against your own risk tolerance. For the semantic-versioning
+rules behind these levels, see [API stability & versioning](/project/versioning).
+
+## Component maturity
+
+| Capability | Status | What that means |
+|-----------|--------|-----------------|
+| **Archive & manifest format** | **Stable** | Documented in the [format spec](/reference/format/). Manifest is `v2.0`; `v1.0` remains readable. Backward-readable across the versions the spec states — your archives don't become unreadable on upgrade. |
+| **Core upload / verify / restore** | **Stable** | The canonical `cargoship upload`, `verify`, `download`, and `restore` paths are covered by integration + regression tests. |
+| **Cost, budget & lifecycle** | **Stable** | Estimation, budgets/quotas, and lifecycle commands are established. |
+| **Sharding & compression** | **Stable** | Multi-prefix sharding and content-aware zstd are core to the pipeline. |
+| **Encryption (SSE / KMS-envelope manifest)** | **Stable** | See the [security model](/project/security). |
+| **DVC integration** | **Beta** | The Go `dvc` commands and Python plugin work; command surface and metadata may change between minor releases (changes are documented per release). |
+| **Magika AI file detection** | **Beta / opt-in** | Requires `pip install magika`; degrades gracefully when absent. |
+| **Multi-region** | **Experimental** | A library capability in `pkg/multiregion`, **not** wired into `cargoship upload` today — see the [multi-region note](/guides/features/multi-region). Use `--region` + sharding for in-region parallelism. |
+| **Distributed agents / controller / ghost-ship** | **Beta** | Functional; configuration and wire formats may change. See [Distributed / Enterprise](/enterprise/). |
+| **Public Go API** | **Mixed** | Stability is per-package — some packages are stable, others beta. See [API stability](/project/versioning#stability-levels-for-the-go-library). |
+
+## Guarantees
+
+- **Archive compatibility** — archives written by a given release stay readable by
+  later releases within the format-version guarantees in the spec. This is the
+  guarantee that matters most for archival software, and it's the one we hold
+  most firmly.
+- **Semantic versioning** — `v0.PATCH` is always safe to upgrade;
+  `v0.MINOR` *may* carry documented breaking changes while pre-1.0. See
+  [versioning](/project/versioning).
+- **Security** — the current minor release receives security fixes; see the
+  [Security Policy](https://github.com/scttfrdmn/cargoship/blob/main/SECURITY.md).
+
+## What is *not* promised
+
+- **No support SLA.** Issues and vulnerability reports are handled best-effort by
+  a small team — there is no contractual response or resolution time.
+- **No recovery-time objective** for the distributed/agent components.
+- **Pre-1.0 API churn.** Beta and experimental components may change shape between
+  minor releases; pin a version if you need stability.
+
+## Using it in production today
+
+Reasonable if you: pin a specific release, rely on the **stable** components, keep
+`verify` in your workflow (prove the round trip), and treat beta/experimental
+features as opt-in. The archive format's portability — plain `tar.zst` objects
+plus a documented JSON manifest — means your data isn't hostage to the tool even
+if you stop using it.

--- a/docs/start/aws-setup.md
+++ b/docs/start/aws-setup.md
@@ -53,18 +53,32 @@ bucket. A minimal policy:
     {
       "Sid": "CargoShipBucketLevel",
       "Effect": "Allow",
-      "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads"
+      ],
       "Resource": "arn:aws:s3:::my-bucket"
     },
     {
       "Sid": "CargoShipObjectLevel",
       "Effect": "Allow",
-      "Action": ["s3:PutObject", "s3:GetObject", "s3:DeleteObject"],
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
       "Resource": "arn:aws:s3:::my-bucket/*"
     }
   ]
 }
 ```
+
+Large files upload via S3 multipart, which is why the multipart actions are
+included (`s3:PutObject` authorizes create/upload-part; `AbortMultipartUpload`
+lets CargoShip clean up interrupted uploads).
 
 Add these only if you use the matching features:
 

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -22,7 +22,7 @@ brew install scttfrdmn/tap/cargoship
 
 ## Go install
 
-If you already have Go 1.23+:
+If you already have Go 1.26+:
 
 ```bash
 go install github.com/scttfrdmn/cargoship/cmd/cargoship@latest


### PR DESCRIPTION
Addresses the **Priority 0** findings from the project review: repo-level docs
described CargoShip a few architectural generations back while the new site was
accurate. This resyncs them to the current v0.13.2 reality.

## Changes

**SECURITY.md** — rewritten to match reality:
- Supported versions `0.3.x` → `0.13.x`
- Removed fictional env vars (`CARGOSHIP_SECURITY_MODE`, `_TLS_REQUIRED`, `_AUDIT_LOG`) and the OpenPGP-as-primary framing
- Describes the actual **KMS / envelope-encrypted-manifest** model
- Lists the real scanners (govulncheck, gitleaks, Trivy, Semgrep — not the old gosec/Nancy/CodeQL list)
- Reporting via **GitHub Security Advisories**; removed the unverified email and the fake response-time SLA

**CONTRIBUTING.md**:
- Go `1.21` → `1.26`
- Removed Docker/LocalStack (integration tests use the in-process **Substrate emulator** since v0.13.1)
- Replaced the unbacked "95%+ coverage" with the real pre-commit coverage gate
- Fixed the bug-report version template (was hardcoded v0.4.0 / Go 1.21.5)

**ROADMAP.md** — current **v0.13.2** (was "v0.12.0 / v0.13.0 in development"); marked v0.13.0–0.13.2 released.

**README.md**:
- Basic Workflow now leads with canonical `cargoship upload SRC s3://...`
- Moved `create upload` (with its real `--chunk-size-mb/--workers/--shards`) to the advanced Performance Tuning section, pointing at the upload-vs-create-upload guide
- Added a Project Maturity link

**docs/start/aws-setup.md** — added the S3 **multipart IAM actions** so the minimal policy matches what troubleshooting says uploads need.

**docs/start/install.md** — Go `1.23` → `1.26`.

**New `docs/project/maturity.md`** — component maturity matrix (stable / beta / experimental) plus explicit guarantees and non-guarantees (archive compatibility yes; support SLA no), so "enterprise / production-ready" is backed honestly. Wired into the sidebar and README.

## Verification
- Site builds clean, no dead links; all new cross-links resolve.
- Confirmed every stale marker is gone (0.3.x, CARGOSHIP_SECURITY_MODE, Go 1.21, 95%, v0.12-current).

## Also checked (no action needed)
The review's "stale v0.4.0/MIT page at site root" was investigated: apex, www, sitemap, llms.txt, 404, OG metadata, and the Pages deploy all return current content — it was a transient Fastly edge-cache artifact from the pre-migration legacy deploy, since refreshed.

Scope: Priority 0 items + the maturity matrix. P1/P2 items from the review (CI guard against stale version strings, reproducible benchmark page, comparison table, recovery runbook, FAQ expansion) are deferred.