### PR TITLE
docs: re-review polish — trim README/ROADMAP, fix policy contradictions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,10 @@ Thank you for your interest in contributing to CargoShip! This project builds up
 
 ### Code Standards
 
-CargoShip follows strict development standards outlined in [DEVELOPMENT_RULES.md](DEVELOPMENT_RULES.md):
+CargoShip enforces these standards via the pre-commit hook and CI:
 
-- **Zero linting violations** - golangci-lint must pass
-- **Security scanning** - gosec and vulnerability checks
+- **Zero linting violations** - `golangci-lint` must pass
+- **Security scanning** - `govulncheck` (zero known vulnerabilities), gitleaks, Trivy, Semgrep
 - **Test coverage** - New code requires tests
 - **Go module consistency** - All modules must be verified
 
@@ -145,11 +145,13 @@ func TestFeature(t *testing.T) {
 
 ### Key Modules
 
-- **`pkg/aws/s3/`** - Advanced S3 optimization with BBR/CUBIC
-- **`pkg/compression/`** - Multi-algorithm compression
-- **`pkg/controller/`** - Distributed agent coordination
+- **`pkg/pipeline/`** - Streaming pipeline (Scanner → Chunker → Archiver → Uploader)
+- **`pkg/chunking/`** - File grouping into chunks and shard routing
+- **`pkg/compression/`** - Compression (zstd and others)
+- **`pkg/manifest/`** - Manifest read/write, query, and extraction
+- **`pkg/aws/s3/`** - S3 upload transporters and Glacier restore
+- **`pkg/controller/`** / **`pkg/launch/`** - Distributed agent coordination
 - **`pkg/tui/`** - Terminal user interface
-- **`pkg/suitcase/`** - Archive format handling
 
 ### Adding New Features
 
@@ -195,7 +197,7 @@ func TestFeature(t *testing.T) {
 Clear description of the bug.
 
 **Steps to Reproduce**
-1. Run command `cargoship ship...`
+1. Run command `cargoship upload ...`
 2. See error
 
 **Expected Behavior**
@@ -229,25 +231,18 @@ What actually happened.
 
 ## 🎯 Priority Areas
 
-We particularly welcome contributions in these areas:
+We particularly welcome contributions aligned with the current
+[roadmap](ROADMAP.md):
 
-### High Priority
-- **Network optimization** - BBR/CUBIC algorithm improvements
-- **Cost optimization** - Enhanced cost analysis algorithms
-- **Security** - Additional encryption and compliance features
-- **Performance** - Upload speed and memory optimization
+- **Cost & budget** - cost-analysis accuracy, reporting, budget/quota features
+- **Reliability** - upload/restore robustness, resume, verification
+- **Performance** - upload throughput and memory efficiency
+- **DVC & workflows** - graduating the DVC integration from beta toward stable
+- **Documentation & tests** - guides, examples, and edge-case coverage
 
-### Medium Priority
-- **Multi-cloud support** - Azure, GCP integration
-- **UI improvements** - Enhanced terminal interface
-- **Documentation** - User guides and examples
-- **Testing** - Additional edge case coverage
-
-### Future Focus
-- **Machine learning** - Predictive optimization
-- **Advanced analytics** - Usage pattern analysis
-- **Enterprise features** - RBAC, audit logging
-- **API expansion** - REST API enhancements
+Speculative directions (multi-cloud, ML-based optimization, a REST API) are
+listed as **not committed** on the [roadmap](ROADMAP.md) — discuss in an issue
+before investing significant effort.
 
 ## 🔄 Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="assets/images/logo.png" alt="CargoShip Logo" width="200" height="200">
   <h1>CargoShip</h1>
-  <p><strong>Enterprise data archiving for AWS, built for speed and intelligence</strong></p>
+  <p><strong>High-performance S3 data archiving</strong></p>
 </div>
 
 [![Go Version](https://img.shields.io/github/go-mod/go-version/scttfrdmn/cargoship)](https://github.com/scttfrdmn/cargoship/blob/main/go.mod)
@@ -15,24 +15,21 @@
 [![GitHub Issues](https://img.shields.io/github/issues/scttfrdmn/cargoship)](https://github.com/scttfrdmn/cargoship/issues)
 [![GitHub Pull Requests](https://img.shields.io/github/issues-pr/scttfrdmn/cargoship)](https://github.com/scttfrdmn/cargoship/pulls)
 
-CargoShip is a next-generation data archiving tool optimized for AWS infrastructure, featuring streaming pipeline architecture, multi-prefix parallel uploads (up to ~8× S3 request-rate capacity), and intelligent cost optimization. Originally inspired by Duke University's SuitcaseCTL research, CargoShip has evolved into a modern, production-ready solution for enterprise-scale data archiving.
+CargoShip turns large directory trees into compressed, verifiable, portable
+archives streamed directly to Amazon S3. It is for research and technical
+datasets with many files, where ordinary copy tools create excessive S3
+requests, give weak recovery guarantees, or make storage costs hard to predict.
 
-## 🚀 Enterprise Features with Modern Architecture
+## Why not plain `aws s3 cp` or `rclone`?
 
-**High-performance streaming data uploads (v0.5.1+):**
-- 🚀 **Streaming Pipeline** - Zero local disk usage, stream directly to S3
-- ⚡ **Multi-Prefix Parallel Uploads** - up to ~8× S3 request-rate capacity via prefix sharding
-- 📊 **Real-Time Progress Tracking** - Beautiful TUI with live upload metrics
-- 🧠 **Intelligent Chunking** - Adaptive chunk sizing with compression-aware optimization
-- 💰 **Cost Optimization** - Intelligent storage class selection and lifecycle policies
-- 🎯 **Advanced S3 Features** - Multi-region support, predictive prefetching
-- 📈 **Performance Monitoring** - Comprehensive metrics and analytics
-- 💵 **Budget Tracking** - Project-based cost and volume quota management with burn rate forecasting
-- 🛡️ **Security first** - KMS encryption and compliance-ready audit trails
+Those tools copy files one-to-one, which turns a million-file dataset into a
+million S3 requests with no packaging, manifest, or cost model. CargoShip packs
+files into compressed archives, shards uploads across S3 prefixes for
+throughput, records a verifiable manifest, and can estimate cost before you
+commit. See the [feature comparison](https://cargoship.app/reference/comparison)
+for a side-by-side breakdown.
 
-## 🚀 Quick Start
-
-### Installation
+## Installation
 
 ```bash
 # Homebrew (macOS/Linux)
@@ -42,485 +39,137 @@ brew install scttfrdmn/tap/cargoship
 scoop bucket add scttfrdmn https://github.com/scttfrdmn/scoop-bucket
 scoop install cargoship
 
-# Go Install
+# Go install
 go install github.com/scttfrdmn/cargoship/cmd/cargoship@latest
 ```
 
-See the [Installation Guide](https://cargoship.app/start/install) for more options.
+Pre-built binaries for macOS, Linux, and Windows are on the
+[releases page](https://github.com/scttfrdmn/cargoship/releases). CargoShip
+reads AWS credentials from the standard SDK chain (environment, shared config,
+or IAM role); see [AWS setup](https://cargoship.app/start/aws-setup) for the
+minimal IAM policy and the [installation guide](https://cargoship.app/start/install)
+for more options.
 
-### Basic Workflow
+## Example
+
+A complete round trip: estimate, upload, inspect, verify, and restore a single file.
 
 ```bash
-# 1. Estimate costs before uploading
+# 1. Estimate cost before uploading
 cargoship estimate /data/project-2024 --storage-class deep-archive
 
 # 2. Upload a directory to S3 (canonical command)
-cargoship upload /data/completed-analysis s3://my-bucket/project-2024 \
+cargoship upload /data/project-2024 s3://my-bucket/project-2024 \
   --storage-class INTELLIGENT_TIERING
 
-# Real-time progress display:
 # 🚢 Uploading: 1234 files | 5.67 GB | 89 chunks | 123.4 MB/s | 1m30s elapsed
+# ✅ Upload Complete!  Upload ID: 20260721-123456-abcd1234
 
-# 3. List uploaded files using manifest (no download required)
-cargoship list --bucket my-bucket --upload-id 20251206-123456-abcd1234
+# 3. Inspect what was uploaded, straight from the manifest (no download)
+cargoship info s3://my-bucket/project-2024
 
-# 4. Manage S3 lifecycle policies
-cargoship lifecycle --bucket my-bucket --template archive-optimization
+# 4. Verify the archive against its manifest checksums
+cargoship verify s3://my-bucket/project-2024
+
+# 5. Restore a single file without pulling the whole archive
+cargoship restore s3://my-bucket/project-2024 \
+  --file results/summary.csv --output ./restored/
 ```
 
-## 💰 Intelligent Cost Optimization
+See the [quick start](https://cargoship.app/start/quickstart) for a guided
+walkthrough and the [command reference](https://cargoship.app/reference/) for
+every command and flag.
 
-CargoShip provides enterprise-grade cost optimization with proven algorithms:
+Sharding is chosen automatically from the workload, but you can override it:
 
 ```bash
-$ cargoship estimate ./genomics-analysis --show-breakdown
-
-📊 Archive Cost Estimate (1.2TB genomics data)
-┌─────────────────┬──────────────┬──────────────┐
-│ Storage Class   │ Monthly Cost │ Annual Cost  │
-├─────────────────┼──────────────┼──────────────┤
-│ Standard        │ $276.48     │ $3,317.76   │
-│ Glacier         │ $61.44      │ $737.28     │
-│ Deep Archive    │ $12.29      │ $147.48     │
-└─────────────────┴──────────────┴──────────────┘
-
-💡 Optimization Recommendations (v0.5.1+):
-• Archive raw data → Deep Archive (90% savings)
-• Analysis results → Glacier (75% savings)
-• Enable lifecycle policies → Additional 15% savings
-• Multi-prefix parallel uploads → 8x throughput improvement
-• Streaming pipeline → Zero local disk usage
-• Intelligent chunking → Optimal compression ratios
-
-Total annual savings: $3,170/year with 8x upload performance
-
-✅ Available Now:
-• `cargoship upload` - Sharded, compressed, verifiable uploads
-• `cargoship lifecycle` - Automated lifecycle policy management
-• `cargoship budget` - Project-based cost and volume quota tracking
-• Real-time progress tracking with TUI
+cargoship upload /data/project-2024 s3://my-bucket/project-2024 --shard-count 16
 ```
 
-### Storage Tier Cost Implications ⚠️
-
-When using `--tier-strategy tier-aware` with `--auto-tier`, CargoShip assigns files to cost-optimized storage tiers. **Understanding the full cost implications is critical** to avoid unexpected charges.
-
-#### Hidden Costs: Minimum Storage Duration & Retrieval Fees
-
-AWS charges for minimum storage duration **even if you delete data early**:
-
-| Tier | Storage Cost | Minimum Duration | Retrieval Cost | Retrieval Time | Best For |
-|------|--------------|------------------|----------------|----------------|----------|
-| **STANDARD** | $0.023/GB-month | None | Free | Immediate | Active data, frequent access |
-| **STANDARD_IA** | $0.0125/GB-month | 30 days | $0.01/GB | Immediate | Infrequent access (< 1x/month) |
-| **GLACIER** | $0.004/GB-month | **90 days** ⚠️ | $0.01/GB | 3-5 hours | Rarely accessed (<1x/year) |
-| **DEEP_ARCHIVE** | $0.00099/GB-month | **180 days** ⚠️ | $0.02/GB | 12 hours | Compliance (<1x/5 years) |
-
-**Example: Early Deletion Penalty**
-```
-Upload 100GB to DEEP_ARCHIVE, delete after 30 days:
-├─ Storage (30 days):        $0.10
-├─ Early deletion penalty:   $0.50 (charged for remaining 150 days)
-└─ Total:                    $0.60 (6x more than expected!)
-```
-
-**Example: Retrieval Costs**
-```
-Retrieve 1TB from GLACIER:
-├─ Retrieval fee:   1024GB × $0.01/GB  = $10.24
-├─ Data transfer:   1024GB × $0.09/GB  = $92.16
-└─ Total:                               = $102.40
-```
-
-#### Cost Scenarios: When to Use Each Strategy
-
-**Scenario 1: Long-term Archive (No Retrieval) - ✅ Use tier-aware**
-```
-100GB mixed-age dataset, stored 1 year, no retrievals:
-
-V1 (youngest-file):
-└─ 100GB STANDARD:          $27.60/year
-
-V2 (tier-aware):
-├─ 25GB STANDARD:           $6.90/year
-├─ 25GB STANDARD_IA:        $3.75/year
-├─ 25GB GLACIER:            $1.20/year
-└─ 25GB DEEP_ARCHIVE:       $0.30/year
-   Total:                   $12.15/year
-
-Savings: $15.45/year (56% reduction) ✅
-```
-
-**Scenario 2: Frequent Retrieval (10x/year) - ❌ Use youngest-file instead**
-```
-100GB dataset, 10 retrievals per year:
-
-V1 (youngest-file):
-└─ Storage + retrieval:     $27.60/year (no retrieval fees)
-
-V2 (tier-aware):
-├─ Storage:                 $12.15/year
-├─ Retrieval fees:          $7.50/year
-└─ Data transfer:           $22.50/year
-   Total:                   $42.15/year
-
-Loss: -$14.55/year (53% increase) ❌
-```
-
-#### Interactive Confirmation
-
-CargoShip prompts for confirmation when using tier-aware strategy:
-
-```bash
-$ cargoship upload --auto-tier --tier-strategy tier-aware ./data s3://bucket
-
-⚠️  TIER-AWARE CHUNKING: COST IMPLICATIONS WARNING
-══════════════════════════════════════════════════
-
-🧊 GLACIER:
-   • 90-day minimum storage duration (early deletion penalty applies)
-   • $0.01/GB retrieval fee
-   • 3-5 hour retrieval time (standard)
-   • Best for: Data accessed <1x per year
-
-❄️  DEEP_ARCHIVE:
-   • 180-day minimum storage duration (early deletion penalty applies)
-   • $0.02/GB retrieval fee
-   • 12 hour retrieval time (standard)
-   • Best for: Compliance/long-term archives accessed <1x per 5 years
-
-Do you understand these cost implications and wish to proceed? [y/N]:
-```
-
-Skip prompt with `--yes` flag for automation:
-```bash
-cargoship upload --auto-tier --tier-strategy tier-aware --yes ./data s3://bucket
-```
-
-#### Limiting Maximum Tier Selection
-
-Use `--tier-max` to cap automatic tier selection and avoid more restrictive tiers:
-
-```bash
-# Allow up to GLACIER, but exclude DEEP_ARCHIVE
-$ cargoship upload --auto-tier --tier-strategy tier-aware --tier-max GLACIER ./data s3://bucket
-
-📊 Automatic storage tier selection enabled
-   Hot threshold:     30 days (STANDARD)
-   Cold threshold:    90 days (GLACIER)
-   Archive threshold: 180 days (DEEP_ARCHIVE)
-   Maximum tier:      GLACIER (capped)
-```
-
-**Use Cases:**
-- `--tier-max STANDARD_IA`: Avoid archive tiers entirely (no 90-180 day minimums)
-- `--tier-max GLACIER`: Use Glacier for cold storage, but avoid Deep Archive (no 180-day minimum)
-- Combined with tier-aware: Benefit from tier-based chunking while controlling cost exposure
-
-#### Decision Matrix: Which Strategy to Use?
-
-| Access Pattern | Retention | Recommended Strategy | Why |
-|----------------|-----------|---------------------|-----|
-| >1x per month | Any | `youngest-file` (v1) | Retrieval costs exceed savings |
-| <1x per month | <6 months | `youngest-file` (v1) | Early deletion penalties |
-| <1x per year | >6 months | `tier-aware` (v2) | Storage savings outweigh retrieval |
-| <1x per 5 years | >1 year | `tier-aware` (v2) | Maximum savings from DEEP_ARCHIVE |
-| Compliance/backup | >1 year | `tier-aware` (v2) | Designed for long-term storage |
-
-**Best Practices:**
-1. **Estimate costs first**: Use `cargoship estimate` before uploading
-2. **Know your access patterns**: Track how often you retrieve data
-3. **Ensure 6+ month retention**: Avoid early deletion penalties
-4. **Use youngest-file for active data**: Frequent access makes v1 cheaper
-5. **Use tier-aware for cold data**: Backups, compliance, long-term archives
-
-See [Issue #168](https://github.com/scttfrdmn/cargoship/issues/168) for complete documentation.
-
-#### Total Cost of Ownership (TCO) Analysis
-
-Use the `estimate` command with `--show-comparison` to see detailed TCO scenarios for archive tiers:
-
-```bash
-$ cargoship estimate ./data --storage-class GLACIER --show-comparison
-
-📊 TOTAL COST OF OWNERSHIP (TCO) SCENARIOS
-
-Archive tiers (Glacier, Deep Archive) have restore costs and access patterns
-that affect Total Cost of Ownership. Here are common usage scenarios:
-
-1. Zero Retrievals (Pure Archival)
-   Description:   Data stored long-term with no retrievals
-   Retrievals:    0x/year (0% of data each time)
-
-   Cost Breakdown:
-      Storage:    $48.00/year
-      Upload:     $0.15 (one-time)
-      ────────────────────────
-      Total TCO:  $48.15/year
-
-2. Occasional Retrievals (2x/year)
-   Description:   Retrieve 10% of data twice yearly (Standard restore, 7-day access)
-   Retrievals:    2x/year (10% of data each time)
-   Restore Tier:  Standard
-
-   Cost Breakdown:
-      Storage:    $48.00/year
-      Upload:     $0.15 (one-time)
-      Retrieval:  $24.00/year
-      ────────────────────────
-      Total TCO:  $72.15/year
-
-3. Frequent Retrievals (10x/year) ⚠️
-   Description:   Retrieve 20% of data 10x yearly (Bulk restore, 3-day access) - NOT RECOMMENDED
-   Retrievals:    10x/year (20% of data each time)
-   Restore Tier:  Bulk
-
-   Cost Breakdown:
-      Storage:    $48.00/year
-      Upload:     $0.15 (one-time)
-      Retrieval:  $240.00/year
-      ────────────────────────
-      Total TCO:  $288.15/year
-
-      ⚠️  This retrieval pattern is NOT RECOMMENDED for archive tiers.
-          Consider STANDARD or INTELLIGENT_TIERING for frequent access.
-
-💡 TCO Analysis:
-   • Archive tiers (Glacier, Deep Archive) are cost-effective for infrequent access
-   • Retrieval costs can exceed storage savings if accessed frequently
-   • Use INTELLIGENT_TIERING if access pattern is unpredictable
-   • Early deletion penalties apply (30-180 days minimum storage)
-```
-
-**Key Takeaway:** Always model your access patterns before choosing archive tiers. Use `--show-comparison` to understand the full TCO impact.
-
-### Budget Tracking and Cost Control
-
-CargoShip includes enterprise-grade budget management to prevent cost overruns:
-
-```bash
-# Set project budget with cost and volume limits
-$ cargoship budget set genomics-2025 --cost 5000 --volume 2000
-
-# Monitor budget status with burn rate forecasting
-$ cargoship budget status genomics-2025
-
-📊 Budget Status: genomics-2025
-Cost Budget:
-├─ Maximum:     $5,000.00
-├─ Current:     $1,234.56 (24.7%)
-├─ Remaining:   $3,765.44
-├─ Daily Burn:  $41.23
-└─ Projected:   $4,123.00 (within budget ✅)
-
-Volume Quota:
-├─ Maximum:     2,000 GB
-├─ Current:     487 GB (24.4%)
-├─ Remaining:   1,513 GB
-└─ Projected:   1,948 GB (within quota ✅)
-```
-
-**Features**:
-- **Dual Controls**: Cost budgets (USD) and volume quotas (GB)
-- **Project-Based**: Track spending per project, grant, or department
-- **Burn Rate Forecasting**: ML-powered end-of-period projections
-- **Automatic Blocking**: Prevents uploads that exceed budgets
-- **Multi-Channel Alerts**: Email, Slack, CloudWatch notifications
-
-See the [Budget Management Guide](https://cargoship.app/guides/cost/budgets) for complete documentation.
-
-```
-
-## 🏗️ Modern Streaming Architecture
-
-### High-Performance Pipeline (v0.5.1+)
-
-CargoShip uses a modern streaming pipeline architecture for maximum performance:
-
-**Pipeline Stages**:
-- **Scanner**: Multi-threaded file discovery with parallel directory traversal
-- **Chunker**: Intelligent chunking with compression-aware boundary detection
-- **Archiver**: Streaming tar+zstd compression with zero disk writes
-- **Uploader**: Multi-prefix parallel S3 uploads (8x capacity improvement)
-
-**Performance Features**:
-- **Zero Local Disk**: Streams directly from filesystem → compression → S3
-- **Bounded Memory**: O(chunk_size × workers) prevents OOM conditions
-- **Adaptive Chunking**: Smart file grouping based on size and compressibility
-- **Multi-Prefix Sharding**: Parallel uploads across 8 S3 prefixes
-- **Real-Time Progress**: Live metrics with throughput and ETA tracking
-
-### Architecture Diagram
-
-```
-┌─────────────────────┐    ┌──────────────────┐    ┌─────────────────┐
-│   Source Data       │    │  CargoShip       │    │   AWS S3        │
-│                     │    │  Pipeline        │    │                 │
-│ • Local Files       │───▶│                  │───▶│ • Standard      │
-│ • Network Shares    │    │ • Scanner        │    │ • IA            │
-│ • Data Lakes        │    │ • Chunker        │    │ • Glacier       │
-│ • Archive Systems   │    │ • Archiver       │    │ • Deep Archive  │
-└─────────────────────┘    │ • Uploader (8x)  │    └─────────────────┘
-                           └──────────────────┘
-                                    │
-                                    ▼
-                           Real-Time Progress TUI
-                           Files | GB | MB/s | ETA
-```
-
-### Performance Tuning
-
-For fine-grained pipeline control, the advanced `cargoship create upload` variant
-exposes explicit worker/chunk/shard tuning (most users should use the canonical
-`cargoship upload` — see [upload vs. create upload](https://cargoship.app/guides/upload-vs-create-upload)):
-
-```bash
-# For many small files (<1MB):
-cargoship create upload /data --bucket my-bucket \
-  --chunk-size-mb 50 --workers 8
-
-# For large files (>100MB):
-cargoship create upload /data --bucket my-bucket \
-  --chunk-size-mb 500 --workers 4
-
-# Maximum throughput:
-cargoship create upload /data --bucket my-bucket \
-  --shards 16 --workers 8 --storage-class STANDARD
-```
-
-### Real-Time Progress Tracking
-
-CargoShip provides beautiful real-time progress display during uploads (v0.5.1+):
-
-```bash
-$ cargoship create upload /data/genomics --bucket research-data --prefix 2024-study
-
-🚢 Uploading: 1,234 files | 5.67 GB | 89 chunks | 123.4 MB/s | 1m30s elapsed
-
-✅ Upload Complete!
-   Files:       1,234 files
-   Data Size:   5.67 GB (uncompressed)
-   Chunks:      89 archives
-   Shards:      8 S3 prefixes
-   Throughput:  123.4 MB/s
-   Duration:    1m32s
-   Upload ID:   20251206-123456-abcd1234
-```
-
-**Features**:
-- **Terminal Detection**: Automatically disables for non-TTY contexts (pipes, CI/CD)
-- **Live Metrics**: Files, data size, chunks, throughput, elapsed time
-- **Clean Display**: Single-line progress with ANSI escape codes
-- **Zero Configuration**: Works out of the box, no flags required
-
-### Performance Benchmarks
-
-Illustrative results from one benchmark run (CargoShip **v0.5.1**, real AWS S3,
-`us-west-2`, STANDARD class, 8 shards / 8 workers, zstd level 3). These are a
-point-in-time snapshot, not a guarantee — **your numbers depend on file-size
-distribution, network, region, instance, and concurrency.**
-
-| Workload | Files | Size | Duration | Throughput | Memory |
-|----------|-------|------|----------|------------|--------|
-| **Small files** | 10,000 | 176 MB | 437ms | 403 MB/s | 3.4 GB |
-| **Large files** | 100 | 56 GB | 311s | 185 MB/s | 4.9 GB |
-
-Architecture-grounded characteristics (independent of any single run):
-
-- **Multi-prefix sharding** distributes chunks across S3 prefixes, so request-rate
-  capacity scales with the shard count (up to ~8× with the default 8 shards) — see
-  [sharding](https://cargoship.app/guides/features/sharding).
-- **Content-aware zstd** compresses text/code well and skips already-compressed
-  data — see [compression](https://cargoship.app/guides/features/compression).
-- **Bounded memory** — data streams to S3 without staging to disk, so memory
-  tracks `chunk_size × workers`, not dataset size.
-
-**Reproduce these yourself** (results include environment + commit metadata):
-
-```bash
-# In-process Go micro-benchmarks (no AWS):
-scripts/run-benchmarks.sh            # or: make test-benchmark
-
-# End-to-end against your own S3 bucket:
-export CARGOSHIP_BENCHMARK_BUCKET=my-bench-bucket
-make bench-s3 SCENARIO=small         # small | medium | large | xlarge
-```
-
-See [Performance tuning](https://cargoship.app/guides/features/optimization) for
-the knobs behind these results.
-
-## 🎯 Use Cases
-
-CargoShip excels at large-scale data archiving:
-
-- **Research Data**: Genomics, imaging, sensor data archiving
-- **Analytics Output**: ML training data, analysis results
-- **Enterprise Backup**: Long-term retention with cost optimization
-- **Compliance**: Audit trails and secure archival storage
-- **Data Lakes**: Cost-effective cold storage tier migration
-
-## 📖 Documentation
+## Common commands
+
+| Command | Purpose |
+|---------|---------|
+| `cargoship estimate` | Model storage cost before uploading |
+| `cargoship upload` | Pack, compress, and stream a directory to S3 |
+| `cargoship info` | Inspect an archive from its manifest, no download |
+| `cargoship verify` | Check archive contents against manifest checksums |
+| `cargoship restore` | Restore all or selected files from an archive |
+| `cargoship budget` | Set and monitor per-project cost and volume budgets |
+| `cargoship lifecycle` | Manage S3 lifecycle policies for stored archives |
+
+## Key differentiators
+
+- **Zero-disk streaming pipeline** — files stream from disk through compression
+  to S3 with no local staging; memory stays bounded to `chunk_size × workers`.
+- **Multi-prefix sharding** — chunks are distributed across S3 prefixes, so
+  request-rate capacity scales with the shard count (up to ~8× with the default
+  8 shards). See [sharding](https://cargoship.app/guides/features/sharding).
+- **Content-aware compression** — zstd compresses text and code well and skips
+  already-compressed data. See [compression](https://cargoship.app/guides/features/compression).
+- **Cost and budget controls** — estimate spend before uploading and enforce
+  per-project cost and volume budgets. See [budgets](https://cargoship.app/guides/cost/budgets).
+- **Open, portable format** — archives are `tar.zst` with a JSON manifest, both
+  readable with standard tools. See the [format spec](https://cargoship.app/reference/format/).
+
+CargoShip suits research data, analytics output, long-term backup and
+compliance retention, and cold-tier data-lake migration — anywhere a large file
+count and predictable cost matter more than one-to-one file copies.
+
+## Safety and portability
+
+CargoShip never modifies source files; it only reads them. Archives use the
+open `tar.zst` format alongside a plain JSON manifest, so your data stays
+recoverable with standard tools (`tar`, `zstd`, `jq`) even without CargoShip
+installed. The manifest records per-file checksums, letting `cargoship verify`
+confirm integrity after upload and letting `cargoship restore` pull a single
+file without downloading the whole archive. The
+[format spec](https://cargoship.app/reference/format/) documents the layout in
+full.
+
+## Documentation
 
 Full documentation lives at **[cargoship.app](https://cargoship.app)**.
 
-### Getting Started
-- **[Quick Start](https://cargoship.app/start/quickstart)** - Zero to a verified upload in minutes
-- **[Installation](https://cargoship.app/start/install)** - Get CargoShip running in your environment
-- **[AWS Setup & Credentials](https://cargoship.app/start/aws-setup)** - Credentials and minimal IAM policy
-- **[How It Works](https://cargoship.app/intro/how-it-works)** - The streaming pipeline, explained
-- **[Command Reference](https://cargoship.app/reference/)** - Every command and flag
+### Getting started
+- [Quick Start](https://cargoship.app/start/quickstart) — zero to a verified upload in minutes
+- [Installation](https://cargoship.app/start/install) — get CargoShip running in your environment
+- [AWS Setup & Credentials](https://cargoship.app/start/aws-setup) — credentials and minimal IAM policy
+- [How It Works](https://cargoship.app/intro/how-it-works) — the streaming pipeline, explained
+- [Command Reference](https://cargoship.app/reference/) — every command and flag
 
-### Performance & Optimization
-- **[Performance Tuning](https://cargoship.app/guides/features/optimization)** - Tuning for maximum throughput
-- **[Multi-Prefix Sharding](https://cargoship.app/guides/features/sharding)** - How parallel uploads scale
-- **[Compression](https://cargoship.app/guides/features/compression)** - Content-aware zstd
-- **[Troubleshooting](https://cargoship.app/reference/troubleshooting)** - Common issues and solutions
+### Guides & tutorials
+- [Use-case Tutorials](https://cargoship.app/tutorials/) — genomics, imaging, ML/DVC, lab data
+- [Performance Tuning](https://cargoship.app/guides/features/optimization) — throughput knobs and benchmarks
+- [Migration from rclone / aws cli](https://cargoship.app/tutorials/migrating) — switching to CargoShip
+- [upload vs. create upload](https://cargoship.app/guides/upload-vs-create-upload) — the advanced tuning variant
 
-### Migration & Integration
-- **[Migration from rclone / aws cli](https://cargoship.app/tutorials/migrating)** - Switch to CargoShip
-- **[Use-case Tutorials](https://cargoship.app/tutorials/)** - Genomics, imaging, ML/DVC, lab data
-- **[DVC Integration](https://cargoship.app/guides/dvc/)** - Data Version Control remote
+### Cost & format
+- [Estimating Costs](https://cargoship.app/guides/cost/estimate) — model spend before uploading
+- [Budgets & Quotas](https://cargoship.app/guides/cost/budgets) — project-based cost and volume tracking
+- [Lifecycle & Storage Tiers](https://cargoship.app/guides/cost/lifecycle) — tier selection and retrieval costs
+- [Archive & Manifest Format Spec](https://cargoship.app/reference/format/) — the open, portable format
 
-### Architecture & Format
-- **[Archive & Manifest Format Spec](https://cargoship.app/reference/format/)** - Open, portable format for data portability
-- **[Architecture](https://cargoship.app/project/architecture)** - System design
-- **[Project Maturity & Compatibility](https://cargoship.app/project/maturity)** - What's stable vs. beta, and what's guaranteed
-- **[Manifest System](pkg/manifest/README.md)** - File indexing and fast query API
+### Project
+- [Architecture](https://cargoship.app/project/architecture) — system design
+- [Project Maturity & Compatibility](https://cargoship.app/project/maturity) — what's stable vs. beta
+- [Comparison](https://cargoship.app/reference/comparison) — CargoShip vs. other tools
+- [Contributing](CONTRIBUTING.md) — how to get involved
+- [Security Policy](SECURITY.md) — reporting vulnerabilities
 
-### Cost & Budget
-- **[Estimating Costs](https://cargoship.app/guides/cost/estimate)** - Model spend before uploading
-- **[Cost Management](https://cargoship.app/guides/cost/management)** - Reports and forecasts
-- **[Budgets & Quotas](https://cargoship.app/guides/cost/budgets)** - Project-based cost and volume tracking
+## Project status and license
 
-### Deployment & Operations
-- **[Deployment Guide](https://cargoship.app/enterprise/deployment)** - Production deployment strategies
-- **[Launch Agents](https://cargoship.app/enterprise/launch-agent)** - Enterprise agent deployment
-- **[Ghost Ship](https://cargoship.app/enterprise/ghost-ship)** - Distributed agent setup
+CargoShip is at **v0.13.2** and is a community-maintained v0.x project — the CLI
+and archive format are usable in production, with compatibility caveats tracked
+on the [maturity page](https://cargoship.app/project/maturity). To report a
+security issue, see [SECURITY.md](SECURITY.md).
 
-## 🤝 Contributing
+Licensed under the Apache License 2.0; see [LICENSE](LICENSE). Originally
+inspired by Duke University's [SuitcaseCTL](https://gitlab.oit.duke.edu/devil-ops/suitcasectl)
+research project, now an independent project.
 
-CargoShip welcomes contributions from developers and researchers! Originally inspired by Duke University's SuitcaseCTL research, now a fully independent project.
+## Support
 
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/amazing-feature`
-3. Commit your changes: `git commit -m 'Add amazing feature'`
-4. Push to the branch: `git push origin feature/amazing-feature`
-5. Open a Pull Request
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
-
-## 📄 License and Attribution
-
-CargoShip is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.
-
-**Research Origins**: Originally inspired by Duke University's [SuitcaseCTL](https://gitlab.oit.duke.edu/devil-ops/suitcasectl) research project. CargoShip has evolved into an independent, production-ready solution with a modern streaming architecture and enterprise features.
-
-## 🆘 Support
-
-- **Documentation**: [cargoship.app](https://cargoship.app)
-- **Issues**: [GitHub Issues](https://github.com/scttfrdmn/cargoship/issues)
-- **Community**: [GitHub Discussions](https://github.com/scttfrdmn/cargoship/discussions)
-
----
-
-**Ship your data with confidence. Ship it with CargoShip.** 🚢
+- Documentation: [cargoship.app](https://cargoship.app)
+- Issues: [GitHub Issues](https://github.com/scttfrdmn/cargoship/issues)
+- Community: [GitHub Discussions](https://github.com/scttfrdmn/cargoship/discussions)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,539 +1,73 @@
-# CargoShip Release Roadmap
+# CargoShip Roadmap
 
 **Last Updated**: July 2026
 **Current Version**: v0.13.2 (Released 2026-07-07)
-**Next Release**: v0.14.0 (Planning)
 
-This document outlines the planned feature releases for CargoShip, organized by version with clear deliverables and timelines.
+This is a forward-looking roadmap: it answers "what's next," not "what happened."
+For released-version history, see [CHANGELOG.md](CHANGELOG.md).
 
----
-
-## ✅ **v0.13.2 - CI Repair & Security Hardening** (RELEASED July 2026)
-**Status**: Complete
-
-- ✅ Repaired CI (broken since February); Substrate emulator import fixes, `go.sum`/dependency reconciliation
-- ✅ Multi-scanner security workflow: govulncheck, gitleaks, Trivy, Semgrep — all SHA-pinned
-- ✅ Dependency CVE fixes (go-git, aws-sdk-go-v2, x/text, grpc); same-origin WebSocket checks; non-root containers
-- ✅ New VitePress documentation site at cargoship.app; stub pages expanded
-
-## ✅ **v0.13.1 - Substrate Test Migration** (RELEASED 2026-03-18)
-**Status**: Complete
-
-- ✅ Migrated all integration tests from LocalStack to an in-process Substrate emulator (no Docker required)
-- ✅ Removed LocalStack endpoint hard-codes; real-AWS path retained via `CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS=1`
-
-## ✅ **v0.13.0 - DVC Pipeline Auto-Discovery** (RELEASED 2026-02)
-**Status**: Complete — populates `FileEntry.DVCMetadata.Stage` during real uploads
-
-- ✅ **`BuildFileStageIndex`** — parse `dvc.yaml` → map of output path → stage name
-- ✅ **`AnnotateFilesWithDVCStages`** — walk `[]FileEntry` and set `DVCMetadata.Stage` via stage index
-- ✅ **`cargoship upload --dvc-auto`** — auto-discover DVC stages from `dvc.yaml` and annotate each file entry; re-uploads manifest so stage-aware commands function in production
-- ✅ **`cargoship dvc stages <S3_URL>`** — list pipeline stages and file counts from manifest
-- ✅ **`cargoship dvc status <LOCAL_PATH> <S3_URL>`** — compare local files against manifest (unchanged / modified / missing), with optional `--stage` filter
-- ✅ **`cargoship dvc export <S3_URL> [OUTPUT_DIR]`** — generate `.dvc` sidecar files from manifest `ContentHash` entries
+Dates and scope are targets, not commitments, and may shift with community
+feedback and development progress.
 
 ---
 
-## ✅ **v0.3.2 - Multi-Region Stability** (RELEASED July 2025)
-**Status**: Complete - Advanced multi-region testing and production readiness
+## Current release — v0.13.2
 
-### Completed Features:
-- ✅ **Region Selection Strategy Tests** - Comprehensive validation of all selection algorithms
-- ✅ **Failover Scenario Testing** - Region failure simulation and recovery validation
-- ✅ **Performance Benchmarking Suite** - Real-world performance metrics and comparison tools
-- ✅ **Test Coverage Improvements** - Achieved 85%+ coverage across all multiregion packages
+CI repair and security hardening: multi-scanner security workflow, dependency
+CVE fixes, and the new documentation site. See the [changelog](CHANGELOG.md) for
+details.
 
----
+## Next — v0.14.0 (Planning)
 
-## ✅ **v0.4.0 - Advanced Network Algorithms** (RELEASED July 2025)
-**Status**: Complete - Production-proven network optimization algorithms
+Theme: **enterprise budget foundations**. Candidate items (planned/proposed, not
+yet committed to a date):
 
-### Completed Features:
-- ✅ **BBR Congestion Control** - Google's production-tested bandwidth probing algorithm
-- ✅ **CUBIC TCP Algorithm** - Linux kernel's proven congestion window management
-- ✅ **RTT Estimation System** - Signal processing with Kalman filtering and statistical methods
-- ✅ **Loss Detection & Recovery** - Multi-method packet loss detection with deterministic recovery
-- ✅ **Bandwidth-Delay Product** - Dynamic buffer optimization for maximum throughput
+- Multi-grant portfolio management — track multiple concurrent grants/budgets.
+- Hierarchical budget controls — department → lab → project → user inheritance.
+- Advanced burn-rate analytics — predictive spending with seasonality.
+- Budget approval workflows — multi-stage approval for large transfers.
 
-### Achieved Performance:
-- ✅ 4.6x faster uploads than generic tools
-- ✅ Production-proven algorithms from Google and Linux kernel
-- ✅ 95% test coverage with comprehensive validation
-- ✅ Real-time network condition adaptation
+Exact scope will be finalized during planning; some items may land across
+several minor releases.
 
----
+## Near-term (following minor releases)
 
-## ✅ **v0.4.1 - Documentation & Accuracy** (RELEASED July 2025)
-**Status**: Complete - Honest documentation and enterprise messaging alignment
+High-level themes, in rough priority order:
 
-### Completed Features:
-- ✅ **Documentation Accuracy** - Corrected ML claims to reflect actual algorithm implementations
-- ✅ **Enterprise Messaging** - Unified professional positioning across all documentation
-- ✅ **Performance Transparency** - Accurate representation of proven network algorithms
-- ✅ **GitHub Pages Updates** - Enhanced site with v0.4.0 capabilities
+- **Institutional workflows** — cost-center integration and chargeback;
+  research/federal compliance reporting (OSTP 2025, NSF/NIH).
+- **Transfer integrations** — Globus endpoint integration for institutional
+  data movement.
+- **Maturity work** — graduate beta components (DVC integration, distributed
+  agents) toward stable; expand test coverage and docs.
 
----
+## Longer-term — path to v1.0.0
 
-## ✅ **v0.5.1 - Integration Testing & Reliability** (RELEASED November 2025)
-**Status**: Complete - Production-ready testing infrastructure and benchmarks
+v1.0.0 is about stability and maturity, not a feature dump:
 
-### Completed Features:
-- ✅ **Integration Testing Framework** - 19 tests with real AWS S3 validation (not just LocalStack)
-- ✅ **Performance Benchmark Suite** - 5 comprehensive benchmarks
-  - Compression speed: zstd 527.30 MB/s (10.7x faster than gzip)
-  - S3 Upload: 10MB → 32.20 MB/s, 100MB → 23.07 MB/s
-  - S3 Download: 10MB → 64.15 MB/s, 100MB → 89.68 MB/s
-  - Memory efficiency: 4.21 MB peak for 100MB file
-- ✅ **Failure Scenario Tests** - 7 production reliability tests
-  - S3 bucket not found, corrupted archives, invalid permissions
-  - Network timeouts, partial upload cleanup, concurrent races
-  - Disk space monitoring and handling
-- ✅ **Large-Scale Scenario Tests** - 5 comprehensive edge case tests
-  - Large directory: 10,000 files in 11.38s (11,383 files/sec)
-  - Deep nesting: 25 directory levels, 330-char paths
-  - Long paths: 484-494 character validation
-  - Special characters: Unicode, emoji, punctuation
-  - Mixed file sizes: 184 files (1KB-50MB), 855 MB/s compression
+- **API stabilization** — settle the public Go API package-by-package (today
+  it's mixed per `docs/project/maturity.md`) and commit to semver guarantees.
+- **Graduate beta → stable** — DVC commands/plugin, distributed agents, and
+  Magika detection move from beta to stable once wire formats and command
+  surfaces settle.
+- **Experimental → supported** — decide the fate of multi-region (library-only
+  today, not wired into `cargoship upload`).
+- **Uphold the archive-compatibility guarantee** — archives stay readable across
+  releases within the documented format versions.
 
-### Performance Validation:
-- ✅ 10,000 files in 9.26s (133x faster than 20min target)
-- ✅ All failure scenarios validated for production readiness
-- ✅ Real AWS S3 integration with automatic bucket lifecycle management
+Aspirational, and gated on real-world validation rather than a fixed date.
+
+## Exploratory — NOT committed
+
+Ideas under consideration only. These are not promises and may never ship:
+
+- Multi-cloud support (Azure, GCP) alongside AWS.
+- True ML / predictive optimization — learned parameter tuning and network
+  modeling (current optimization is deterministic).
+- Serverless / auto-scaling agents and container-orchestrated deployment.
+- Next-gen protocols (HTTP/3) and a REST API surface.
 
 ---
 
-## ✅ **v0.6.0 - Enterprise Budget & Cost Management** (RELEASED December 2025)
-**Status**: Complete - Production-ready cost tracking and forecasting
-
-### Completed Features:
-- ✅ **Dual Budget Controls** - Cost budgets (USD) AND volume quotas (GB) enforced independently
-  - Grant period management: 1-3 year budget periods with rollover support
-  - Threshold alerts: Warning at 80%, critical at 100%
-  - Budget enforcement: Operations blocked if limits would be exceeded
-- ✅ **Project-Based Cost Tracking** - Each manifest upload ID = project for granular analysis
-  - Time period filtering (day/week/month/year/custom date ranges)
-  - Multi-dimensional breakdowns (region, storage class, project)
-  - Cost summaries with total costs, savings, file counts, data volumes
-- ✅ **ML-Powered Forecasting** - Budget forecasting and burn rate analysis
-  - 4 forecasting models: linear, exponential, moving_average, ensemble
-  - Confidence intervals: 90%, 95%, 99% prediction bounds
-  - Burn rate analysis: Historical trends, acceleration, volatility tracking
-  - Budget exhaustion predictions with exact dates and probability estimates
-- ✅ **Multi-Channel Alert Notifications** - Production-ready alert system
-  - Email (SMTP): TLS 1.2+ encrypted, multiple recipients
-  - Slack webhooks: Rich message formatting with color-coded attachments
-  - Custom webhooks: JSON payload with complete alert metadata
-  - CloudWatch integration: Native AWS metrics and alarms
-  - 6 alert types, 3 severity levels (info, warning, critical)
-- ✅ **Comprehensive CLI Commands** - 20+ subcommands across 3 groups
-  - Budget: `budget status`, `budget set`, `budget list`, `budget remove`
-  - Cost: `cost summary`, `cost projects`, `cost forecast`, `cost burnrate`
-  - Alerts: `alerts configure`, `alerts test`, `alerts enable/disable`
-- ✅ **Rclone Integration Removal** - Transitioned to S3-native architecture
-  - Simplified codebase focusing on S3 optimization
-  - Removed `--cloud-destination` flag and `cargoship rclone` command
-
-### Technical Achievements:
-- ✅ ~140KB production code across 6 core files
-- ✅ ~102KB test code with 67 tests passing
-- ✅ 72.5% test coverage (pkg/aws/cost)
-- ✅ Zero linting issues, zero security vulnerabilities
-- ✅ 2,970+ lines of comprehensive documentation
-
-### Issues Closed:
-- #147: Budget & Cost Management System (Phases 1-6)
-- #148: Incremental sync with manifest-based delta detection
-- #149: Project-based cost tracking
-- #150: Timezone issue in week period calculation
-- #163: AWS KMS encryption support for manifests and data
-- #162: OptimizedTransporter Content-Length header bug
-- #161: Transporter performance benchmarks
-- #160: GoReleaser for automated multi-platform releases
-- #159: FindFile O(1) hash map lookup optimization
-- #158: Automatic cleanup on upload failure
-- #157: Resume capability for failed uploads
-- #156: Flaky TestRealTimeLoadBalancerRealTimeMonitoring
-- #155: Distributed tracing and observability infrastructure
-- #154: Network stack tuning: HTTP/2 and TCP optimization
-
----
-
-## ✅ **v0.7.0 - Performance & Optimization** (RELEASED Q1 2026)
-**Focus**: Zero-copy I/O, adaptive sharding, network improvements, and content-aware compression
-
-### Completed Features:
-- ✅ **Adaptive Shard Count** - Automatic S3 prefix optimization (Issue #106)
-  - Auto-tunes 4–32 shards based on file count, data size, CPU, and memory
-- ✅ **Zero-Copy I/O** - Linux splice-based transfer with buffer pooling (Issue #153)
-- ✅ **HTTP/2 and TCP Tuning** - 3x throughput improvement on high-latency links (Issue #154)
-- ✅ **Geographic Region Selection** - Automatic S3 region from client location (Issue #138)
-- ✅ **Content-Aware Compression** - Magika AI file type detection (Issue #105)
-- ✅ **File Deduplication** - Cross-upload deduplication via content hashing (Issue #108)
-- ✅ **Shard Rebalancing** - `cargoship balance` command (Issue #109)
-- ✅ **Resume Failed Uploads** (Issue #157), **Cleanup on Failure** (Issue #158)
-- ✅ **Incremental Sync** - MD5-based change detection (Issue #148, #177–#179)
-- ✅ **CargoHold Archive Format** - Selective extraction and manifest query API (Issues #88–#93)
-- ✅ **`upload` command** - Primary upload with CargoHold sharding (Issue #95)
-- ✅ **`verify` command** - Dataset integrity verification (Issue #99)
-- ✅ **Staging Package Refactor** - Merged compression types, removed stubs (Issue #16)
-
----
-
-## ✅ **v0.10.0 - DVC Integration** (RELEASED February 2026)
-**Focus**: Native DVC remote support for ML/data science workflows
-
-### Planned Features:
-- **`dvc-cargoship` Python Package** - Native DVC remote backed by CargoShip (Issue #181)
-- **DVC `.dvc` File Generation** - Track datasets in Git (Issue #180)
-- **Incremental Sync** - MD5-based change detection for DVC workflows (Issues #177–#179)
-- **Budget Integration for DVC** - Cost tracking per DVC pipeline run (Issue #183)
-- **DVC Pipeline Metadata** - Extract and store pipeline provenance (Issue #185)
-- **Federal Compliance Reports** - NSF/NIH grant compliance for DVC datasets (Issue #187)
-- **Hash-Based Manifest Queries** - DVC-aware lookups (Issue #188)
-- **Selective Restore** - Batch restore with LRU cache (Issue #189)
-- **Interactive TUI Browser** - Browse and restore archived datasets (Issue #190)
-
-### Issues:
-- #171–#192: Full DVC integration milestone
-
----
-
-## ✅ **v0.11.0 - Enhanced Data Retrieval** (RELEASED February 2026)
-**Focus**: Comprehensive restoration capabilities and interactive data access
-
-### Planned Features:
-- ✅ **Selective File Restoration** - Extract specific files without full suitcase restoration (Issues #188, #189)
-- ✅ **S3 Glacier Management** - Automated Deep Archive and Glacier restoration workflows (Issue #200)
-- ✅ **Interactive Browse Interface** - TUI browsing of archived data (Issue #190)
-- ✅ **Bulk Restoration Operations** - Restore entire datasets with progress tracking (Issues #189, #201)
-- ✅ **Restoration Job Management** - Queue, schedule, and monitor restoration processes (Issue #202)
-- ✅ **Quota-Aware Restoration** - Track restoration costs against budget quotas (Issue #201)
-
-### Restoration Features:
-```bash
-# Interactive browsing of archived data
-cargoship browse s3://archive-bucket/project-2024 --interactive
-cargoship browse --tui --search "*.fastq.gz" --preview
-
-# Selective file restoration with quota tracking
-cargoship restore s3://archive-bucket/genomics/sample-001.bam \
-  --destination /tmp/restored \
-  --quota restoration-budget \
-  --priority expedited
-
-# Bulk restoration with progress tracking
-cargoship restore s3://archive-bucket/analysis-results/ \
-  --destination /data/restored \
-  --tier standard \
-  --track-progress
-
-# S3 Glacier restoration management
-cargoship restore request s3://archive-bucket/large-dataset/ \
-  --tier expedited \
-  --notify-when-ready \
-  --max-cost 500
-```
-
-### Success Criteria:
-- ✅ Selective restoration without full archive extraction
-- ✅ Automated Glacier/Deep Archive workflow handling
-- ✅ Interactive TUI with search and preview capabilities
-- ✅ Quota tracking for all restoration operations
-- ✅ Progress monitoring for long-running restoration jobs
-
----
-
-## ✅ **v0.12.0 - Archive Inspection & Developer Experience** (RELEASED February 2026)
-**Focus**: Make archived data inspectable without extraction; documentation accuracy and polish
-
-### Completed Features:
-- ✅ **Archive Filesystem REPL** - `cargoship shell s3://bucket/prefix` virtual filesystem shell (Issue #203)
-  - Navigate archive like a local directory: `ls`, `cd`, `pwd`
-  - Inspect file content: `cat`, `head`, streaming decompression
-  - Metadata commands: `stat`, `find`
-  - DVC/git awareness: `stage list`, filter by stage or commit
-  - On-demand restore: `get <file> [dest]`
-- ✅ **Documentation Overhaul** - Accuracy fixes, cruft removal, user-facing rewrites (Issue #204)
-  - Removed stale internal planning artifacts from docs/
-  - CLI_REFERENCE.md updated with Data Retrieval Commands section
-  - USER_GUIDE.md updated with Retrieving Archived Data section
-  - mkdocs.yml navigation rebuilt
-
-### REPL Session Example:
-```bash
-$ cargoship shell s3://my-bucket/uploads/20240101-abc123
-
-CargoShip Archive Shell — 2847 files, 10 chunks
-Type 'help' for available commands.
-
-archive:/> ls data/
-  models/    raw/    train/
-archive:/> cd data/train
-archive:/data/train> ls
-  features.parquet  (12.4 MB, stage: train, hash: d8e8fc...)
-  labels.csv        (2.1 MB, stage: train, hash: a3f2c1...)
-archive:/data/train> stat features.parquet
-  Path:        data/train/features.parquet
-  Size:        12.4 MB (4.1 MB compressed)
-  Hash:        d8e8fca2dc0f896fd7cb4cb0031ba249
-  Chunk:       shard-0/chunk-3.tar.zst
-  DVC stage:   train
-  Git commit:  deadbeef
-archive:/data/train> cat labels.csv
-[streams decompressed content to stdout]
-archive:/data/train> get features.parquet ./local/
-  ✅ Restored features.parquet → ./local/features.parquet
-archive:/> stage list
-  preprocess  (50 files)
-  train       (2 files)
-archive:/> exit
-```
-
-### Success Criteria:
-- Archive can be explored without any local extraction
-- `cat` streams individual files without downloading full chunks when possible
-- Tab completion works on manifest paths
-- DVC stage and git commit filtering available as first-class filters
-- All user-facing docs use correct command syntax and license
-
----
-
-## 💼 **v1.0.0 - Enterprise Integration** (Target: Q4 2026)
-**Focus**: Multi-grant management, hierarchical budgets, and institutional workflows
-
-### Planned Features:
-- **Multi-Grant Portfolio Management** - Track multiple concurrent grants/budgets
-- **Hierarchical Budget Controls** - Department → Lab → Project → User inheritance
-- **Advanced Burn Rate Analytics** - Predictive spending with seasonality
-- **Budget Approval Workflows** - Multi-stage approval for large transfers
-- **Cost Center Integration** - Enterprise cost accounting and chargeback systems
-- **Globus Transfer Integration** - Direct integration with institutional Globus endpoints
-- **Research Workflow Support** - Academic data archiving with federal compliance
-
-### Enterprise Features:
-```bash
-# Multi-grant portfolio with hierarchical limits
-cargoship budget create-portfolio \
-  --grants "NSF-2024:$10k,NIH-2025:$15k" \
-  --department-limit 50000 \
-  --lab-limit 5000 \
-  --user-limit 1000
-
-# Approval workflow for large transfers
-cargoship upload /large-dataset \
-  --max-cost 2000 \
-  --require-approval \
-  --approvers "pi@university.edu,admin@university.edu"
-
-# Automated cost optimization under budget pressure
-cargoship budget set-optimization \
-  --auto-tier-when-over 80% \
-  --emergency-glacier-at 95%
-
-# Globus integration with budget tracking
-cargoship upload /research/genomics-data \
-  --via globus \
-  --endpoint duke-cluster \
-  --grant NSF-2024 \
-  --budget-limit 500
-```
-
-### Success Criteria:
-- ✅ Support for 10+ concurrent grant periods
-- ✅ Automated budget optimization recommendations
-- ✅ Integration with university financial systems
-- ✅ Approval workflows reducing unauthorized spending
-- ✅ Seamless Globus endpoint discovery and authentication
-- ✅ OSTP 2025 federal data sharing compliance
-
----
-
-## 🤖 **v1.0.0 - Machine Learning Implementation** (Target: Q4 2026)
-**Focus**: True ML integration and predictive optimization
-
-### Planned Features:
-- **ML-Based Parameter Optimization** - Train models on historical transfer data
-- **Predictive Network Modeling** - ML models for network condition prediction
-- **Transfer Performance Learning** - Optimize future transfers from patterns
-- **Adaptive Algorithm Selection** - ML-driven selection between BBR, CUBIC, etc.
-
-### ML Implementation:
-- 🤖 Supervised learning models trained on transfer telemetry
-- 📊 Time series prediction for network condition forecasting
-- 🧠 Reinforcement learning for dynamic parameter optimization
-- 📈 Feature engineering from network metrics and performance
-
-### Technical Requirements:
-- Data collection infrastructure for training datasets
-- Model training pipeline with performance validation
-- A/B testing framework for algorithm comparison
-- Model deployment and inference optimization
-
-### Success Criteria:
-- ✅ Demonstrable performance improvement over deterministic algorithms
-- ✅ Model accuracy validation against real-world scenarios
-- ✅ Reduced manual parameter tuning through learned optimization
-- ✅ Production-ready ML infrastructure with monitoring and rollback
-
----
-
-## 👻 **v1.1.0 - Cloud-Native Scaling** (Target: Q1 2027)
-**Focus**: Serverless and auto-scaling architecture
-
-### Planned Features:
-- **Ghostships** - Ephemeral cloud-based auto-scaling agents
-- **Serverless Data Movement** - Cost-optimized cloud bursting
-- **Multi-Cloud Support** - Azure, GCP integration alongside AWS
-- **Container Orchestration** - Kubernetes-based agent deployment
-
-### Success Criteria:
-- ✅ Cost-effective scaling for variable workloads
-- ✅ Multi-cloud cost optimization and vendor flexibility
-- ✅ Zero-management deployment in cloud environments
-
----
-
-## 🔮 **v1.2.0 - Protocol Innovation** (Target: Q2 2027)
-**Focus**: Advanced protocols and enterprise features
-
-### Planned Features:
-- **HTTP/3 Optimizations** - Next-generation protocol support
-- **Advanced Analytics** - Comprehensive transfer analytics and reporting
-- **Backup & Versioning** - Incremental backups with lifecycle management
-- **Enterprise Security** - LDAP, SSO, and compliance features
-
-### Success Criteria:
-- ✅ Industry-leading transfer protocols and optimizations
-- ✅ Comprehensive analytics for transfer optimization
-- ✅ Enterprise-ready security and compliance features
-- ✅ Full backup and disaster recovery capabilities
-
----
-
-## 📋 **Release Planning & Tracking**
-
-### Development Phases:
-- **Alpha**: Core features implemented, internal testing
-- **Beta**: Feature complete, community testing and feedback
-- **RC**: Release candidate, final testing and bug fixes
-- **GA**: General availability, production ready
-
-### Version Numbering:
-- **Major (x.0.0)**: Significant architectural changes or new major features
-- **Minor (0.x.0)**: New features, performance improvements, API additions
-- **Patch (0.0.x)**: Bug fixes, security updates, minor improvements
-
-### Release Cadence:
-- **Major Releases**: Every 6-9 months
-- **Minor Releases**: Every 2-3 months
-- **Patch Releases**: As needed for critical fixes
-
----
-
-## 🎯 **Success Metrics by Version**
-
-### v0.6.0 Achieved:
-- ✅ Dual budget controls (cost + volume quotas)
-- ✅ 4 ML forecasting models with 90-99% confidence intervals
-- ✅ Multi-channel alerts (Email, Slack, CloudWatch, webhooks)
-- ✅ 20+ CLI commands for budget/cost management
-- ✅ 72.5% test coverage, zero linting issues
-
-### v0.7.0 Achievements:
-- ✅ Zero-copy I/O via Linux splice integration
-- ✅ 3x throughput on high-latency links (HTTP/2 + TCP tuning)
-- ✅ Adaptive shard count: 4–32 shards auto-tuned
-- ✅ Content-aware compression with Magika AI detection
-
-### v0.10.0 Targets (DVC Integration):
-- Native DVC remote backed by CargoShip
-- Budget tracking per DVC pipeline run
-- Federal compliance reports for NSF/NIH grants
-- Selective restore with interactive TUI browser
-
-### v0.9.0 Targets:
-- Selective file restoration without full extraction
-- Interactive TUI with search and preview
-- Quota-aware restoration cost tracking
-- Automated Glacier workflow handling
-
-### v1.0.0 Targets:
-- 10+ concurrent grant period support
-- Automated optimization saving 15%+ costs
-- Globus integration with institutional endpoints
-- Federal compliance (OSTP 2025) support
-
-### v1.0.0 Targets:
-- ML-based performance improvements over deterministic algorithms
-- Predictive network modeling with 90%+ accuracy
-- Automated parameter optimization reducing manual tuning
-
----
-
-## 🔄 **Continuous Improvements**
-
-### Every Release:
-- **Security Updates** - Latest vulnerability fixes and security enhancements
-- **Performance Monitoring** - Continuous performance regression testing
-- **Documentation** - Updated guides, examples, and API documentation
-- **Test Coverage** - Maintain 80%+ coverage across all packages
-- **Code Quality** - Zero linting violations and automated quality checks
-
-### Community Feedback:
-- Regular community input on feature priorities
-- User experience improvements based on real-world usage
-- Performance optimization based on field deployment data
-- Research community specific feature requests
-
----
-
-## 📞 **Release Communication**
-
-### Pre-Release:
-- Feature announcements and development updates
-- Alpha/Beta testing program for early adopters
-- Documentation preview and migration guides
-
-### Release:
-- Comprehensive changelog and feature highlights
-- Performance benchmarks and improvement metrics
-- Migration guides and breaking change documentation
-- Community demos and feature walkthroughs
-
-### Post-Release:
-- User feedback collection and analysis
-- Performance monitoring and optimization
-- Bug fix releases and security updates
-- Next version planning and roadmap updates
-
----
-
-## 📊 **Current Status (v0.6.0)**
-
-### Production Readiness: ✅ EXCELLENT
-- All tests passing with race detector enabled
-- 75.4% test coverage (pkg/aws/s3)
-- Zero linting issues, zero security vulnerabilities
-- Thread-safety hardened (all race conditions resolved)
-- Clean builds across all platforms
-
-### Recent Achievements (December 2025):
-- Fixed 4 critical race conditions in memory buffer, network monitor, and interface segregation
-- Resolved deadlock in RealTimeLoadBalancer.performRealTimeMonitoring()
-- Comprehensive thread-safety audit completed
-- All concurrent access patterns validated and protected
-
-### Open Issues: 15
-**High Priority:**
-- #166: Realistic Benchmark Data & Infrastructure
-- #165: Cost Benchmarking & Transparency
-
-**Enhancement Backlog:**
-- #167: AI-Powered Optimizer (vision)
-- #140: Adaptive staging enhancements
-- #138: Geographic region selection
-- #137: ML-based adaptive routing
-
----
-
-**Note**: This roadmap is subject to change based on community feedback, technical discoveries, and research priorities. All dates are targets and may be adjusted based on development progress and quality requirements.
+**Note**: This roadmap is subject to change. All dates are targets and may be
+adjusted based on development progress, quality requirements, and priorities.

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -58,3 +58,20 @@
 .vp-doc .tip     { border-color: var(--vp-c-brand-1); }
 .vp-doc .warning { border-color: #b45309; }
 .vp-doc .danger  { border-color: #dc2626; }
+
+/* ── Development-branch banner (layout-top slot) ── */
+.cs-dev-banner {
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-text-2);
+  border-bottom: 1px solid var(--vp-c-divider);
+  text-align: center;
+  font-size: 0.8rem;
+  padding: 0.4rem 1rem;
+  line-height: 1.4;
+}
+.cs-dev-banner code {
+  font-size: 0.78rem;
+  background: var(--vp-c-bg-soft);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,27 @@
 import DefaultTheme from 'vitepress/theme'
+import { h } from 'vue'
 import './custom.css'
 
-export default DefaultTheme
+// Site-wide banner noting that the docs track `main` (the development branch),
+// not necessarily the latest tagged release. Update LATEST_RELEASE when cutting a
+// release. Rendered via the built-in `layout-top` slot so it appears on every
+// page, including the home layout.
+const LATEST_RELEASE = 'v0.13.2'
+
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'layout-top': () =>
+        h(
+          'div',
+          { class: 'cs-dev-banner' },
+          [
+            'These docs track the development branch (',
+            h('code', null, 'main'),
+            `). Latest release: ${LATEST_RELEASE}.`,
+          ],
+        ),
+    })
+  },
+}

--- a/docs/project/security.md
+++ b/docs/project/security.md
@@ -2,8 +2,15 @@
 
 CargoShip encrypts data at rest using AWS Key Management Service (KMS). It offers
 two independent, composable layers — encrypt data chunks, encrypt the manifest, or
-both for end-to-end protection. This page covers the model and setup; for the
-day-to-day flags see [Encryption (KMS & GPG)](/guides/features/encryption).
+both for complete at-rest protection of your data and its metadata. This page
+covers the model and setup; for the day-to-day flags see
+[Encryption (KMS & GPG)](/guides/features/encryption).
+
+::: info Not end-to-end encryption
+Data chunks use **SSE-KMS**, so S3 sees plaintext at write time and encrypts it
+server-side — this is at-rest encryption, not end-to-end. The manifest layer
+(`--encrypt-manifest`) *is* client-side (S3 never sees the plaintext manifest).
+:::
 
 ## Two encryption layers
 

--- a/docs/project/versioning.md
+++ b/docs/project/versioning.md
@@ -4,24 +4,30 @@ CargoShip follows [Semantic Versioning 2.0.0](https://semver.org/):
 `MAJOR.MINOR.PATCH`. This page explains what that means for the CLI and for
 projects that import CargoShip as a Go library.
 
-## Semantic versioning
+CargoShip follows [Semantic Versioning 2.0.0](https://semver.org/), but the exact
+compatibility rules differ before and after `v1.0` — as SemVer itself specifies
+for the `0.x` series. **CargoShip is currently `v0.x`, so the pre-1.0 policy
+below is the one in force today.**
 
-- **MAJOR** (`v0.x → v1.0`) — breaking API changes: removing or renaming public
-  functions, changing signatures or return types, removing struct fields, or
-  changing documented behavior. Requires consumer code changes; a migration guide
-  is provided.
-- **MINOR** (`v0.4 → v0.5`) — backward-compatible additions: new features, new
-  methods, new struct fields with zero-value defaults, new packages, and
-  deprecations (marking, not removing).
-- **PATCH** (`v0.4.4 → v0.4.5`) — bug fixes, security patches, performance
-  improvements, and documentation. Safe to upgrade immediately.
+## Current policy (pre-1.0)
 
-## Pre-1.0 status
+- **`0.MINOR.0`** (`v0.13 → v0.14`) — *may* contain **documented breaking
+  changes** alongside new features. This is standard for the `0.x` series. Any
+  break is called out in the release notes with a migration path.
+- **`0.MINOR.PATCH`** (`v0.13.1 → v0.13.2`) — bug fixes, security patches,
+  performance, and docs. Always backward compatible; safe to upgrade immediately.
 
-CargoShip is currently `v0.x`. In this phase, `v0.MINOR` bumps *may* include
-documented breaking changes, while `v0.PATCH` is always backward compatible.
-Despite the `v0.x` label, the **stable** library APIs are treated as
-production-ready and are not broken casually.
+Even so, the packages marked **Stable** below are not broken casually — they get
+the [deprecation policy](#deprecation-policy) treatment rather than abrupt
+changes. Pin a version if you need certainty across minor bumps.
+
+## Policy after 1.0
+
+Once CargoShip reaches `v1.0`, standard SemVer applies:
+
+- **MAJOR** (`v1 → v2`) — breaking changes; migration guide provided.
+- **MINOR** (`v1.1 → v1.2`) — backward-compatible additions only.
+- **PATCH** (`v1.1.1 → v1.1.2`) — backward-compatible fixes.
 
 ## Stability levels for the Go library
 
@@ -31,8 +37,8 @@ Public APIs are classified into three levels:
   and `pkg/aws/config` (`S3Config`, `StorageClass` constants). Backward compatible
   within the major version; new methods and fields may be added, but existing ones
   are not removed or changed.
-- **Beta** — cost-control config and `pkg/multiregion` coordination. Production-
-  ready but evolving; changes come with a deprecation notice (at least 2 minor
+- **Beta** — cost-control config and `pkg/multiregion` coordination. Usable but
+  still evolving; changes come with a deprecation notice (at least 2 minor
   versions).
 - **Experimental** — `pkg/staging`, `pkg/s3optimization` (predictive prefetching).
   May change in any version without notice; marked with

--- a/scripts/ci/check-doc-versions.sh
+++ b/scripts/ci/check-doc-versions.sh
@@ -73,7 +73,34 @@ for token in "${denylist[@]}"; do
   fi
 done
 
+# --- Check 3: local file links in root markdown resolve ------------------------
+#
+# VitePress already fails its build on dead links inside the docs/ site. This
+# covers the gap: relative file links in the repo-root markdown (README,
+# CONTRIBUTING, SECURITY, ROADMAP) that point at files in the repo — e.g.
+# [x](docs/foo.md), [x](pkg/manifest/README.md), [x](CHANGELOG.md). External
+# (http) and in-page anchor links are skipped.
+
+root_md=(README.md CONTRIBUTING.md SECURITY.md ROADMAP.md CLAUDE.md)
+for f in "${root_md[@]}"; do
+  [ -f "$f" ] || continue
+  # Extract link targets: [text](target). Drop http(s):, mailto:, and #anchors.
+  while IFS= read -r target; do
+    [ -z "$target" ] && continue
+    case "$target" in
+      http://*|https://*|mailto:*|\#*) continue ;;
+    esac
+    # Strip any #fragment from the path before checking existence.
+    path="${target%%#*}"
+    [ -z "$path" ] && continue
+    if [ ! -e "$path" ]; then
+      echo "::error file=$f::broken local link → $target"
+      fail=1
+    fi
+  done < <(grep -oE '\]\([^)]+\)' "$f" | sed -E 's/^\]\(//; s/\)$//')
+done
+
 if [ "$fail" -eq 0 ]; then
-  echo "✅ doc-consistency: Current Version matches $latest_tag; no denylisted tokens."
+  echo "✅ doc-consistency: Current Version matches $latest_tag; no denylisted tokens; local links resolve."
 fi
 exit $fail


### PR DESCRIPTION
Addresses the editorial/policy items from the second project review (which raised
the project to A−, 8.7/10, with these as the path to 9.1–9.3).

## Highest-priority items

- **README: 525 → 175 lines.** Trusts the docs site now. Keeps: one-paragraph
  intro, "why not aws s3/rclone", install, one complete
  estimate→upload→verify→restore example, 5 differentiators, safety/portability,
  doc links, status/license. Moved cost/architecture/tuning/benchmark/budget
  detail to the site (already there). Dropped the over-marketed opener and the
  dated v0.5.1 benchmark table.
- **ROADMAP: 540 → 73 lines, forward-only.** Current / Next / Near-term /
  Longer-term / Exploratory; released history → CHANGELOG.md. (CI-guarded
  "Current Version" line preserved.)
- **Versioning contradiction fixed.** Split into "Current policy (pre-1.0):
  `0.MINOR` may break, `0.PATCH` compatible" vs "Policy after 1.0" (standard
  SemVer). Fixed the "Production- ready" typo.
- **Doc-versioning clarity.** Site-wide banner: "these docs track the development
  branch (main). Latest release: v0.13.2." (Full `/latest//dev/` versioning
  deferred as a larger effort.)
- **CONTRIBUTING stale details.** Removed the dead `DEVELOPMENT_RULES.md` link
  (inlined the standards), fixed `cargoship ship` → `cargoship upload`, corrected
  the module map (dropped nonexistent `pkg/suitcase`), regrounded priority areas
  to the real roadmap.

## Smaller polish

- **Security wording.** "end-to-end protection" → accurate at-rest phrasing, with
  an info box: SSE-KMS is server-side (not E2E); the manifest layer is client-side.
- **Adjective audit.** Toned down bare superlatives in the README opening;
  capability-tied language retained.
- **Markdown link checking in CI.** Extended the doc-consistency guard to verify
  local file links in README/CONTRIBUTING/SECURITY/ROADMAP (VitePress already
  covers the site's internal links) — catches dead relative links CI missed.

## Verification
- README 175 lines, ROADMAP 73; doc-consistency guard passes (version + denylist
  + local links); site builds clean, no dead links; banner renders on every page.
- Stale-token sweep clean (create suitcase / v0.4.0 / 7x-40x / CARGOSHIP_SECURITY_MODE
  / DEVELOPMENT_RULES / cargoship ship / the typo all → 0).

## Deferred (larger, noted for later)
Full release-versioned docs (`/latest` + `/dev`); a reproducible benchmark report
with environment/commit metadata (the README now links to `make bench-s3` /
`run-benchmarks.sh` to regenerate); auto-running the Quick Start against the
in-process S3 emulator in CI.