### PR TITLE
fix: record first packet send time in BBR prober; deterministic test

### DIFF
--- a/pkg/aws/s3/bbr_bandwidth_probing.go
+++ b/pkg/aws/s3/bbr_bandwidth_probing.go
@@ -272,7 +272,9 @@ func NewBBRBandwidthProber(ctx context.Context, config *BBRConfig) *BBRBandwidth
 		appLimited:     false,
 		deliveredBytes: 0,
 		deliveredTime:  time.Now(),
-		firstSentTime:  time.Now(),
+		// firstSentTime is intentionally left zero: OnPacketSent records the
+		// actual send time of the first packet (its IsZero guard depends on it).
+		// Pre-seeding it here would make that guard never fire.
 
 		// lossDetector:        NewBBRLossDetector(), // Reserved for future use
 		lossThreshold:        config.LossThreshold,

--- a/pkg/aws/s3/bbr_bandwidth_probing_test.go
+++ b/pkg/aws/s3/bbr_bandwidth_probing_test.go
@@ -90,14 +90,13 @@ func TestBBRPacketSentTracking(t *testing.T) {
 	// Test first packet sent
 	prober.OnPacketSent(packetSize, sendTime)
 
-	if prober.firstSentTime.IsZero() {
-		t.Error("Expected first sent time to be set")
-	}
-
-	// Allow for timing variance in the test (Issue #152: increased from 1ms to 10ms to fix flaky test)
-	// The exact timing isn't critical - we just verify firstSentTime is set approximately correctly
-	if prober.firstSentTime.Sub(sendTime).Abs() > 10*time.Millisecond {
-		t.Errorf("Expected first sent time to be close to %v, got %v (diff: %v)", sendTime, prober.firstSentTime, prober.firstSentTime.Sub(sendTime))
+	// OnPacketSent records the exact send time it was given, so assert equality
+	// rather than a wall-clock tolerance. (Previously this compared against a
+	// second time.Now() with a 10ms fudge, which flaked on loaded CI runners —
+	// and masked a bug where the constructor pre-seeded firstSentTime, so the
+	// real send time was never recorded.)
+	if !prober.firstSentTime.Equal(sendTime) {
+		t.Errorf("Expected first sent time to be %v, got %v", sendTime, prober.firstSentTime)
 	}
 
 	// Test app-limited tracking


### PR DESCRIPTION
The flaky `TestBBRPacketSentTracking` (seen blocking #231) turned out to be
masking a real bug.

## The bug

`NewBBRBandwidthProber` initialized `firstSentTime` to `time.Now()`. That made
the `if bbr.firstSentTime.IsZero()` guard in `OnPacketSent` **never** fire — so
the first packet's actual send time was never recorded; the field just held the
construction timestamp forever.

The test only passed because it compared that construction `time.Now()` against
another `time.Now()` taken a moment later, with a 10ms tolerance (already
loosened once in #152). On a loaded CI runner the gap exceeded 10ms and it
failed (13.8ms on the #231 run).

## The fix

- **`bbr_bandwidth_probing.go`** — leave `firstSentTime` zero at construction so
  `OnPacketSent` records the real send time, as the field name and guard intend.
  (`deliveredTime` is a genuine running timestamp and is left initialized.)
  `firstSentTime` is only read by that guard, so nothing else depends on the old
  pre-seeded value.
- **`bbr_bandwidth_probing_test.go`** — assert `firstSentTime.Equal(sendTime)`
  exactly instead of a wall-clock tolerance. `OnPacketSent` stores the passed-in
  time verbatim, so the comparison is now deterministic.

## Verification

- `go test ./pkg/aws/s3/ -run TestBBRPacketSentTracking -count=20` — passes every
  time (no tolerance, no flake).
- Full `./pkg/aws/s3/` suite green; `gofmt`/`go vet` clean.