### PR TITLE
docs: versioned docs — latest (root) + dev (/dev) trees with switcher

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,11 +3,14 @@ name: Deploy Documentation
 on:
   push:
     branches:
+      # Rebuilds the dev (/dev) tree, which must track main. No paths filter: a
+      # commit that changes cmd/cargoship (the generated CLI reference) or the
+      # workflow itself must also rebuild, and per-ref-type path filters aren't
+      # expressible here.
       - main
-    paths:
-      - 'docs/**'
-      - 'cmd/cargoship/**'
-      - '.github/workflows/docs.yml'
+    # A new release tag ships a new "latest": rebuild so the root tree tracks it.
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 permissions:
@@ -26,6 +29,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Need tags + history to resolve the newest release that ships the site.
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -39,9 +45,31 @@ jobs:
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
+      # Resolve which ref backs the "latest" (root) tree: the newest release tag
+      # whose tree contains the VitePress site. The docs site shipped after the
+      # most recent release tag, so until a release includes it this resolves to
+      # main — root and /dev then track main identically, and the split activates
+      # automatically at the next release. main is always the /dev tree.
+      - name: Resolve latest docs ref
+        id: refs
+        run: |
+          latest_ref="main"
+          for tag in $(git tag -l 'v*' --sort=-v:refname); do
+            if git cat-file -e "${tag}:docs/.vitepress/config.mts" 2>/dev/null; then
+              latest_ref="$tag"
+              break
+            fi
+          done
+          echo "latest_ref=${latest_ref}" >> "$GITHUB_OUTPUT"
+          echo "Latest (root) tree builds from: ${latest_ref}"
+
+      # --- latest (root) tree -------------------------------------------------
+      - name: Check out latest docs ref
+        run: git checkout --detach "${{ steps.refs.outputs.latest_ref }}"
+
       # Regenerate the vendored CLI reference from the live cobra tree and fail
       # if it drifts from what's committed. Keeps docs/gen/cli/ authoritative.
-      - name: Check CLI reference is in sync
+      - name: Check CLI reference is in sync (latest)
         run: |
           ./docs/scripts/gen-cli.sh
           if ! git diff --quiet -- docs/gen/cli; then
@@ -50,13 +78,48 @@ jobs:
             exit 1
           fi
 
-      - name: Install dependencies
+      - name: Reinstall deps for latest ref
         working-directory: docs
         run: npm ci
 
-      - name: Build docs (VitePress)
+      - name: Build docs — latest (root)
         working-directory: docs
+        env:
+          DOCS_BASE: /
+          DOCS_VERSION_LABEL: latest
         run: npm run build
+
+      - name: Stage latest tree
+        run: |
+          mkdir -p site
+          cp -r docs/.vitepress/dist/. site/
+
+      # --- dev tree (main) ----------------------------------------------------
+      # The dev tree always tracks main's tip, even when this run was triggered
+      # by a tag push (where GITHUB_SHA is the tagged commit, not necessarily
+      # main). Fetch and check out origin/main explicitly.
+      - name: Check out main for dev tree
+        run: |
+          git fetch --depth=1 origin main
+          git checkout --detach FETCH_HEAD
+
+      - name: Reinstall deps for main
+        working-directory: docs
+        run: npm ci
+
+      - name: Build docs — dev (main)
+        working-directory: docs
+        env:
+          DOCS_BASE: /dev/
+          DOCS_VERSION_LABEL: dev
+        run: npm run build
+
+      - name: Stage dev tree under /dev
+        run: |
+          mkdir -p site/dev
+          cp -r docs/.vitepress/dist/. site/dev/
+          # One CNAME at the root serves both trees; drop the nested copy.
+          rm -f site/dev/CNAME
 
       - name: Configure Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
@@ -64,7 +127,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
-          path: docs/.vitepress/dist
+          path: site
 
   deploy:
     environment:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,6 +4,17 @@ import path from 'node:path'
 
 const SITE_URL = 'https://cargoship.app'
 
+// Versioned docs (task #37). The site deploys two trees from one config:
+//   /      → "latest": docs from the newest release tag that contains the site
+//            (falls back to main until a release ships the site)
+//   /dev/  → "dev": docs built from main (unreleased)
+// The deploy workflow sets DOCS_BASE ('/' or '/dev/') and DOCS_VERSION_LABEL
+// per build. The version switcher (below) uses absolute SITE_URL links so it
+// navigates between trees regardless of the active base.
+const DOCS_BASE = process.env.DOCS_BASE || '/'
+const DOCS_VERSION_LABEL = process.env.DOCS_VERSION_LABEL || 'latest'
+const IS_DEV_TREE = DOCS_BASE === '/dev/'
+
 // One global sidebar (keyed on '/') applied to every page, so the whole site
 // reads as a single progressive-disclosure path: Introduction → Get Started →
 // Tutorials → Core Workflows → Cost & Budget → Features → DVC → Configuration →
@@ -205,9 +216,14 @@ export default defineConfig({
   cleanUrls: true,
   lastUpdated: true,
 
+  // Set per deploy: '/' for the latest tree, '/dev/' for the unreleased tree.
+  base: DOCS_BASE,
+
   // Emit sitemap.xml for search + AI indexers (VitePress only generates it when
-  // a hostname is set).
-  sitemap: {
+  // a hostname is set). Only the latest (root) tree is indexed; the dev tree is
+  // excluded from the sitemap and marked noindex (see head, below) so search
+  // engines don't surface unreleased docs as canonical.
+  sitemap: IS_DEV_TREE ? undefined : {
     hostname: SITE_URL,
   },
 
@@ -230,6 +246,9 @@ export default defineConfig({
     ['meta', { property: 'og:image', content: SITE_URL + '/og-cover.png' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
     ['meta', { name: 'twitter:image', content: SITE_URL + '/og-cover.png' }],
+    // The dev tree (built from main) must not be indexed as canonical — the
+    // latest release docs at the root are authoritative.
+    ...(IS_DEV_TREE ? [['meta', { name: 'robots', content: 'noindex' }] as const] : []),
   ],
 
   themeConfig: {
@@ -242,6 +261,15 @@ export default defineConfig({
       { text: 'Guides', link: '/guides/uploading' },
       { text: 'Reference', link: '/reference/' },
       { text: 'Format Spec', link: '/reference/format/' },
+      // Version switcher. Absolute links so it crosses between the latest (root)
+      // and dev trees regardless of which base this build was rendered with.
+      {
+        text: DOCS_VERSION_LABEL,
+        items: [
+          { text: 'latest (released)', link: SITE_URL + '/' },
+          { text: 'dev (main)', link: SITE_URL + '/dev/' },
+        ],
+      },
       {
         text: 'Get help',
         items: [


### PR DESCRIPTION
Adds release-versioned docs to cargoship.app without breaking a single existing
URL. Closes the last of the three post-review follow-ups.

## Structure (chosen: root = latest, /dev added)

- **`/` (root) → "latest"** — built from the newest release tag whose tree
  contains the VitePress site. Every current `cargoship.app/reference/...` link
  keeps working.
- **`/dev/` → "dev"** — built from `main` (unreleased). `noindex` + excluded from
  the sitemap so it's never surfaced as canonical.
- A **version switcher** in the nav (absolute links) crosses between the two trees
  from either base.

## Bootstrap note (important)

The VitePress site (PR #216, 2026-07-21) landed **after** the latest release tag
**v0.13.2** (2026-07-07), so **no released tag contains the docs site yet**. The
deploy resolves "latest" to the newest tag that *has* the site and falls back to
`main` when none does — so today root and `/dev` both track `main` identically.
The split activates **automatically** at the next release (v0.13.3+), which will
be the first tag to ship the site. No manual step needed.

## Changes

- **`docs/.vitepress/config.mts`** — reads `DOCS_BASE` + `DOCS_VERSION_LABEL`
  (set per build) to switch `base`, the switcher label, and noindex/sitemap
  behavior for the dev tree.
- **`.github/workflows/docs.yml`** — builds both trees, stages latest at the
  artifact root and dev under `/dev`, keeps a single root CNAME + sitemap, and
  rebuilds on every `main` push and every `v*` tag. The dev tree always tracks
  `main`'s tip, even on a tag-triggered run.

## Verification (local)

- Both trees `npm run build` clean — no dead links.
- Dev tree: `/dev/` base on all assets, `robots: noindex` present, no sitemap.
- Root tree: `/` base, sitemap present, no noindex, CNAME in dist.
- Simulated the combined artifact: correct `root` + `/dev` layout, one CNAME, one
  (root) sitemap.