### PR TITLE
ci+docs: doc-drift guard + re-qualified performance claims

### DIFF
--- a/.github/workflows/doc-consistency.yml
+++ b/.github/workflows/doc-consistency.yml
@@ -1,0 +1,40 @@
+name: Doc Consistency
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'SECURITY.md'
+      - 'CONTRIBUTING.md'
+      - 'ROADMAP.md'
+      - 'CLAUDE.md'
+      - 'docs/**'
+      - 'scripts/ci/check-doc-versions.sh'
+      - '.github/workflows/doc-consistency.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'SECURITY.md'
+      - 'CONTRIBUTING.md'
+      - 'ROADMAP.md'
+      - 'CLAUDE.md'
+      - 'docs/**'
+      - 'scripts/ci/check-doc-versions.sh'
+      - '.github/workflows/doc-consistency.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Docs match the current release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0  # need full tag history for the version check
+      - name: Check doc version consistency
+        run: ./scripts/ci/check-doc-versions.sh

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 [![GitHub Issues](https://img.shields.io/github/issues/scttfrdmn/cargoship)](https://github.com/scttfrdmn/cargoship/issues)
 [![GitHub Pull Requests](https://img.shields.io/github/issues-pr/scttfrdmn/cargoship)](https://github.com/scttfrdmn/cargoship/pulls)
 
-CargoShip is a next-generation data archiving tool optimized for AWS infrastructure, featuring streaming pipeline architecture, multi-prefix parallel uploads (8× throughput), and intelligent cost optimization. Originally inspired by Duke University's SuitcaseCTL research, CargoShip has evolved into a modern, production-ready solution for enterprise-scale data archiving.
+CargoShip is a next-generation data archiving tool optimized for AWS infrastructure, featuring streaming pipeline architecture, multi-prefix parallel uploads (up to ~8× S3 request-rate capacity), and intelligent cost optimization. Originally inspired by Duke University's SuitcaseCTL research, CargoShip has evolved into a modern, production-ready solution for enterprise-scale data archiving.
 
 ## 🚀 Enterprise Features with Modern Architecture
 
 **High-performance streaming data uploads (v0.5.1+):**
 - 🚀 **Streaming Pipeline** - Zero local disk usage, stream directly to S3
-- ⚡ **Multi-Prefix Parallel Uploads** - 8x throughput improvement with S3 prefix sharding
+- ⚡ **Multi-Prefix Parallel Uploads** - up to ~8× S3 request-rate capacity via prefix sharding
 - 📊 **Real-Time Progress Tracking** - Beautiful TUI with live upload metrics
 - 🧠 **Intelligent Chunking** - Adaptive chunk sizing with compression-aware optimization
 - 💰 **Cost Optimization** - Intelligent storage class selection and lifecycle policies
@@ -415,25 +415,39 @@ $ cargoship create upload /data/genomics --bucket research-data --prefix 2024-st
 
 ### Performance Benchmarks
 
-Real AWS S3 performance results (v0.5.1):
+Illustrative results from one benchmark run (CargoShip **v0.5.1**, real AWS S3,
+`us-west-2`, STANDARD class, 8 shards / 8 workers, zstd level 3). These are a
+point-in-time snapshot, not a guarantee — **your numbers depend on file-size
+distribution, network, region, instance, and concurrency.**
 
 | Workload | Files | Size | Duration | Throughput | Memory |
 |----------|-------|------|----------|------------|--------|
 | **Small files** | 10,000 | 176 MB | 437ms | 403 MB/s | 3.4 GB |
 | **Large files** | 100 | 56 GB | 311s | 185 MB/s | 4.9 GB |
 
-**Key Performance Metrics**:
-- **Compression**: zstd @ 527 MB/s (10.7× faster than gzip)
-- **Memory Efficiency**: 6-8% of data size (excellent scaling)
-- **Multi-Prefix**: 8× S3 request rate capacity
-- **Streaming**: Zero local disk usage
+Architecture-grounded characteristics (independent of any single run):
 
-**Benchmark Details**:
-- Test environment: Real AWS S3 (not LocalStack simulation)
-- Storage class: STANDARD
-- Shards: 8 (default)
-- Workers: 8 (Phase 4 optimization)
-- Compression: zstd level 3
+- **Multi-prefix sharding** distributes chunks across S3 prefixes, so request-rate
+  capacity scales with the shard count (up to ~8× with the default 8 shards) — see
+  [sharding](https://cargoship.app/guides/features/sharding).
+- **Content-aware zstd** compresses text/code well and skips already-compressed
+  data — see [compression](https://cargoship.app/guides/features/compression).
+- **Bounded memory** — data streams to S3 without staging to disk, so memory
+  tracks `chunk_size × workers`, not dataset size.
+
+**Reproduce these yourself** (results include environment + commit metadata):
+
+```bash
+# In-process Go micro-benchmarks (no AWS):
+scripts/run-benchmarks.sh            # or: make test-benchmark
+
+# End-to-end against your own S3 bucket:
+export CARGOSHIP_BENCHMARK_BUCKET=my-bench-bucket
+make bench-s3 SCENARIO=small         # small | medium | large | xlarge
+```
+
+See [Performance tuning](https://cargoship.app/guides/features/optimization) for
+the knobs behind these results.
 
 ## 🎯 Use Cases
 

--- a/scripts/ci/check-doc-versions.sh
+++ b/scripts/ci/check-doc-versions.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Doc-consistency guard: keep repo docs from drifting behind releases.
+#
+# Two independent checks, both intentionally SURGICAL to avoid false positives on
+# legitimate version mentions (semver examples like "v0.4 → v0.5", historical
+# roadmap entries, benchmark-environment notes):
+#
+#   1. "Current Version" declarations must match the latest release. The files
+#      below each carry one authoritative "Current Version: vX.Y.Z" line; those
+#      must equal the newest semver git tag. Every OTHER version string in the
+#      repo is left alone.
+#
+#   2. Denylisted tokens must not appear anywhere in the tracked docs. These are
+#      removed commands / fictional settings that are always wrong if present
+#      (not version numbers). Historical prose that must reference them can be
+#      added to the allowlist below.
+#
+# Usage: scripts/ci/check-doc-versions.sh
+# Exit 0 = consistent; exit 1 = drift found (prints what and where).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+fail=0
+
+# --- Check 1: "Current Version" declarations track the latest release tag ------
+
+# Newest vX.Y.Z tag (sorted by version). Fall back gracefully if no tags.
+latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)"
+if [ -z "$latest_tag" ]; then
+  echo "::warning::no vX.Y.Z git tags found; skipping current-version check"
+else
+  # Files that declare the canonical current version.
+  version_files=(CLAUDE.md ROADMAP.md)
+  for f in "${version_files[@]}"; do
+    [ -f "$f" ] || continue
+    # Extract the version from a line like: **Current Version**: v0.13.2 (...)
+    declared="$(grep -oE 'Current Version\*{0,2}:? *v[0-9]+\.[0-9]+\.[0-9]+' "$f" \
+                  | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    if [ -z "$declared" ]; then
+      echo "::error file=$f::no 'Current Version: vX.Y.Z' declaration found"
+      fail=1
+    elif [ "$declared" != "$latest_tag" ]; then
+      echo "::error file=$f::declares Current Version $declared but latest release is $latest_tag"
+      fail=1
+    fi
+  done
+fi
+
+# --- Check 2: denylisted (removed/fictional) tokens must not appear ------------
+
+# Tokens that are ALWAYS wrong if present in current docs (not version numbers).
+denylist=(
+  "create suitcase"          # removed command
+  "CARGOSHIP_SECURITY_MODE"  # fictional env var
+  "CARGOSHIP_TLS_REQUIRED"   # fictional env var
+  "CARGOSHIP_AUDIT_LOG"      # fictional env var
+)
+
+# Files/dirs to police (tracked docs + governance). Excludes generated CLI docs,
+# the VitePress build output, node_modules, and CHANGELOG (historical record).
+mapfile -t doc_files < <(git ls-files \
+  'README.md' 'SECURITY.md' 'CONTRIBUTING.md' 'ROADMAP.md' 'CLAUDE.md' 'docs/**/*.md' \
+  | grep -vE '^docs/gen/|^docs/\.vitepress/dist/')
+
+for token in "${denylist[@]}"; do
+  hits="$(grep -rn -F "$token" "${doc_files[@]}" 2>/dev/null || true)"
+  if [ -n "$hits" ]; then
+    echo "::error::denylisted token '$token' found in docs:"
+    echo "$hits"
+    fail=1
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "✅ doc-consistency: Current Version matches $latest_tag; no denylisted tokens."
+fi
+exit $fail


### PR DESCRIPTION
The two remaining **Priority 1** items from the project review.

## 1. Doc-consistency guard

`scripts/ci/check-doc-versions.sh` + a lightweight `doc-consistency.yml` workflow:

- **Version check** — the "Current Version" declarations in `CLAUDE.md` and
  `ROADMAP.md` must equal the latest `vX.Y.Z` git tag. This catches exactly the
  drift the review found (ROADMAP said v0.12.0 while v0.13.2 had shipped).
- **Denylist** — removed commands / fictional settings (`create suitcase`,
  `CARGOSHIP_SECURITY_MODE`/`_TLS_REQUIRED`/`_AUDIT_LOG`) must not appear in the
  tracked docs.
- **Surgical** — it deliberately does *not* flag legitimate version mentions
  (semver examples like `v0.4 → v0.5`, roadmap history, benchmark-environment
  notes), so it won't false-positive. I verified it passes clean today and fails
  on injected drift (stale version + denylisted token both caught).
- Runs on doc changes only, `fetch-depth: 0` for tag history.

## 2. Re-qualified performance claims

- The README's **v0.5.1 benchmark table** is now framed as an illustrative
  point-in-time snapshot ("your numbers depend on file distribution, network,
  region, instance, concurrency") with a **"reproduce these yourself"** block
  (`scripts/run-benchmarks.sh`, `make bench-s3`) so the numbers are regenerable
  rather than hand-copied.
- Headline **"8× throughput"** → **"up to ~8× S3 request-rate capacity"** — the
  architecture-accurate claim (sharding raises request-rate parallelism; it isn't
  a guaranteed throughput multiplier). Architecture-grounded characteristics are
  separated from single-run numbers.

## Review status

This closes out the review's actionable P0/P1/P2 items:
- P0 governance sync + maturity matrix (#224)
- P2 comparison / recovery runbook / FAQ (#225)
- P1 doc-drift guard + perf re-qualification (this PR)

Note: `make bench-s3` (the S3 benchmark suite behind "reproduce these yourself")
runs against a real bucket and isn't a per-PR CI gate — see the earlier decision
to keep it as a manual/local target.