### PR TITLE
fix: restore & verify direct-upload archives + Quick Start E2E test (Fixes #228)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,30 @@ jobs:
       - name: Run tests
         run: go test ./... -short -timeout=10m
 
+  e2e-quickstart:
+    name: Quick Start E2E (emulator)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      # Drives the real cargoship binary through the documented Quick Start
+      # (upload → info → verify → restore) against an in-process Substrate S3
+      # emulator. No AWS credentials required. Guards docs/start/quickstart.md.
+      - name: Run Quick Start end-to-end
+        run: go test -tags e2e ./tests/e2e/ -timeout 10m
+
   test-race:
     name: Test with Race Detector
     runs-on: ubuntu-latest

--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -230,7 +231,7 @@ func (se *SelectiveExtractor) BatchRestore(ctx context.Context, targets []string
 	chunkMap := make(map[string]*chunkGroup)
 
 	for _, target := range targets {
-		entry := se.query.FindFile(target)
+		entry := se.resolveEntry(target)
 		if entry == nil {
 			stats.Failed++
 			continue
@@ -246,6 +247,11 @@ func (se *SelectiveExtractor) BatchRestore(ctx context.Context, targets []string
 		return nil, fmt.Errorf("create destination directory: %w", err)
 	}
 
+	// Direct-upload manifests have no chunks: each file was stored as its own S3
+	// object (the object at FileEntry.S3Key IS the raw file, not a tar.zst chunk).
+	// Restore those by writing the downloaded bytes directly. (Issue #228)
+	directMode := len(se.manifest.Chunks) == 0
+
 	for _, grp := range chunkMap {
 		data := se.cache.get(grp.s3Key)
 		if data == nil {
@@ -259,6 +265,17 @@ func (se *SelectiveExtractor) BatchRestore(ctx context.Context, targets []string
 			stats.ChunksDownloaded++
 		}
 
+		if directMode {
+			// One S3 object == one file; write the raw bytes.
+			restored, written, err := se.writeDirectFiles(data, grp.files, destDir)
+			stats.Restored += int64(restored)
+			stats.Bytes += written
+			if err != nil {
+				stats.Failed += int64(len(grp.files)) - int64(restored)
+			}
+			continue
+		}
+
 		restored, written, err := se.extractFromChunkData(data, grp.files, destDir)
 		stats.Restored += int64(restored)
 		stats.Bytes += written
@@ -268,6 +285,54 @@ func (se *SelectiveExtractor) BatchRestore(ctx context.Context, targets []string
 	}
 
 	return stats, nil
+}
+
+// resolveEntry finds the manifest entry for a restore target. It tries an exact
+// path match first (via the O(1) index), then falls back to matching by relative
+// suffix / basename — so `--file greeting.txt` resolves even though manifests
+// currently store the file's absolute source path. (Issue #228)
+func (se *SelectiveExtractor) resolveEntry(target string) *FileEntry {
+	if entry := se.query.FindFile(target); entry != nil {
+		return entry
+	}
+	clean := filepath.Clean(target)
+	base := filepath.Base(clean)
+	var suffixMatch *FileEntry
+	for i := range se.manifest.Files {
+		p := se.manifest.Files[i].Path
+		// e.g. target "sub/greeting.txt" matching stored "/abs/root/sub/greeting.txt"
+		if p == clean || strings.HasSuffix(p, string(filepath.Separator)+clean) {
+			return &se.manifest.Files[i]
+		}
+		if filepath.Base(p) == base {
+			if suffixMatch != nil {
+				// Ambiguous basename; require a more specific target.
+				return nil
+			}
+			suffixMatch = &se.manifest.Files[i]
+		}
+	}
+	return suffixMatch
+}
+
+// writeDirectFiles writes direct-upload objects (raw file bytes, one object per
+// file) to destDir. The output path is the file's basename (manifests may store
+// an absolute source path; we never write outside destDir). (Issue #228)
+func (se *SelectiveExtractor) writeDirectFiles(data []byte, files []*FileEntry, destDir string) (int, int64, error) {
+	var restored int
+	var totalBytes int64
+	for _, entry := range files {
+		outPath := filepath.Join(destDir, filepath.Base(entry.Path))
+		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+			return restored, totalBytes, fmt.Errorf("mkdir for %s: %w", outPath, err)
+		}
+		if err := os.WriteFile(outPath, data, 0644); err != nil {
+			return restored, totalBytes, fmt.Errorf("write %s: %w", outPath, err)
+		}
+		restored++
+		totalBytes += int64(len(data))
+	}
+	return restored, totalBytes, nil
 }
 
 // BatchRestoreByDVCStage restores all files tagged with the given DVC pipeline

--- a/pkg/manifest/direct_restore_test.go
+++ b/pkg/manifest/direct_restore_test.go
@@ -1,0 +1,136 @@
+package manifest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for Issue #228: direct-upload manifests (no chunks — each file
+// stored as its own S3 object) must be restorable and verifiable. Before the fix,
+// restore treated every object as a tar.zst chunk (extracting nothing) and verify
+// failed file_consistency because chunk_id 0 was "out of range" when TotalChunks
+// was 0.
+
+// buildDirectUploadManifest builds a direct-upload manifest (TotalChunks == 0)
+// with the given file paths, and a mock S3 client serving each file's raw bytes
+// at its S3 key. The stored Path is absolute, mirroring the real scanner.
+func buildDirectUploadManifest(paths map[string]string) (*Manifest, *mockS3Client) {
+	const shardCount = 4
+	m := &Manifest{
+		Version:         ManifestVersion,
+		UploadID:        "direct-test-001",
+		CreatedAt:       time.Now(),
+		Bucket:          "test-bucket",
+		Region:          "us-east-1",
+		CompressionType: "none",
+		TotalChunks:     0,
+		ShardCount:      shardCount,
+		// A real direct-upload manifest has ShardCount shard entries (created by
+		// Builder.SetShardCount), just with zero chunks each.
+		Shards: make([]ShardEntry, shardCount),
+	}
+	for i := range m.Shards {
+		m.Shards[i] = ShardEntry{ID: i, Prefix: filepath.Join("uploads", "direct-test-001", "shard-"+string(rune('0'+i)))}
+	}
+	client := &mockS3Client{chunks: make(map[string][]byte)}
+	for absPath, content := range paths {
+		s3Key := "archives/" + filepath.Base(absPath)
+		m.Files = append(m.Files, FileEntry{
+			Path:    absPath,
+			Size:    int64(len(content)),
+			ModTime: time.Now(),
+			ChunkID: 0, // no chunks exist; this is the direct-upload sentinel
+			ShardID: 0,
+			S3Key:   s3Key,
+		})
+		client.chunks[s3Key] = []byte(content)
+	}
+	m.TotalFiles = int64(len(m.Files))
+	m.TotalBytes = func() int64 {
+		var t int64
+		for _, f := range m.Files {
+			t += f.Size
+		}
+		return t
+	}()
+	return m, client
+}
+
+func TestBatchRestore_DirectUpload_WritesRawFile(t *testing.T) {
+	m, client := buildDirectUploadManifest(map[string]string{
+		"/abs/src/greeting.txt": "hello cargoship",
+		"/abs/src/notes.txt":    "some notes",
+	})
+	se := NewSelectiveExtractor(m, client, 0)
+	dest := t.TempDir()
+
+	// Select by basename — the manifest stores the absolute path, but --file
+	// greeting.txt should still resolve. (Issue #228, root cause 2)
+	stats, err := se.BatchRestore(context.Background(), []string{"greeting.txt"}, dest)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.Restored)
+	assert.Equal(t, int64(0), stats.Failed)
+
+	// File written by basename under dest, with the original raw content.
+	got, err := os.ReadFile(filepath.Join(dest, "greeting.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello cargoship", string(got))
+}
+
+func TestBatchRestore_DirectUpload_ExactAndSuffixMatch(t *testing.T) {
+	m, client := buildDirectUploadManifest(map[string]string{
+		"/abs/src/data/report.csv": "a,b,c",
+	})
+	se := NewSelectiveExtractor(m, client, 0)
+
+	for _, target := range []string{
+		"/abs/src/data/report.csv", // exact
+		"data/report.csv",          // relative suffix
+		"report.csv",               // basename
+	} {
+		dest := t.TempDir()
+		stats, err := se.BatchRestore(context.Background(), []string{target}, dest)
+		require.NoError(t, err, "target %q", target)
+		assert.Equal(t, int64(1), stats.Restored, "target %q should resolve", target)
+	}
+}
+
+func TestBatchRestore_DirectUpload_UnknownTargetFails(t *testing.T) {
+	m, client := buildDirectUploadManifest(map[string]string{
+		"/abs/src/greeting.txt": "hi",
+	})
+	se := NewSelectiveExtractor(m, client, 0)
+	stats, err := se.BatchRestore(context.Background(), []string{"missing.txt"}, t.TempDir())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.Restored)
+	assert.Equal(t, int64(1), stats.Failed)
+}
+
+func TestValidate_DirectUpload_Passes(t *testing.T) {
+	m, _ := buildDirectUploadManifest(map[string]string{
+		"/abs/src/greeting.txt": "hello",
+		"/abs/src/notes.txt":    "notes",
+	})
+	result := NewValidator(m).Validate()
+	// A direct-upload manifest (no chunks, files carry S3 keys) must not fail
+	// file_consistency. (Issue #228, root cause 3)
+	assert.True(t, result.Checks["file_consistency"],
+		"file_consistency should pass for a direct-upload manifest")
+	assert.False(t, result.HasErrors(), "no hard errors expected: %s", result.Summary())
+}
+
+func TestValidate_DirectUpload_MissingS3KeyFails(t *testing.T) {
+	m, _ := buildDirectUploadManifest(map[string]string{
+		"/abs/src/greeting.txt": "hello",
+	})
+	m.Files[0].S3Key = "" // a direct-upload file with no object key is invalid
+	result := NewValidator(m).Validate()
+	assert.False(t, result.Checks["file_consistency"],
+		"a direct-upload file without an S3 key should fail validation")
+}

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -305,8 +305,18 @@ func (v *Validator) validateFileConsistency(result *ValidationResult) {
 			valid = false
 		}
 
-		// Check chunk ID is valid
-		if file.ChunkID < 0 || file.ChunkID >= v.manifest.TotalChunks {
+		// Check chunk ID is valid. Direct-upload manifests have no chunks
+		// (TotalChunks == 0); each file is its own S3 object, so validate that it
+		// carries an S3 key instead of a chunk reference. (Issue #228)
+		if v.manifest.TotalChunks == 0 {
+			if file.S3Key == "" {
+				result.AddError(fmt.Sprintf("file[%d].s3_key", i),
+					"non-empty",
+					"",
+					fmt.Sprintf("Direct-upload file %s has no S3 key", file.Path))
+				valid = false
+			}
+		} else if file.ChunkID < 0 || file.ChunkID >= v.manifest.TotalChunks {
 			result.AddError(fmt.Sprintf("file[%d].chunk_id", i),
 				fmt.Sprintf("0-%d", v.manifest.TotalChunks-1),
 				fmt.Sprintf("%d", file.ChunkID),

--- a/tests/e2e/quickstart_test.go
+++ b/tests/e2e/quickstart_test.go
@@ -1,0 +1,223 @@
+//go:build e2e
+
+// Package e2e drives the real `cargoship` binary through the documented Quick
+// Start (upload → info → verify → restore) against an in-process Substrate S3
+// emulator. It is the executable form of docs/start/quickstart.md — if the
+// documented happy path breaks (as it did for direct-upload mode in #228), this
+// test fails.
+//
+// Run with:  go test -tags e2e ./tests/e2e/ -timeout 5m
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	substrate "github.com/scttfrdmn/substrate/emulator"
+)
+
+var (
+	substrateURL string
+	cargoshipBin string
+)
+
+func TestMain(m *testing.M) {
+	url, cancel, err := launchSubstrate()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: start emulator: %v\n", err)
+		os.Exit(1)
+	}
+	substrateURL = url
+	// Point the CLI (and its SDK) at the emulator. The endpoint contains
+	// 127.0.0.1:, which the CLI auto-detects to enable path-style addressing.
+	os.Setenv("AWS_ENDPOINT_URL", url)
+	os.Setenv("AWS_ACCESS_KEY_ID", "test")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	os.Setenv("AWS_REGION", "us-east-1")
+
+	bin, buildErr := buildCargoship()
+	if buildErr != nil {
+		cancel()
+		fmt.Fprintf(os.Stderr, "e2e: build cargoship: %v\n", buildErr)
+		os.Exit(1)
+	}
+	cargoshipBin = bin
+
+	code := m.Run()
+	cancel()
+	os.Exit(code)
+}
+
+// TestQuickStart_RoundTrip mirrors docs/start/quickstart.md end to end: upload a
+// directory, inspect it, verify integrity, and restore a single file — asserting
+// the restored content matches the original.
+func TestQuickStart_RoundTrip(t *testing.T) {
+	bucket := "quickstart-e2e"
+	if err := createBucket(substrateURL, bucket); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	// Source data.
+	src := t.TempDir()
+	want := "hello cargoship — quickstart e2e\n"
+	writeFile(t, filepath.Join(src, "greeting.txt"), want)
+	writeFile(t, filepath.Join(src, "notes.txt"), "second file\n")
+
+	dest := "s3://" + bucket + "/archives"
+
+	// 1. Upload.
+	out := runCargoship(t, "upload", src, dest, "--region", "us-east-1")
+	uploadID := extractUploadID(t, out)
+	uploadURL := dest + "/uploads/" + uploadID
+
+	// 2. Inspect (must not error and must report the files).
+	runCargoship(t, "info", uploadURL, "--region", "us-east-1")
+
+	// 3. Verify integrity (exits non-zero on failure).
+	runCargoship(t, "verify", uploadURL, "--region", "us-east-1")
+
+	// 4. Restore a single file and confirm the round trip.
+	restoreDir := t.TempDir()
+	runCargoship(t, "restore", uploadURL, restoreDir, "--file", "greeting.txt", "--region", "us-east-1")
+
+	got, err := os.ReadFile(filepath.Join(restoreDir, "greeting.txt"))
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("restored content mismatch:\n got: %q\nwant: %q", string(got), want)
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// runCargoship runs the built binary with the given args, failing the test on a
+// non-zero exit. Returns combined stdout+stderr.
+func runCargoship(t *testing.T, args ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cargoshipBin, args...)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cargoship %v failed: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// extractUploadID pulls the timestamped upload ID (e.g. 20260722-abcd1234) from
+// upload output.
+func extractUploadID(t *testing.T, out string) string {
+	t.Helper()
+	// Look for "uploads/<id>/" in the output.
+	const marker = "uploads/"
+	idx := -1
+	if i := indexOf(out, marker); i >= 0 {
+		idx = i + len(marker)
+	}
+	if idx < 0 {
+		t.Fatalf("no upload ID in output:\n%s", out)
+	}
+	end := idx
+	for end < len(out) && out[end] != '/' && out[end] != '\n' && out[end] != ' ' {
+		end++
+	}
+	id := out[idx:end]
+	if id == "" {
+		t.Fatalf("empty upload ID parsed from output:\n%s", out)
+	}
+	return id
+}
+
+func indexOf(s, sub string) int { return bytes.Index([]byte(s), []byte(sub)) }
+
+func buildCargoship() (string, error) {
+	dir, err := os.MkdirTemp("", "cargoship-e2e-bin")
+	if err != nil {
+		return "", err
+	}
+	bin := filepath.Join(dir, "cargoship")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", bin, "../../cmd/cargoship")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func createBucket(baseURL, bucket string) error {
+	cfg := aws.Config{
+		Region:       "us-east-1",
+		BaseEndpoint: aws.String(baseURL),
+		Credentials:  credentials.NewStaticCredentialsProvider("test", "test", ""),
+	}
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) { o.UsePathStyle = true })
+	_, err := client.CreateBucket(context.Background(), &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	return err
+}
+
+// launchSubstrate starts an in-process Substrate S3 emulator on a random local
+// port and returns its base URL plus a cancel func. Mirrors the helper used by
+// the integration suites.
+func launchSubstrate() (string, context.CancelFunc, error) {
+	cfg := substrate.DefaultConfig()
+	cfg.EventStore.Enabled = false
+	cfg.Log.Level = "error"
+
+	state := substrate.NewMemoryStateManager()
+	tc := substrate.NewTimeController(time.Now())
+	registry := substrate.NewPluginRegistry()
+	logger := substrate.NewDefaultLogger(slog.LevelError, false)
+	store := substrate.NewEventStore(cfg.EventStore.ToEventStoreConfig(), substrate.WithTimeController(tc))
+
+	ctx := context.Background()
+	if err := substrate.RegisterDefaultPlugins(ctx, registry, state, tc, logger, store, nil); err != nil {
+		return "", nil, fmt.Errorf("register plugins: %w", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, fmt.Errorf("listen: %w", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	srv := substrate.NewServer(*cfg, registry, store, state, tc, logger)
+	srvCtx, cancel := context.WithCancel(context.Background())
+	go func() { _ = srv.Serve(srvCtx, ln) }()
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if resp, pingErr := http.Get(baseURL + "/health"); pingErr == nil { //nolint:noctx
+			_ = resp.Body.Close()
+			return baseURL, cancel, nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	return "", nil, fmt.Errorf("emulator did not become healthy")
+}


### PR DESCRIPTION
Fixes #228, and adds the end-to-end test that would have caught it.

## The bug (found while building the Quick Start CI test)

Direct-upload mode — the **default** for datasets < 500 MB, i.e. the documented
Quick Start path — produced archives that could not be restored or verified:

- **restore returned "0 files"** — `BatchRestore` downloaded each file's S3 object
  and always tar-extracted it, but direct-upload objects are the *raw file*, not a
  `tar.zst` chunk.
- **`--file greeting.txt` never matched** — manifests store the absolute source path.
- **verify FAILed `file_consistency`** — a direct-upload file has `chunk_id 0`
  while `TotalChunks` is `0`, so the "chunk_id out of range" check tripped on
  every file.

Confirmed end-to-end against the in-process Substrate emulator (upload succeeded,
verify failed, restore wrote nothing).

## The fix (restore-side, `pkg/manifest` only)

The archived-mode write/read path is untouched.

- **`batch_restore.go`** — when the manifest has no chunks, write the downloaded
  object bytes directly instead of tar-extracting; add `resolveEntry()` so a
  target resolves by exact path, relative suffix, or basename (ambiguous
  basenames rejected); direct-upload output is written under the file's basename
  so an absolute stored path can't escape `destDir`.
- **`validate.go`** — for a no-chunk manifest, validate each file carries an
  `s3_key` rather than a chunk id in range.

## The guard

- **`tests/e2e/quickstart_test.go`** (`e2e` build tag) — starts the emulator,
  builds the real `cargoship` binary, and drives the documented Quick Start
  (upload → info → verify → restore), asserting the restored content matches.
- New **"Quick Start E2E (emulator)"** CI job runs it on every PR (no AWS creds
  needed).

## Verification

- Round trip now works end-to-end: verify **PASS**, restore content **matches**
  (both confirmed against the emulator with the built binary).
- New unit tests in `direct_restore_test.go` (raw-file restore, exact/suffix/
  basename resolution, unknown-target failure, direct-upload validation) + the
  e2e test all pass; full `pkg/manifest` suite green.

Follow-up to #205 (which populated `s3_key`/`chunk_id`/`shard_id` in direct mode
but not the read-back). Worth a patch release given it's the default first-run path.