### PR TITLE
fix: correct S3 PUT request fallback price ($0.0005 → $0.005 per 1k)

### DIFF
--- a/pkg/aws/cost/benchmark_test.go
+++ b/pkg/aws/cost/benchmark_test.go
@@ -49,17 +49,17 @@ func TestCalculateCompetitorCost(t *testing.T) {
 	assert.Equal(t, 0.0, comparison.DataTransferCost)
 
 	// PUT requests: 10000 files = 10000 requests
-	// Price: $0.0005 per 1000 requests * 10 = $0.005 total
-	assert.InDelta(t, 0.005, comparison.PUTRequestCost, 0.001)
+	// Price: $0.005 per 1000 requests * 10 = $0.05 total
+	assert.InDelta(t, 0.05, comparison.PUTRequestCost, 0.001)
 
 	// Storage: 100 GB * $0.023 per GB-month = $2.30/month
 	assert.InDelta(t, 2.30, comparison.StorageCostMonthly, 0.10)
 
 	// Upload cost = transfer + requests
-	assert.InDelta(t, 0.005, comparison.TotalUploadCost, 0.001)
+	assert.InDelta(t, 0.05, comparison.TotalUploadCost, 0.001)
 
 	// Annual TCO = upload + (12 * monthly storage)
-	expectedAnnualTCO := 0.005 + (2.30 * 12)
+	expectedAnnualTCO := 0.05 + (2.30 * 12)
 	assert.InDelta(t, expectedAnnualTCO, comparison.AnnualTCO, 0.50)
 }
 

--- a/pkg/aws/cost/pricing.go
+++ b/pkg/aws/cost/pricing.go
@@ -411,16 +411,16 @@ func (pm *PricingManager) getFallbackStoragePrice(storageClass config.StorageCla
 }
 
 func (pm *PricingManager) getFallbackRequestPrice(requestType string) float64 {
-	// Approximate AWS S3 request prices (USD per 1000 requests)
+	// Approximate AWS S3 request prices (USD per 1000 requests), STANDARD tier.
 	switch strings.ToUpper(requestType) {
 	case "PUT", "POST", "COPY", "LIST":
-		return 0.0005
+		return 0.005 // $0.005 per 1,000 PUT/COPY/POST/LIST requests
 	case "GET", "SELECT":
-		return 0.0004
+		return 0.0004 // $0.0004 per 1,000 GET/SELECT requests
 	case "DELETE":
 		return 0.0
 	default:
-		return 0.0005
+		return 0.005
 	}
 }
 


### PR DESCRIPTION
## The bug

`getFallbackRequestPrice` (pkg/aws/cost/pricing.go) returned **$0.0005** per
1,000 PUT/POST/COPY/LIST requests. Real AWS S3 STANDARD PUT pricing is
**$0.005** per 1,000 — the value is **10× too low**. The sibling
`pkg/aws/costs/calculator.go:232` already uses the correct `0.005`.

## Impact

Request costs were understated 10× everywhere the `cost` package prices PUTs —
`cargoship cost estimate` and `cargoship cost benchmark-compare`. Example (50 GB,
5,000,000 files, `--tool aws-cli`):

| | before (bug) | after (fixed) |
|---|---|---|
| `put_request_cost` | $2.50 | **$25.00** |
| `annual_tco` | $16.30 | **$38.80** |

$25 matches the hand check: 5,000,000 ÷ 1,000 × $0.005 = $25.00.

Because live AWS Pricing API queries are still a stub (`pricing.go:244` — the
`GetProducts` call is a TODO), **every** price currently comes from these
fallback constants, so this bug was always in effect regardless of the
`UseAWSPricingAPI` setting. GET/SELECT ($0.0004) was already correct; only
PUT/POST/COPY/LIST was wrong.

## Change

- `pricing.go` — PUT/POST/COPY/LIST fallback `0.0005 → 0.005`; default case too.
- `benchmark_test.go` — `TestCalculateCompetitorCost` now expects $0.05 for 10k
  files (was $0.005).

Follow-ups (separate PRs): implement the live `GetProducts` pricing query so
these fallbacks are only used on API error, and a tutorial quantifying the
small-files request-cost problem.