### PR TITLE
feat: query live AWS Price List API for S3 storage & request pricing

### DIFF
--- a/pkg/aws/cost/pricing.go
+++ b/pkg/aws/cost/pricing.go
@@ -17,7 +17,7 @@ import (
 // PricingManager handles cost calculations with AWS Pricing API integration
 type PricingManager struct {
 	config     *config.PricingConfig
-	pricingAPI *pricing.Client
+	pricingAPI pricingAPIClient
 	logger     *slog.Logger
 	cache      *PricingCache
 	mu         sync.RWMutex
@@ -240,16 +240,22 @@ func (pm *PricingManager) getRequestPrice(ctx context.Context, requestType strin
 		return price, nil
 	}
 
-	// Use AWS Pricing API or fallback
+	// Use AWS Pricing API if enabled, falling back to the static table on error.
 	if pm.config.UseAWSPricingAPI && pm.pricingAPI != nil {
-		// AWS Pricing API implementation would go here
-		// For now, use fallback prices
-		price = pm.getFallbackRequestPrice(requestType)
+		apiPrice, err := pm.getAWSRequestPrice(ctx, strings.ToUpper(requestType), region)
+		if err != nil {
+			pm.logger.Warn("Failed to get AWS request pricing, using fallback", "error", err)
+			price = pm.getFallbackRequestPrice(requestType)
+			pm.setCachedPrice(cacheKey, price, "fallback")
+		} else {
+			price = apiPrice
+			pm.setCachedPrice(cacheKey, price, "aws_api")
+		}
 	} else {
 		price = pm.getFallbackRequestPrice(requestType)
+		pm.setCachedPrice(cacheKey, price, "fallback")
 	}
 
-	pm.setCachedPrice(cacheKey, price, "fallback")
 	return price, nil
 }
 
@@ -383,10 +389,41 @@ func (pm *PricingManager) calculateEnterpriseDiscount(cost float64, service stri
 }
 
 // Helper methods for AWS Pricing API integration
+
+// getAWSStoragePrice queries the AWS Price List API for the per-GB-month storage
+// price of storageClass in region. Returns an error (so the caller falls back to
+// the static table) when the storage class has no Price List mapping or the
+// query yields no usable price.
 func (pm *PricingManager) getAWSStoragePrice(ctx context.Context, storageClass config.StorageClass, region string) (float64, error) {
-	// This would implement actual AWS Pricing API calls
-	// For now, return fallback prices
-	return pm.getFallbackStoragePrice(storageClass), nil
+	volumeType, ok := s3StorageVolumeType(storageClass)
+	if !ok {
+		return 0, fmt.Errorf("no Price List volumeType for storage class %q", storageClass)
+	}
+	return pm.queryAWSPrice(ctx, region, map[string]string{
+		"productFamily": "Storage",
+		"volumeType":    volumeType,
+	})
+}
+
+// getAWSRequestPrice queries the AWS Price List API for the per-request price of
+// requestType in region, returned as a price per 1,000 requests to match the
+// rest of the pricing code. Returns an error (caller falls back) when the
+// request type has no Price List mapping or the query yields no usable price.
+func (pm *PricingManager) getAWSRequestPrice(ctx context.Context, requestType, region string) (float64, error) {
+	group, ok := s3RequestGroup(requestType)
+	if !ok {
+		return 0, fmt.Errorf("no Price List group for request type %q", requestType)
+	}
+	// The API returns a per-request price; the rest of the code works in
+	// price-per-1,000-requests, so scale up.
+	perRequest, err := pm.queryAWSPrice(ctx, region, map[string]string{
+		"productFamily": "API Request",
+		"group":         group,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return perRequest * 1000, nil
 }
 
 // Fallback pricing methods

--- a/pkg/aws/cost/pricing_api.go
+++ b/pkg/aws/cost/pricing_api.go
@@ -1,0 +1,150 @@
+package cost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+	pricingtypes "github.com/aws/aws-sdk-go-v2/service/pricing/types"
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+)
+
+// pricingAPIClient is the subset of the AWS Pricing client used here, extracted
+// as an interface so queryAWSPrice can be unit-tested with a fake. *pricing.Client
+// satisfies it.
+type pricingAPIClient interface {
+	GetProducts(ctx context.Context, params *pricing.GetProductsInput, optFns ...func(*pricing.Options)) (*pricing.GetProductsOutput, error)
+}
+
+// priceListItem is the subset of an AWS Price List API product JSON document we
+// need to extract an on-demand USD price. The GetProducts response returns each
+// product as a JSON string in this shape (FormatVersion aws_v1).
+type priceListItem struct {
+	Product struct {
+		Attributes map[string]string `json:"attributes"`
+	} `json:"product"`
+	Terms struct {
+		OnDemand map[string]struct {
+			PriceDimensions map[string]struct {
+				BeginRange   string `json:"beginRange"`
+				Unit         string `json:"unit"`
+				PricePerUnit struct {
+					USD string `json:"USD"`
+				} `json:"pricePerUnit"`
+			} `json:"priceDimensions"`
+		} `json:"OnDemand"`
+	} `json:"terms"`
+}
+
+// s3StorageVolumeType maps a CargoShip storage class to the AWS Price List
+// `volumeType` attribute for the S3 Storage product family. Values verified
+// against the live Pricing API (us-east-1).
+func s3StorageVolumeType(storageClass config.StorageClass) (string, bool) {
+	switch storageClass {
+	case config.StorageClassStandard:
+		return "Standard", true
+	case config.StorageClassStandardIA:
+		return "Standard - Infrequent Access", true
+	case config.StorageClassOneZoneIA:
+		return "One Zone - Infrequent Access", true
+	case config.StorageClassIntelligentTiering:
+		return "Intelligent-Tiering Frequent Access", true
+	case config.StorageClassGlacier:
+		return "Glacier Instant Retrieval", true
+	case config.StorageClassDeepArchive:
+		return "Glacier Deep Archive", true
+	default:
+		return "", false
+	}
+}
+
+// s3RequestGroup maps a request type to the AWS Price List `group` attribute for
+// the S3 "API Request" product family. PUT/COPY/POST/LIST are Tier1; GET/SELECT
+// and others are Tier2. Verified against the live Pricing API.
+func s3RequestGroup(requestType string) (string, bool) {
+	switch requestType {
+	case "PUT", "POST", "COPY", "LIST":
+		return "S3-API-Tier1", true
+	case "GET", "SELECT":
+		return "S3-API-Tier2", true
+	default:
+		return "", false
+	}
+}
+
+// queryAWSPrice runs a GetProducts query with the given S3 attribute filters and
+// returns the lowest first-tier on-demand USD price found (per the product's
+// unit — GB-Mo for storage, per-request for requests). It returns an error when
+// the API call fails or no usable price is found, so callers fall back to the
+// static price table.
+func (pm *PricingManager) queryAWSPrice(ctx context.Context, region string, filters map[string]string) (float64, error) {
+	apiFilters := make([]pricingtypes.Filter, 0, len(filters)+1)
+	apiFilters = append(apiFilters, pricingtypes.Filter{
+		Type:  pricingtypes.FilterTypeTermMatch,
+		Field: aws.String("regionCode"),
+		Value: aws.String(region),
+	})
+	// Deterministic filter order keeps the cache key and requests stable.
+	keys := make([]string, 0, len(filters))
+	for k := range filters {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		apiFilters = append(apiFilters, pricingtypes.Filter{
+			Type:  pricingtypes.FilterTypeTermMatch,
+			Field: aws.String(k),
+			Value: aws.String(filters[k]),
+		})
+	}
+
+	out, err := pm.pricingAPI.GetProducts(ctx, &pricing.GetProductsInput{
+		ServiceCode:   aws.String("AmazonS3"),
+		FormatVersion: aws.String("aws_v1"),
+		Filters:       apiFilters,
+		MaxResults:    aws.Int32(100),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("pricing GetProducts: %w", err)
+	}
+
+	best := -1.0
+	for _, raw := range out.PriceList {
+		var item priceListItem
+		if err := json.Unmarshal([]byte(raw), &item); err != nil {
+			continue // skip malformed entries rather than failing the whole query
+		}
+		for _, term := range item.Terms.OnDemand {
+			// Pick the first pricing band (lowest beginRange) for this product.
+			type dim struct {
+				begin float64
+				usd   string
+			}
+			var dims []dim
+			for _, pd := range term.PriceDimensions {
+				begin, _ := strconv.ParseFloat(pd.BeginRange, 64)
+				dims = append(dims, dim{begin: begin, usd: pd.PricePerUnit.USD})
+			}
+			if len(dims) == 0 {
+				continue
+			}
+			sort.Slice(dims, func(i, j int) bool { return dims[i].begin < dims[j].begin })
+			price, err := strconv.ParseFloat(dims[0].usd, 64)
+			if err != nil || price <= 0 {
+				continue
+			}
+			if best < 0 || price < best {
+				best = price
+			}
+		}
+	}
+
+	if best < 0 {
+		return 0, fmt.Errorf("no usable price in %d products", len(out.PriceList))
+	}
+	return best, nil
+}

--- a/pkg/aws/cost/pricing_api_test.go
+++ b/pkg/aws/cost/pricing_api_test.go
@@ -1,0 +1,177 @@
+package cost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePricingClient is a pricingAPIClient that returns canned Price List
+// products (or an error) without touching AWS.
+type fakePricingClient struct {
+	products []string
+	err      error
+}
+
+func (f *fakePricingClient) GetProducts(_ context.Context, _ *pricing.GetProductsInput, _ ...func(*pricing.Options)) (*pricing.GetProductsOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &pricing.GetProductsOutput{PriceList: f.products}, nil
+}
+
+// newTestPricingManager builds a PricingManager wired to a fake pricing client
+// with the API enabled.
+func newTestPricingManager(t *testing.T, client pricingAPIClient) *PricingManager {
+	t.Helper()
+	pm, err := NewPricingManager(&config.PricingConfig{
+		UseAWSPricingAPI:     true,
+		Currency:             "USD",
+		PricingCacheDuration: "24h",
+	}, aws.Config{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	pm.pricingAPI = client
+	return pm
+}
+
+func storageProduct(volumeType, usd string) string {
+	return fmt.Sprintf(`{"product":{"attributes":{"volumeType":%q,"regionCode":"us-east-1"}},`+
+		`"terms":{"OnDemand":{"K.T":{"priceDimensions":{"K.T.D":{"beginRange":"0","unit":"GB-Mo","pricePerUnit":{"USD":%q}}}}}}}`,
+		volumeType, usd)
+}
+
+func requestProduct(group, usdPerRequest string) string {
+	return fmt.Sprintf(`{"product":{"attributes":{"group":%q,"regionCode":"us-east-1"}},`+
+		`"terms":{"OnDemand":{"K.T":{"priceDimensions":{"K.T.D":{"beginRange":"0","unit":"Requests","pricePerUnit":{"USD":%q}}}}}}}`,
+		group, usdPerRequest)
+}
+
+func TestGetAWSStoragePrice_FromAPI(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{
+		products: []string{storageProduct("Standard", "0.0230000000")},
+	})
+	price, err := pm.getAWSStoragePrice(context.Background(), config.StorageClassStandard, "us-east-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.023, price, 1e-9)
+}
+
+func TestGetAWSStoragePrice_UnmappedClass(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{})
+	_, err := pm.getAWSStoragePrice(context.Background(), config.StorageClass("BOGUS"), "us-east-1")
+	assert.Error(t, err)
+}
+
+func TestGetAWSRequestPrice_ScalesToPerThousand(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{
+		products: []string{requestProduct("S3-API-Tier1", "0.0000050000")},
+	})
+	// $0.000005 per request → $0.005 per 1,000.
+	price, err := pm.getAWSRequestPrice(context.Background(), "PUT", "us-east-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.005, price, 1e-9)
+}
+
+func TestGetAWSRequestPrice_UnmappedType(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{})
+	_, err := pm.getAWSRequestPrice(context.Background(), "DELETE", "us-east-1")
+	assert.Error(t, err)
+}
+
+func TestQueryAWSPrice_NoUsablePrice(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{products: []string{`{"bogus":true}`}})
+	_, err := pm.queryAWSPrice(context.Background(), "us-east-1", map[string]string{"productFamily": "Storage"})
+	assert.Error(t, err)
+}
+
+func TestQueryAWSPrice_APIError(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{err: fmt.Errorf("boom")})
+	_, err := pm.queryAWSPrice(context.Background(), "us-east-1", map[string]string{"productFamily": "Storage"})
+	assert.Error(t, err)
+}
+
+// TestGetRequestPrice_FallsBackOnAPIError confirms getRequestPrice returns the
+// static fallback (not an error) when the API call fails, so cost estimation
+// keeps working offline.
+func TestGetRequestPrice_FallsBackOnAPIError(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{err: fmt.Errorf("no network")})
+	price, err := pm.getRequestPrice(context.Background(), "PUT", config.StorageClassStandard, "us-east-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.005, price, 1e-9) // corrected fallback
+}
+
+func TestGetRequestPrice_UsesAPIWhenAvailable(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{
+		products: []string{requestProduct("S3-API-Tier2", "0.0000004000")},
+	})
+	price, err := pm.getRequestPrice(context.Background(), "GET", config.StorageClassStandard, "eu-west-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.0004, price, 1e-9)
+}
+
+func TestS3StorageVolumeType(t *testing.T) {
+	cases := map[config.StorageClass]string{
+		config.StorageClassStandard:           "Standard",
+		config.StorageClassStandardIA:         "Standard - Infrequent Access",
+		config.StorageClassOneZoneIA:          "One Zone - Infrequent Access",
+		config.StorageClassIntelligentTiering: "Intelligent-Tiering Frequent Access",
+		config.StorageClassGlacier:            "Glacier Instant Retrieval",
+		config.StorageClassDeepArchive:        "Glacier Deep Archive",
+	}
+	for sc, want := range cases {
+		got, ok := s3StorageVolumeType(sc)
+		assert.True(t, ok, "storage class %q should map", sc)
+		assert.Equal(t, want, got, "storage class %q", sc)
+	}
+
+	_, ok := s3StorageVolumeType(config.StorageClass("BOGUS"))
+	assert.False(t, ok, "unknown storage class must not map")
+}
+
+func TestS3RequestGroup(t *testing.T) {
+	tier1 := []string{"PUT", "POST", "COPY", "LIST"}
+	for _, rt := range tier1 {
+		got, ok := s3RequestGroup(rt)
+		assert.True(t, ok, "%s should map", rt)
+		assert.Equal(t, "S3-API-Tier1", got, "%s", rt)
+	}
+	tier2 := []string{"GET", "SELECT"}
+	for _, rt := range tier2 {
+		got, ok := s3RequestGroup(rt)
+		assert.True(t, ok, "%s should map", rt)
+		assert.Equal(t, "S3-API-Tier2", got, "%s", rt)
+	}
+	_, ok := s3RequestGroup("DELETE")
+	assert.False(t, ok, "DELETE has no Tier group (free)")
+}
+
+// TestPriceListItem_Parse verifies the Price List product JSON is parsed the way
+// the AWS Pricing API actually returns it (shape confirmed against the live API).
+func TestPriceListItem_Parse(t *testing.T) {
+	// Trimmed real-world Standard storage product (us-east-1), with two pricing
+	// bands to confirm we can read the first-band ($0.023/GB-Mo) price.
+	raw := `{
+      "product": {"attributes": {"volumeType": "Standard", "regionCode": "us-east-1"}},
+      "terms": {"OnDemand": {"ABC.JRTCKXETXF": {"priceDimensions": {
+        "ABC.JRTCKXETXF.D1": {"beginRange": "0", "unit": "GB-Mo", "pricePerUnit": {"USD": "0.0230000000"}},
+        "ABC.JRTCKXETXF.D2": {"beginRange": "512000", "unit": "GB-Mo", "pricePerUnit": {"USD": "0.0220000000"}}
+      }}}}
+    }`
+
+	var item priceListItem
+	require.NoError(t, json.Unmarshal([]byte(raw), &item))
+	assert.Equal(t, "Standard", item.Product.Attributes["volumeType"])
+
+	term, ok := item.Terms.OnDemand["ABC.JRTCKXETXF"]
+	require.True(t, ok)
+	require.Len(t, term.PriceDimensions, 2)
+	assert.Equal(t, "0.0230000000", term.PriceDimensions["ABC.JRTCKXETXF.D1"].PricePerUnit.USD)
+}


### PR DESCRIPTION
Finishes the AWS Pricing API integration that was scaffolded but never
implemented, so `cargoship cost estimate` / `cost benchmark-compare` use
**real, current, region-specific** S3 prices instead of hardcoded constants.

## Background

`NewPricingManager` built a `pricing.Client` whenever `UseAWSPricingAPI` was set
(it defaults to `true`), but:
- `getAWSStoragePrice` just returned the static fallback (`// implementation
  would go here`), and
- `getRequestPrice` never called the API at all.

So every price came from the hardcoded table regardless of configuration — which
is also how the 10× PUT bug (#233) went unnoticed for so long.

## What this does

New `pkg/aws/cost/pricing_api.go`:
- **`queryAWSPrice`** — issues a `GetProducts` call for `AmazonS3` with a
  `regionCode` filter plus product-attribute filters, parses the `aws_v1` Price
  List JSON, and returns the lowest first-band on-demand USD price.
- **`getAWSStoragePrice`** — maps each storage class to its Price List
  `volumeType` and queries the `Storage` family (per GB-Mo).
- **`getAWSRequestPrice`** — maps request types to the `API Request` `group`
  (`PUT/COPY/POST/LIST → S3-API-Tier1`, `GET/SELECT → S3-API-Tier2`) and returns
  price per 1,000 requests.
- **`getRequestPrice`** now calls the API when enabled and **falls back to the
  static table on any error** (unmapped type, API failure, no usable price),
  tagging cache entries `aws_api` vs `fallback`.

`pricingAPI` became a small `pricingAPIClient` interface (`GetProducts`) so the
query path is unit-testable with a fake; `*pricing.Client` still satisfies it.
Prices are cached for the configured duration (default 24h).

## Verification

**Live** (against the real AWS Pricing API, with credentials):

| query | result |
|---|---|
| STANDARD storage, us-east-1 | $0.02300 / GB-mo ✓ |
| PUT, us-east-1 | $0.00500 / 1k ✓ |
| GET, us-west-2 | $0.00040 / 1k ✓ |

Region-specific prices resolve correctly; unmapped/edge cases (e.g. DEEP_ARCHIVE
where some regions return only a staging product) fall back cleanly to the
static table.

**Offline unit tests** (fake `GetProducts` client) cover the API path, per-1k
scaling, unmapped request/storage types, no-usable-price, and the API-error
fallback. Package coverage 72.8%.

## Note (follow-up, not this PR)

There are two parallel pricing stacks: `pkg/aws/cost` (this PR;
backs `cost …` commands) and `pkg/aws/pricing` + `pkg/aws/costs` (backs
`estimate --real-time-pricing`, already had a live `GetProducts` impl). Worth
consolidating later; out of scope here.