### PR TITLE
docs: comparison page, recovery runbook, expanded FAQ

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -124,6 +124,8 @@ const sidebar = {
         { text: 'Global flags', link: '/reference/commands/global-flags' },
         { text: 'Environment variables', link: '/reference/environment-variables' },
         { text: 'Configuration schema', link: '/reference/configuration' },
+        { text: 'CargoShip vs. other tools', link: '/reference/comparison' },
+        { text: 'Recovery & operations runbook', link: '/reference/recovery' },
         { text: 'Troubleshooting', link: '/reference/troubleshooting' },
         { text: 'FAQ', link: '/reference/faq' },
         { text: 'Glossary', link: '/reference/glossary' },

--- a/docs/reference/comparison.md
+++ b/docs/reference/comparison.md
@@ -1,0 +1,54 @@
+# CargoShip vs. other tools
+
+CargoShip isn't a general-purpose S3 client. It's built specifically for
+archiving **large directory trees of many files** to S3 cheaply, verifiably, and
+reversibly. This page is an honest guide to when it's the right tool and when a
+simpler one is.
+
+## At a glance
+
+| | `aws s3 cp/sync` | `rclone` | `tar` → `aws s3 cp` | DVC remote | **CargoShip** |
+|---|---|---|---|---|---|
+| One object per file | yes | yes | no (one blob) | via cache | **no — packs into chunks** |
+| Handles many small files well | request-heavy | request-heavy | yes (opaque) | ok | **yes — chunked** |
+| Compression | no | no | manual | no | **yes (content-aware zstd)** |
+| Selective single-file restore | yes | yes | **no — full download** | yes | **yes (from a chunk)** |
+| Integrity manifest + `verify` | no | check flags | no | hashes | **yes** |
+| Cost estimate before upload | no | no | no | no | **yes** |
+| Storage-class / tier automation | flags | flags | manual | no | **yes** |
+| Resumable / incremental | sync | yes | no | yes | **yes** |
+| Open, tool-independent format | yes (raw) | yes (raw) | yes (tar) | opaque cache | **yes (tar.zst + JSON manifest)** |
+
+## When to use each
+
+**`aws s3 cp` / `aws s3 sync`** — the right choice for a handful of files, or when
+you want each file to remain an individually-addressable S3 object. Simple,
+ubiquitous, no packing. Downsides at scale: one PUT per file (request cost and
+throughput), no compression, no cost preview.
+
+**`rclone`** — excellent general-purpose sync across many cloud backends, with
+filtering and bandwidth control. Reach for it for ongoing folder sync or
+multi-cloud. It doesn't pack/compress into archives or produce a verifiable
+manifest, so per-file request overhead and retrieval guarantees are on you.
+
+**`tar` piped to `aws s3 cp`** — fine for "one dataset, one blob, restore the whole
+thing." You lose selective restore (you must download the entire archive to get
+one file), get no manifest/index, and manage compression and multipart yourself.
+
+**DVC remotes** — the right tool for versioning ML datasets and wiring data into
+pipelines. CargoShip complements rather than replaces it: the
+[`dvc-cargoship` plugin](/guides/dvc/plugin) can serve as a faster DVC remote, and
+`cargoship upload --dvc-auto` records DVC stage provenance in the manifest.
+
+**CargoShip** — the right choice when you have **large trees of many files** to
+land in S3 as compressed, indexed, integrity-checked archives, want to **estimate
+cost first**, need **selective restore without downloading everything**, and care
+that the result stays **readable with standard tools**. Its sweet spot is research
+and technical datasets (genomics, imaging, sensor, analytics output) and bulk
+archival — cases where per-file copy tools create excessive requests, give weak
+recovery guarantees, or make cost hard to predict.
+
+## Migrating
+
+Already using rclone or the AWS CLI? See
+[Migrating from rclone / aws cli](/tutorials/migrating).

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -29,6 +29,68 @@ delete` or `scuttle`) are separate, explicit commands; see
 [Destructive operations](/reference/commands/destructive) and
 [Costs & safety guarantees](/intro/costs-and-safety).
 
+## What AWS credentials does it use?
+
+The standard AWS credential chain — the same one the AWS CLI uses (environment
+variables, `AWS_PROFILE`, `~/.aws/*`, or an IAM role). If `aws s3 ls` works,
+CargoShip works. CargoShip stores no credentials of its own. See
+[AWS setup](/start/aws-setup).
+
+## What S3 permissions do I need?
+
+Read/write on the target bucket, including the multipart actions large uploads
+use. The [minimal IAM policy](/start/aws-setup#minimal-iam-policy) lists exactly
+what to grant (and which extra permissions Glacier restores and KMS need).
+
+## What happens if an upload is interrupted?
+
+Nothing is corrupted — an incomplete upload just leaves some chunks in S3 and a
+saved state file in `~/.cargoship/state/`. Re-run the same command and CargoShip
+detects the state and resumes; `--force-restart` ignores it and starts fresh. See
+[Resuming interrupted uploads](/guides/resuming) and the
+[recovery runbook](/reference/recovery).
+
+## Is it safe to retry a failed upload?
+
+Yes. Uploads are idempotent at the chunk level — re-running re-uploads only what's
+missing, and object keys are deterministic so a retry overwrites the same key
+rather than duplicating data. Transient S3 errors are retried automatically
+(3 attempts by default). Details in [Recovery](/reference/recovery#retries-and-idempotency).
+
+## How do I clean up a partial or unwanted upload?
+
+`cargoship delete s3://…/uploads/<id> --dry-run` to preview, then without
+`--dry-run` to remove that one upload. Orphaned S3 multipart uploads from a hard
+crash can be listed and aborted with `aws s3api list-multipart-uploads` /
+`abort-multipart-upload`. See [Clean up](/start/cleanup).
+
+## My data is in Glacier / Deep Archive — how do I get it back?
+
+`cargoship restore` handles the thaw: `--tier` picks the retrieval speed
+(`expedited` 1–5 min, `standard` 3–5 h, `bulk` 5–12 h), `--wait` blocks until it's
+ready, and `--dry-run` / `--max-restore-cost` let you see or cap the retrieval
+cost first. See [Restoring files](/guides/restoring#glacier).
+
+## Will archives written today still be readable later?
+
+Yes — the archive/manifest format is versioned and backward-readable within the
+guarantees in the [format spec](/reference/format/) and
+[maturity page](/project/maturity). And since chunks are plain `tar.zst`, you can
+always fall back to standard tools.
+
+## How much memory does it use?
+
+Bounded — roughly `chunk_size × workers`, not the size of your dataset, because
+data streams to S3 without staging to disk. A multi-terabyte upload runs in a few
+GB. See [How it works](/intro/how-it-works).
+
+## How do I keep costs predictable?
+
+Run `cargoship estimate` before uploading, tag uploads with `--project` and set
+[budgets and quotas](/guides/cost/budgets), and choose a
+[storage class](/guides/cost/lifecycle) that matches your access pattern. Cold
+classes store cheaply but cost more (and take longer) to retrieve.
+
 ## See also
 
 - [Concepts & terminology](/intro/concepts).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -28,6 +28,8 @@ binary actually accepts.
 
 - [Environment variables](/reference/environment-variables)
 - [Configuration schema](/reference/configuration)
+- [CargoShip vs. other tools](/reference/comparison)
+- [Recovery & operations runbook](/reference/recovery)
 - [Troubleshooting](/reference/troubleshooting) · [FAQ](/reference/faq)
 - [Glossary](/reference/glossary) · [Cheat sheet](/reference/cheatsheet)
 

--- a/docs/reference/recovery.md
+++ b/docs/reference/recovery.md
@@ -1,0 +1,99 @@
+# Recovery & operations runbook
+
+What to do when something goes wrong mid-upload or mid-restore. Each scenario is
+safe to work through — CargoShip never modifies your source files, and its S3
+operations are designed to be re-runnable.
+
+## Retries and idempotency
+
+- **Automatic retries.** Transient S3 errors are retried automatically — 3
+  attempts per chunk by default (configurable via the `aws.max_retries` config
+  key). Each retry is traced when tracing is enabled.
+- **Chunk-level idempotency.** Object keys are deterministic
+  (`…/uploads/<id>/shard-N/chunk-M.tar.zst`), so re-running an upload overwrites
+  the same keys rather than duplicating data. Re-uploading is safe.
+- **Resume, don't restart.** An interrupted `cargoship upload` leaves a state
+  file in `~/.cargoship/state/`; re-running the same command resumes from it.
+  The streaming variant additionally offers `--skip-existing` (HeadObject check
+  to skip chunks already in S3).
+
+## Scenarios
+
+### Interrupted upload (Ctrl-C, network drop, crash)
+
+Nothing is corrupted — you have some chunks in S3 and a saved state file. Just
+re-run the same command:
+
+```bash
+cargoship upload ./data s3://my-bucket/prefix
+# → detects saved state, resumes the incomplete upload
+```
+
+To start over instead, `--force-restart`. To inspect or tidy saved states:
+`cargoship resume list` and `cargoship resume clean --older-than 168h`. See
+[Resuming interrupted uploads](/guides/resuming).
+
+### Orphaned S3 multipart uploads
+
+A hard crash can leave incomplete S3 multipart uploads that quietly accrue
+storage cost. List and abort them (also a good candidate for an S3 lifecycle rule
+that auto-aborts after N days):
+
+```bash
+aws s3api list-multipart-uploads --bucket my-bucket
+aws s3api abort-multipart-upload --bucket my-bucket --key KEY --upload-id UPLOAD_ID
+```
+
+### Missing or unreadable manifest
+
+The manifest is the index for an upload. If `info`/`list`/`restore` can't read it:
+
+- Confirm the exact upload path: `aws s3 ls s3://my-bucket/prefix/uploads/`.
+- The manifest may be gzip (`manifest.json.gz`) or KMS-encrypted
+  (`manifest.encrypted.json.gz`). If encrypted, ensure your identity still has
+  `kms:Decrypt` on the key.
+- No manifest at all usually means the upload never completed — re-run the upload
+  (it resumes and rewrites the manifest on completion).
+- Worst case, your data is still recoverable without the manifest: the chunks are
+  plain `tar.zst` objects you can download and unpack with standard tools.
+
+### A chunk fails verification / looks damaged
+
+```bash
+cargoship verify s3://my-bucket/prefix/uploads/<id> --verbose
+```
+
+`verify` checks the archive against the manifest's recorded checksums and exits
+non-zero on any mismatch. If a specific chunk is bad, re-upload — chunk keys are
+deterministic, so re-running overwrites the damaged object in place. Use
+`--quick` for a fast metadata-only check.
+
+### Expired or rotated credentials mid-run
+
+You'll see `AccessDenied` / expired-token errors. Refresh credentials (renew SSO,
+new session token, etc.), confirm with `aws s3 ls s3://my-bucket/`, then re-run
+the upload — it resumes from saved state and only uploads what's missing.
+
+### KMS permissions changed after upload
+
+If a key policy or your role changed, `restore`/`list` on a KMS-encrypted manifest
+(or SSE-KMS chunks) will fail with a KMS `AccessDenied`. Restore
+`kms:Decrypt` (and `kms:GenerateDataKey` for new uploads) on the key used at
+upload time — the key ID is recorded in the manifest's encryption metadata. See
+[Encryption metadata](/reference/format/encryption).
+
+### Partial or failed restore
+
+`restore` downloads only the chunks holding your selected files, so a partial
+failure just means some files didn't land. Re-run with the same selection
+(`--file` / `--hash` / `--dvc-stage`); already-written files are simply
+rewritten. For Glacier/Deep Archive, if the thaw hasn't finished, retry with
+`--wait`, or check pending jobs with `cargoship restore jobs list|check`. See
+[Restoring files](/guides/restoring).
+
+## See also
+
+- [Resuming interrupted uploads](/guides/resuming)
+- [Verifying integrity](/guides/verifying)
+- [Restoring files](/guides/restoring)
+- [Troubleshooting](/reference/troubleshooting) · [FAQ](/reference/faq)

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -90,6 +90,7 @@ Collect `cargoship --version`, `cargoship config --show` (redacted), and
 
 ## See also
 
+- [Recovery & operations runbook](/reference/recovery) — step-by-step recovery for interrupted uploads, damaged chunks, credential/KMS issues, and partial restores.
 - [FAQ](/reference/faq).
 - [AWS setup & credentials](/start/aws-setup).
 - [Security model](/project/security).


### PR DESCRIPTION
Priority 2 user-support items from the project review.

## New pages

- **`reference/comparison.md`** — an honest "CargoShip vs. `aws s3 cp`/`sync`,
  `rclone`, tar-to-S3, DVC remotes" feature matrix with clear when-to-use-each
  guidance. States plainly where a simpler tool is the better choice.
- **`reference/recovery.md`** — an operational runbook covering the failure modes
  the review asked for: interrupted upload, orphaned S3 multipart uploads,
  missing/unreadable manifest, damaged chunk, expired/rotated credentials,
  changed KMS permissions, and partial restore. Opens with the documented
  **retry (3 attempts default) and chunk-level idempotency/resume guarantees** —
  verified against `pkg/resume` and `pkg/pipeline/s3_uploader.go`, not asserted.

## Expanded

- **`faq.md`** — from 4 to 13 Q&As: credentials, IAM/multipart permissions,
  interrupted uploads, retry safety, cleanup, Glacier retrieval, archive
  compatibility, memory use, cost predictability.

Both new pages wired into the Reference sidebar and index; recovery cross-linked
from troubleshooting. Site builds clean, no dead links.

## Review coverage

With this, the review's user-support items (expanded FAQ, tool comparison,
recovery runbook, documented idempotency/retry guarantees) are addressed,
alongside the earlier P0 governance sync (#224). Remaining, still deferred: the
infra-heavy P1 items — a CI guard that fails on stale version strings in docs,
and a benchmark page generated from raw artifacts (with the v0.5.1/8× numbers
re-qualified).