### PR TITLE
docs: benchmark methodology page + reproducible provenance in the runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Full documentation lives at **[cargoship.app](https://cargoship.app)**.
 ### Guides & tutorials
 - [Use-case Tutorials](https://cargoship.app/tutorials/) — genomics, imaging, ML/DVC, lab data
 - [Performance Tuning](https://cargoship.app/guides/features/optimization) — throughput knobs and benchmarks
+- [Benchmarks & Methodology](https://cargoship.app/reference/benchmarks) — reproduce the numbers on your own hardware
 - [Migration from rclone / aws cli](https://cargoship.app/tutorials/migrating) — switching to CargoShip
 - [upload vs. create upload](https://cargoship.app/guides/upload-vs-create-upload) — the advanced tuning variant
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -125,6 +125,7 @@ const sidebar = {
         { text: 'Environment variables', link: '/reference/environment-variables' },
         { text: 'Configuration schema', link: '/reference/configuration' },
         { text: 'CargoShip vs. other tools', link: '/reference/comparison' },
+        { text: 'Benchmarks & methodology', link: '/reference/benchmarks' },
         { text: 'Recovery & operations runbook', link: '/reference/recovery' },
         { text: 'Troubleshooting', link: '/reference/troubleshooting' },
         { text: 'FAQ', link: '/reference/faq' },

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -1,0 +1,131 @@
+# Benchmarks & methodology
+
+CargoShip ships a repeatable benchmark suite so that any performance claim can be
+reproduced on your own hardware. This page documents **how** the numbers are
+produced — the methodology, the scenarios, and the provenance recorded with every
+run — so results are never quoted without the context that makes them meaningful.
+
+::: info No headline numbers here
+Throughput depends heavily on your network path to S3, instance type, file mix,
+and region. Rather than publish a single "X MB/s" figure that won't match your
+environment, this page tells you how to measure it yourself. Run the suite and
+read the provenance header for the machine, commit, and settings behind each
+number.
+:::
+
+## Running the suite
+
+From the repository root:
+
+```bash
+# Full run: 3s per benchmark, 5 iterations, with CPU + memory profiles
+scripts/run-benchmarks.sh
+
+# Quick run for iteration (1s, 3 iterations)
+scripts/run-benchmarks.sh --short
+
+# Long run for publishable numbers (10s, 10 iterations)
+scripts/run-benchmarks.sh --long
+
+# Skip profiling (faster, smaller output)
+scripts/run-benchmarks.sh --no-profile
+```
+
+Each run writes a timestamped report to `benchmark-reports/benchmark-<timestamp>.txt`
+and, unless `--no-profile` is set, CPU and memory profiles to `profiles/`.
+
+You can tune the run with environment variables:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `BENCH_TIME` | `3s` | Wall-clock duration per benchmark |
+| `BENCH_COUNT` | `5` | Iterations per benchmark (for `benchstat`) |
+| `AWS_REGION` | `us-west-2` | Region for S3 integration benchmarks |
+| `BENCHMARK_BUCKET` | `cargoship-benchmark-test` | Bucket for S3 integration benchmarks |
+
+## Provenance: every report is reproducible
+
+The runner prepends a provenance header to each report recording exactly what
+produced the numbers:
+
+```
+# CargoShip benchmark report
+#
+# Generated:      20260722-1030
+# Git commit:     a4b8872b081ca9a16a76c28ec5de330594250535
+# Go version:     go1.26.5
+# OS / arch:      Darwin / arm64
+# CPU:            Apple M4 Pro (12 cores)
+# Memory:         49152 MB
+# Bench time:     3s × 5 iterations
+# Benchmark dir:  ./pkg/benchmarks/scenarios
+#
+# Reproduce:      BENCH_TIME=3s BENCH_COUNT=5 scripts/run-benchmarks.sh
+# Methodology:    docs/reference/benchmarks.md
+```
+
+If the working tree has uncommitted changes, the commit line is marked
+`(dirty — uncommitted changes present)` — a signal that the result does not
+correspond to any published commit and should not be quoted as a release number.
+
+**When publishing a benchmark result, always include this header.** A throughput
+figure without its machine, commit, and settings is not reproducible and should
+be treated as anecdote, not measurement.
+
+## What the suite measures
+
+The upload benchmarks live in `pkg/benchmarks/scenarios/`:
+
+| Benchmark | File sizes | Focus |
+|---|---|---|
+| `BenchmarkSmallFileUpload` | 1–10 MB | Request overhead and latency (single-part) |
+| `BenchmarkMediumFileUpload` | 10–100 MB | Multipart efficiency at low concurrency |
+| `BenchmarkLargeFileUpload` | 100 MB–1 GB | Throughput at high concurrency |
+| `BenchmarkXLFileUpload` | > 1 GB | Sustained multipart throughput |
+| `BenchmarkMemoryEfficiency` | — | Bounded memory under streaming |
+| `BenchmarkConcurrencyScaling` | — | Throughput vs. worker count |
+| `BenchmarkChunkSizeImpact` | — | Throughput vs. chunk size |
+
+Each is run with `-benchmem`, so the report includes allocations and bytes per
+operation alongside wall-clock time — memory behavior is a first-class result, not
+an afterthought.
+
+## Comparing runs and detecting regressions
+
+Because runs use `-count`, results are compatible with
+[`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat):
+
+```bash
+# Save a baseline, make a change, then compare
+scripts/run-benchmarks.sh --long   # → benchmark-reports/benchmark-<A>.txt
+# ... make your change ...
+scripts/run-benchmarks.sh --long   # → benchmark-reports/benchmark-<B>.txt
+
+benchstat benchmark-reports/benchmark-<A>.txt benchmark-reports/benchmark-<B>.txt
+```
+
+`benchstat` reports the mean, variation, and whether the delta is statistically
+significant — the right way to judge a change rather than eyeballing two raw
+numbers. Compare only runs whose provenance headers show the **same machine, Go
+version, and settings**; a faster laptop is not a faster CargoShip.
+
+## Reading a result honestly
+
+- **Local S3 emulator vs. real S3.** The default suite exercises the upload code
+  path; it is not a measurement of your network throughput to AWS. For real-world
+  numbers, run against a real bucket in your target region with credentials
+  configured, and note the region in the report.
+- **Warm vs. cold.** The first iteration pays setup costs (connection pools, TLS
+  handshakes). `-count` and `benchstat` smooth this out; a single run does not.
+- **File mix matters.** Compression ratio and per-file overhead depend entirely on
+  content. A tree of already-compressed media behaves nothing like a tree of
+  source code or CSV. Benchmark with a sample that resembles your real data.
+
+## See also
+
+- [Performance tuning](/guides/features/optimization) — the throughput knobs
+  (concurrency, chunk size, sharding) these benchmarks exercise
+- [CargoShip vs. other tools](/reference/comparison) — when CargoShip is and isn't
+  the right choice
+- [Sharding](/guides/features/sharding) — how multi-prefix parallelism affects
+  request-rate ceilings

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -113,6 +113,63 @@ print_config() {
     echo "  Trace:          ${ENABLE_TRACE}"
 }
 
+write_provenance() {
+    print_header "Recording Provenance"
+
+    # Every published benchmark number must be reproducible: capture exactly what
+    # machine, code, and settings produced it. This header is prepended to the
+    # report so results are never quoted without their environment.
+    local git_commit git_dirty go_version os arch cpu_model cpu_cores mem_total
+
+    git_commit=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+        git_dirty=" (dirty — uncommitted changes present)"
+    else
+        git_dirty=""
+    fi
+    go_version=$(go version 2>/dev/null | awk '{print $3}')
+    os=$(uname -s)
+    arch=$(uname -m)
+
+    case "$os" in
+        Darwin)
+            cpu_model=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "unknown")
+            cpu_cores=$(sysctl -n hw.ncpu 2>/dev/null || echo "unknown")
+            mem_total="$(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1024 / 1024 )) MB"
+            ;;
+        Linux)
+            cpu_model=$(grep -m1 "model name" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | sed 's/^ *//' || echo "unknown")
+            cpu_cores=$(nproc 2>/dev/null || echo "unknown")
+            mem_total="$(( $(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || echo 0) / 1024 )) MB"
+            ;;
+        *)
+            cpu_model="unknown"; cpu_cores="unknown"; mem_total="unknown"
+            ;;
+    esac
+
+    # Prepend the provenance block to the report file.
+    {
+        echo "# CargoShip benchmark report"
+        echo "#"
+        echo "# Generated:      ${TIMESTAMP}"
+        echo "# Git commit:     ${git_commit}${git_dirty}"
+        echo "# Go version:     ${go_version}"
+        echo "# OS / arch:      ${os} / ${arch}"
+        echo "# CPU:            ${cpu_model} (${cpu_cores} cores)"
+        echo "# Memory:         ${mem_total}"
+        echo "# Bench time:     ${BENCH_TIME} × ${BENCH_COUNT} iterations"
+        echo "# Benchmark dir:  ${BENCHMARK_DIR}"
+        echo "#"
+        echo "# Reproduce:      BENCH_TIME=${BENCH_TIME} BENCH_COUNT=${BENCH_COUNT} scripts/run-benchmarks.sh"
+        echo "# Methodology:    docs/reference/benchmarks.md"
+        echo ""
+    } > "${REPORT_FILE}"
+
+    log_success "Provenance recorded to ${REPORT_FILE}"
+    log_info "Commit ${git_commit}${git_dirty}"
+    log_info "${os}/${arch}, ${cpu_cores} cores, ${mem_total}"
+}
+
 run_benchmarks() {
     print_header "Running Benchmarks"
 
@@ -135,8 +192,9 @@ run_benchmarks() {
     log_info "Running: go test ${BENCH_FLAGS} ${BENCHMARK_DIR}"
     echo ""
 
-    # Run benchmarks and capture output
-    if go test ${BENCH_FLAGS} ${BENCHMARK_DIR} 2>&1 | tee "${REPORT_FILE}"; then
+    # Run benchmarks and append to the report (the provenance header was already
+    # written by write_provenance).
+    if go test ${BENCH_FLAGS} ${BENCHMARK_DIR} 2>&1 | tee -a "${REPORT_FILE}"; then
         log_success "Benchmarks completed successfully"
     else
         log_error "Benchmarks failed"
@@ -270,6 +328,7 @@ main() {
     check_requirements
     setup_directories
     print_config
+    write_provenance
     run_benchmarks
     analyze_profiles
     compare_baseline


### PR DESCRIPTION
Builds the framework for publishing benchmark numbers that are reproducible —
without inventing any figures. (Real measurements can be dropped into the
methodology page later, each carrying its provenance header.)

## What changed

- **`scripts/run-benchmarks.sh`** — prepends a provenance header to every report:
  git commit (+ a `dirty` flag when the tree has uncommitted changes), Go version,
  OS/arch, CPU model & cores, total memory, bench time × iteration count, and the
  exact command to reproduce. A dirty tree is flagged so a number that doesn't
  correspond to a published commit can't be quoted as a release figure.
- **`docs/reference/benchmarks.md`** (new) — methodology page: how to run the
  suite, what each scenario in `pkg/benchmarks/scenarios/` measures, how to compare
  runs with `benchstat`, and how to read a result honestly (emulator vs. real S3,
  warm vs. cold, file-mix sensitivity). **Deliberately publishes no headline
  throughput number** — it tells you how to measure it on your own hardware.
- Wired into the reference sidebar and linked from the README.

## Verification

- `npm run build` in `docs/` passes with no dead links.
- `bash -n scripts/run-benchmarks.sh` clean; provenance capture smoke-tested on
  macOS/arm64 (correct commit, dirty flag, CPU, cores, memory).
- Only pre-existing shellcheck style/info warnings remain; none in the added code.

Part of the docs-quality follow-ups from the recent project review.