### PR TITLE
docs: tutorial — millions of small files & the S3 request-cost problem

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -51,6 +51,7 @@ const sidebar = {
       collapsed: false,
       items: [
         { text: 'Overview', link: '/tutorials/' },
+        { text: 'Millions of small files', link: '/tutorials/small-files' },
         { text: 'Genomics / sequencing data', link: '/tutorials/genomics' },
         { text: 'Imaging / microscopy data', link: '/tutorials/imaging' },
         { text: 'ML datasets with DVC', link: '/tutorials/ml-dvc' },

--- a/docs/reference/comparison.md
+++ b/docs/reference/comparison.md
@@ -24,7 +24,9 @@ simpler one is.
 **`aws s3 cp` / `aws s3 sync`** — the right choice for a handful of files, or when
 you want each file to remain an individually-addressable S3 object. Simple,
 ubiquitous, no packing. Downsides at scale: one PUT per file (request cost and
-throughput), no compression, no cost preview.
+throughput), no compression, no cost preview. For a worked example of what "one
+PUT per file" costs at millions of files, see
+[Millions of small files](/tutorials/small-files).
 
 **`rclone`** — excellent general-purpose sync across many cloud backends, with
 filtering and bandwidth control. Reach for it for ongoing folder sync or

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -9,6 +9,7 @@ dataset sizes, storage-class choices, and cost trade-offs.
 
 | If you… | Start here |
 |---------|-----------|
+| Archive millions of tiny files without a huge S3 request bill | [Millions of small files](/tutorials/small-files) |
 | Move large sequencing files (FASTQ / BAM / VCF) off an HPC cluster | [Genomics / sequencing data](/tutorials/genomics) |
 | Archive microscopy stacks and screening images without losing pixels | [Imaging / microscopy data](/tutorials/imaging) |
 | Version ML datasets and push them through DVC | [ML datasets with DVC](/tutorials/ml-dvc) |

--- a/docs/tutorials/small-files.md
+++ b/docs/tutorials/small-files.md
@@ -1,0 +1,184 @@
+# Millions of small files: the request-cost problem
+
+**You are:** archiving a huge tree of tiny files — ML training shards, per-read
+genomics output, sensor readings, JSON records, web-scrape results. Individually
+they're bytes to kilobytes; together there are hundreds of thousands or millions
+of them. A naive `aws s3 cp --recursive` or `aws s3 sync` "works," but the bill
+and the wall-clock time are both dominated by something that has nothing to do
+with how much data you have.
+
+This tutorial explains **why** that happens, shows the cost difference with real
+`cargoship` output, and walks a runnable demo you can try in a minute.
+
+## The problem isn't your bytes — it's your requests
+
+S3 charges for **PUT requests**, not just storage. Every individual object you
+upload is one PUT. At the STANDARD price of **$0.005 per 1,000 PUT requests**,
+the request charge scales with your *file count*, independent of file size:
+
+```
+     1,000,000 files ÷ 1,000 × $0.005  =  $5.00
+     5,000,000 files ÷ 1,000 × $0.005  = $25.00
+    50,000,000 files ÷ 1,000 × $0.005  = $250.00
+```
+
+That's **just the upload requests** — before a byte of storage. Fifty million
+100-byte files hold ~5 GB of data (a few cents/month to store) but cost **$250
+to upload** naively. The data is trivial; the request count is the bill.
+
+Throughput suffers for the same reason: a naive tool issues one round-trip PUT
+per file. Millions of sequential small requests spend almost all their time in
+per-request overhead, not moving data.
+
+::: info Why CargoShip helps
+CargoShip **packs many files into a few compressed chunk objects** before
+uploading. A million files become a few hundred `tar.zst` chunks — so you pay a
+few hundred PUTs instead of a million, stream them with high concurrency, and
+compress on the way. Selective restore still pulls a single file back out of its
+chunk. See [How it works](/intro/how-it-works) and
+[Sharding](/guides/features/sharding).
+:::
+
+## The numbers: naive vs CargoShip
+
+CargoShip can compute this for you with `cargoship cost benchmark-compare` — no
+upload, no AWS calls required. Take **5,000,000 files totalling 50 GB**.
+
+**Naive per-file upload** (`aws s3 cp`, `aws s3 sync`, `rclone`, `s5cmd` — all
+one PUT per file):
+
+```bash
+cargoship cost benchmark-compare --tool aws-cli --size-gb 50 --files 5000000
+```
+
+```json
+{
+  "tool": "aws-cli",
+  "put_request_cost": 25,
+  "storage_cost_monthly": 1.15,
+  "total_upload_cost": 25,
+  "annual_tco": 38.8,
+  "currency": "USD"
+}
+```
+
+`put_request_cost` is **$25.00** — exactly the `5,000,000 ÷ 1,000 × $0.005`
+from above. That's the one-time cost of the upload's requests alone.
+
+**CargoShip** (same data, packed into chunks, 3:1 compression):
+
+```bash
+cargoship cost benchmark-compare --tool cargoship --size-gb 50 --files 5000000 \
+  --compression-ratio 3.0
+```
+
+```json
+{
+  "tool": "cargoship",
+  "put_request_cost": 0.00085,
+  "annual_tco": 4.60,
+  "cargoship_advantages": {
+    "request_reduction": 4999830,
+    "savings_percentage": 88.1,
+    "competitor_comparison_cost": 38.8
+  }
+}
+```
+
+CargoShip packs the 5,000,000 files into ~170 chunk objects, so the PUT cost
+collapses from **$25.00 to under a tenth of a cent** — `request_reduction` of
+**4,999,830** fewer requests. Combined with compression on the stored bytes, the
+**first-year total cost drops ~88%** (`$38.80 → $4.60`).
+
+| | Naive (`aws s3 cp`) | CargoShip |
+|---|---|---|
+| Objects PUT | 5,000,000 | ~170 |
+| Upload request cost | **$25.00** | **$0.0009** |
+| First-year total (TCO) | $38.80 | $4.60 |
+
+::: tip These are your prices, not ours
+`benchmark-compare` uses the same pricing engine as `cargoship estimate`. With
+AWS credentials configured it can pull **live, region-specific** rates; otherwise
+it uses current published STANDARD pricing. Nothing here is a marketing number —
+re-run the commands above and you'll get the same result. See
+[Benchmarks & methodology](/reference/benchmarks).
+:::
+
+## Try it: a 10,000-file demo
+
+Generate a tree of tiny files and let CargoShip show the comparison on **your**
+data. This touches no S3 and costs nothing.
+
+```bash
+# 10,000 tiny JSON records across 10 subdirectories
+mkdir -p /tmp/smallfiles-demo
+python3 - <<'PY'
+import os
+for i in range(10000):
+    d = f"/tmp/smallfiles-demo/shard{i//1000:02d}"
+    os.makedirs(d, exist_ok=True)
+    with open(f"{d}/rec{i:05d}.json", "w") as f:
+        f.write('{"id": %d, "value": "%s"}\n' % (i, "x" * 150))
+PY
+
+cargoship estimate /tmp/smallfiles-demo --show-comparison
+```
+
+The `--show-comparison` block reports:
+
+```
+📊 File Statistics:
+   Total Files:        10,000
+   Estimated Chunks:   100
+
+💵 Savings Breakdown:
+   PUT Request Cost Savings:  $0.05 (one-time, 9,900 requests reduced)
+
+🎯 Total Monthly Savings:  $0.07 (99.0% reduction)
+
+💡 Key Benefits:
+   🎉 Excellent! CargoShip chunking provides >75% cost savings for this workload
+   💡 Small files (<40 KB average) - chunking eliminates 4x minimum size penalty
+      on archive tiers
+```
+
+10,000 files → ~100 chunks: **9,900 fewer PUT requests** and a 99% cost
+reduction for this workload. The same ratio holds as you scale to millions —
+that's the whole point.
+
+::: tip Bonus: the minimum-size penalty
+Archive tiers (Glacier, Deep Archive) bill a **minimum billable object size**
+(e.g. 128 KB) per object. A tree of sub-KB files on Glacier is charged as if each
+were 128 KB — a 100×+ storage penalty on tiny files. Packing them into large
+chunks eliminates it, on top of the request savings above.
+:::
+
+## Do the real upload
+
+When the estimate convinces you, the upload itself is the ordinary command:
+
+```bash
+cargoship upload /tmp/smallfiles-demo s3://my-bucket/small-files/ \
+  --region us-west-2 --project small-files-demo
+```
+
+CargoShip scans, chunks, compresses, and streams — no per-file PUT storm, no
+local scratch space. You get an [upload ID](/intro/concepts#upload-id), a
+verifiable [manifest](/reference/format/manifest), and single-file
+[selective restore](/guides/restoring) from within a chunk.
+
+## When this applies (and when it doesn't)
+
+- **Great fit:** large counts of small-to-medium files you're **archiving or
+  backing up** — you read them back occasionally or in bulk, not individually at
+  high frequency.
+- **Not the goal:** if every file must stay an **individually addressable,
+  frequently-served S3 object** (e.g. a public web asset bucket), keep them as
+  separate objects; the packing that saves you requests also means a restore
+  reads a chunk. See the honest [tool comparison](/reference/comparison).
+
+## Next steps
+
+- [Estimating costs](/guides/cost/estimate) · [Benchmarks & methodology](/reference/benchmarks).
+- [How it works](/intro/how-it-works) · [Sharding](/guides/features/sharding) · [Compression](/guides/features/compression).
+- [`cost` reference](/reference/commands/cost) · [`upload` reference](/reference/commands/upload).

--- a/pkg/aws/cost/pricing.go
+++ b/pkg/aws/cost/pricing.go
@@ -17,7 +17,7 @@ import (
 // PricingManager handles cost calculations with AWS Pricing API integration
 type PricingManager struct {
 	config     *config.PricingConfig
-	pricingAPI *pricing.Client
+	pricingAPI pricingAPIClient
 	logger     *slog.Logger
 	cache      *PricingCache
 	mu         sync.RWMutex
@@ -240,16 +240,22 @@ func (pm *PricingManager) getRequestPrice(ctx context.Context, requestType strin
 		return price, nil
 	}
 
-	// Use AWS Pricing API or fallback
+	// Use AWS Pricing API if enabled, falling back to the static table on error.
 	if pm.config.UseAWSPricingAPI && pm.pricingAPI != nil {
-		// AWS Pricing API implementation would go here
-		// For now, use fallback prices
-		price = pm.getFallbackRequestPrice(requestType)
+		apiPrice, err := pm.getAWSRequestPrice(ctx, strings.ToUpper(requestType), region)
+		if err != nil {
+			pm.logger.Warn("Failed to get AWS request pricing, using fallback", "error", err)
+			price = pm.getFallbackRequestPrice(requestType)
+			pm.setCachedPrice(cacheKey, price, "fallback")
+		} else {
+			price = apiPrice
+			pm.setCachedPrice(cacheKey, price, "aws_api")
+		}
 	} else {
 		price = pm.getFallbackRequestPrice(requestType)
+		pm.setCachedPrice(cacheKey, price, "fallback")
 	}
 
-	pm.setCachedPrice(cacheKey, price, "fallback")
 	return price, nil
 }
 
@@ -383,10 +389,41 @@ func (pm *PricingManager) calculateEnterpriseDiscount(cost float64, service stri
 }
 
 // Helper methods for AWS Pricing API integration
+
+// getAWSStoragePrice queries the AWS Price List API for the per-GB-month storage
+// price of storageClass in region. Returns an error (so the caller falls back to
+// the static table) when the storage class has no Price List mapping or the
+// query yields no usable price.
 func (pm *PricingManager) getAWSStoragePrice(ctx context.Context, storageClass config.StorageClass, region string) (float64, error) {
-	// This would implement actual AWS Pricing API calls
-	// For now, return fallback prices
-	return pm.getFallbackStoragePrice(storageClass), nil
+	volumeType, ok := s3StorageVolumeType(storageClass)
+	if !ok {
+		return 0, fmt.Errorf("no Price List volumeType for storage class %q", storageClass)
+	}
+	return pm.queryAWSPrice(ctx, region, map[string]string{
+		"productFamily": "Storage",
+		"volumeType":    volumeType,
+	})
+}
+
+// getAWSRequestPrice queries the AWS Price List API for the per-request price of
+// requestType in region, returned as a price per 1,000 requests to match the
+// rest of the pricing code. Returns an error (caller falls back) when the
+// request type has no Price List mapping or the query yields no usable price.
+func (pm *PricingManager) getAWSRequestPrice(ctx context.Context, requestType, region string) (float64, error) {
+	group, ok := s3RequestGroup(requestType)
+	if !ok {
+		return 0, fmt.Errorf("no Price List group for request type %q", requestType)
+	}
+	// The API returns a per-request price; the rest of the code works in
+	// price-per-1,000-requests, so scale up.
+	perRequest, err := pm.queryAWSPrice(ctx, region, map[string]string{
+		"productFamily": "API Request",
+		"group":         group,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return perRequest * 1000, nil
 }
 
 // Fallback pricing methods

--- a/pkg/aws/cost/pricing_api.go
+++ b/pkg/aws/cost/pricing_api.go
@@ -1,0 +1,150 @@
+package cost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+	pricingtypes "github.com/aws/aws-sdk-go-v2/service/pricing/types"
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+)
+
+// pricingAPIClient is the subset of the AWS Pricing client used here, extracted
+// as an interface so queryAWSPrice can be unit-tested with a fake. *pricing.Client
+// satisfies it.
+type pricingAPIClient interface {
+	GetProducts(ctx context.Context, params *pricing.GetProductsInput, optFns ...func(*pricing.Options)) (*pricing.GetProductsOutput, error)
+}
+
+// priceListItem is the subset of an AWS Price List API product JSON document we
+// need to extract an on-demand USD price. The GetProducts response returns each
+// product as a JSON string in this shape (FormatVersion aws_v1).
+type priceListItem struct {
+	Product struct {
+		Attributes map[string]string `json:"attributes"`
+	} `json:"product"`
+	Terms struct {
+		OnDemand map[string]struct {
+			PriceDimensions map[string]struct {
+				BeginRange   string `json:"beginRange"`
+				Unit         string `json:"unit"`
+				PricePerUnit struct {
+					USD string `json:"USD"`
+				} `json:"pricePerUnit"`
+			} `json:"priceDimensions"`
+		} `json:"OnDemand"`
+	} `json:"terms"`
+}
+
+// s3StorageVolumeType maps a CargoShip storage class to the AWS Price List
+// `volumeType` attribute for the S3 Storage product family. Values verified
+// against the live Pricing API (us-east-1).
+func s3StorageVolumeType(storageClass config.StorageClass) (string, bool) {
+	switch storageClass {
+	case config.StorageClassStandard:
+		return "Standard", true
+	case config.StorageClassStandardIA:
+		return "Standard - Infrequent Access", true
+	case config.StorageClassOneZoneIA:
+		return "One Zone - Infrequent Access", true
+	case config.StorageClassIntelligentTiering:
+		return "Intelligent-Tiering Frequent Access", true
+	case config.StorageClassGlacier:
+		return "Glacier Instant Retrieval", true
+	case config.StorageClassDeepArchive:
+		return "Glacier Deep Archive", true
+	default:
+		return "", false
+	}
+}
+
+// s3RequestGroup maps a request type to the AWS Price List `group` attribute for
+// the S3 "API Request" product family. PUT/COPY/POST/LIST are Tier1; GET/SELECT
+// and others are Tier2. Verified against the live Pricing API.
+func s3RequestGroup(requestType string) (string, bool) {
+	switch requestType {
+	case "PUT", "POST", "COPY", "LIST":
+		return "S3-API-Tier1", true
+	case "GET", "SELECT":
+		return "S3-API-Tier2", true
+	default:
+		return "", false
+	}
+}
+
+// queryAWSPrice runs a GetProducts query with the given S3 attribute filters and
+// returns the lowest first-tier on-demand USD price found (per the product's
+// unit — GB-Mo for storage, per-request for requests). It returns an error when
+// the API call fails or no usable price is found, so callers fall back to the
+// static price table.
+func (pm *PricingManager) queryAWSPrice(ctx context.Context, region string, filters map[string]string) (float64, error) {
+	apiFilters := make([]pricingtypes.Filter, 0, len(filters)+1)
+	apiFilters = append(apiFilters, pricingtypes.Filter{
+		Type:  pricingtypes.FilterTypeTermMatch,
+		Field: aws.String("regionCode"),
+		Value: aws.String(region),
+	})
+	// Deterministic filter order keeps the cache key and requests stable.
+	keys := make([]string, 0, len(filters))
+	for k := range filters {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		apiFilters = append(apiFilters, pricingtypes.Filter{
+			Type:  pricingtypes.FilterTypeTermMatch,
+			Field: aws.String(k),
+			Value: aws.String(filters[k]),
+		})
+	}
+
+	out, err := pm.pricingAPI.GetProducts(ctx, &pricing.GetProductsInput{
+		ServiceCode:   aws.String("AmazonS3"),
+		FormatVersion: aws.String("aws_v1"),
+		Filters:       apiFilters,
+		MaxResults:    aws.Int32(100),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("pricing GetProducts: %w", err)
+	}
+
+	best := -1.0
+	for _, raw := range out.PriceList {
+		var item priceListItem
+		if err := json.Unmarshal([]byte(raw), &item); err != nil {
+			continue // skip malformed entries rather than failing the whole query
+		}
+		for _, term := range item.Terms.OnDemand {
+			// Pick the first pricing band (lowest beginRange) for this product.
+			type dim struct {
+				begin float64
+				usd   string
+			}
+			var dims []dim
+			for _, pd := range term.PriceDimensions {
+				begin, _ := strconv.ParseFloat(pd.BeginRange, 64)
+				dims = append(dims, dim{begin: begin, usd: pd.PricePerUnit.USD})
+			}
+			if len(dims) == 0 {
+				continue
+			}
+			sort.Slice(dims, func(i, j int) bool { return dims[i].begin < dims[j].begin })
+			price, err := strconv.ParseFloat(dims[0].usd, 64)
+			if err != nil || price <= 0 {
+				continue
+			}
+			if best < 0 || price < best {
+				best = price
+			}
+		}
+	}
+
+	if best < 0 {
+		return 0, fmt.Errorf("no usable price in %d products", len(out.PriceList))
+	}
+	return best, nil
+}

--- a/pkg/aws/cost/pricing_api_test.go
+++ b/pkg/aws/cost/pricing_api_test.go
@@ -1,0 +1,177 @@
+package cost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePricingClient is a pricingAPIClient that returns canned Price List
+// products (or an error) without touching AWS.
+type fakePricingClient struct {
+	products []string
+	err      error
+}
+
+func (f *fakePricingClient) GetProducts(_ context.Context, _ *pricing.GetProductsInput, _ ...func(*pricing.Options)) (*pricing.GetProductsOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &pricing.GetProductsOutput{PriceList: f.products}, nil
+}
+
+// newTestPricingManager builds a PricingManager wired to a fake pricing client
+// with the API enabled.
+func newTestPricingManager(t *testing.T, client pricingAPIClient) *PricingManager {
+	t.Helper()
+	pm, err := NewPricingManager(&config.PricingConfig{
+		UseAWSPricingAPI:     true,
+		Currency:             "USD",
+		PricingCacheDuration: "24h",
+	}, aws.Config{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	pm.pricingAPI = client
+	return pm
+}
+
+func storageProduct(volumeType, usd string) string {
+	return fmt.Sprintf(`{"product":{"attributes":{"volumeType":%q,"regionCode":"us-east-1"}},`+
+		`"terms":{"OnDemand":{"K.T":{"priceDimensions":{"K.T.D":{"beginRange":"0","unit":"GB-Mo","pricePerUnit":{"USD":%q}}}}}}}`,
+		volumeType, usd)
+}
+
+func requestProduct(group, usdPerRequest string) string {
+	return fmt.Sprintf(`{"product":{"attributes":{"group":%q,"regionCode":"us-east-1"}},`+
+		`"terms":{"OnDemand":{"K.T":{"priceDimensions":{"K.T.D":{"beginRange":"0","unit":"Requests","pricePerUnit":{"USD":%q}}}}}}}`,
+		group, usdPerRequest)
+}
+
+func TestGetAWSStoragePrice_FromAPI(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{
+		products: []string{storageProduct("Standard", "0.0230000000")},
+	})
+	price, err := pm.getAWSStoragePrice(context.Background(), config.StorageClassStandard, "us-east-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.023, price, 1e-9)
+}
+
+func TestGetAWSStoragePrice_UnmappedClass(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{})
+	_, err := pm.getAWSStoragePrice(context.Background(), config.StorageClass("BOGUS"), "us-east-1")
+	assert.Error(t, err)
+}
+
+func TestGetAWSRequestPrice_ScalesToPerThousand(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{
+		products: []string{requestProduct("S3-API-Tier1", "0.0000050000")},
+	})
+	// $0.000005 per request → $0.005 per 1,000.
+	price, err := pm.getAWSRequestPrice(context.Background(), "PUT", "us-east-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.005, price, 1e-9)
+}
+
+func TestGetAWSRequestPrice_UnmappedType(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{})
+	_, err := pm.getAWSRequestPrice(context.Background(), "DELETE", "us-east-1")
+	assert.Error(t, err)
+}
+
+func TestQueryAWSPrice_NoUsablePrice(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{products: []string{`{"bogus":true}`}})
+	_, err := pm.queryAWSPrice(context.Background(), "us-east-1", map[string]string{"productFamily": "Storage"})
+	assert.Error(t, err)
+}
+
+func TestQueryAWSPrice_APIError(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{err: fmt.Errorf("boom")})
+	_, err := pm.queryAWSPrice(context.Background(), "us-east-1", map[string]string{"productFamily": "Storage"})
+	assert.Error(t, err)
+}
+
+// TestGetRequestPrice_FallsBackOnAPIError confirms getRequestPrice returns the
+// static fallback (not an error) when the API call fails, so cost estimation
+// keeps working offline.
+func TestGetRequestPrice_FallsBackOnAPIError(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{err: fmt.Errorf("no network")})
+	price, err := pm.getRequestPrice(context.Background(), "PUT", config.StorageClassStandard, "us-east-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.005, price, 1e-9) // corrected fallback
+}
+
+func TestGetRequestPrice_UsesAPIWhenAvailable(t *testing.T) {
+	pm := newTestPricingManager(t, &fakePricingClient{
+		products: []string{requestProduct("S3-API-Tier2", "0.0000004000")},
+	})
+	price, err := pm.getRequestPrice(context.Background(), "GET", config.StorageClassStandard, "eu-west-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.0004, price, 1e-9)
+}
+
+func TestS3StorageVolumeType(t *testing.T) {
+	cases := map[config.StorageClass]string{
+		config.StorageClassStandard:           "Standard",
+		config.StorageClassStandardIA:         "Standard - Infrequent Access",
+		config.StorageClassOneZoneIA:          "One Zone - Infrequent Access",
+		config.StorageClassIntelligentTiering: "Intelligent-Tiering Frequent Access",
+		config.StorageClassGlacier:            "Glacier Instant Retrieval",
+		config.StorageClassDeepArchive:        "Glacier Deep Archive",
+	}
+	for sc, want := range cases {
+		got, ok := s3StorageVolumeType(sc)
+		assert.True(t, ok, "storage class %q should map", sc)
+		assert.Equal(t, want, got, "storage class %q", sc)
+	}
+
+	_, ok := s3StorageVolumeType(config.StorageClass("BOGUS"))
+	assert.False(t, ok, "unknown storage class must not map")
+}
+
+func TestS3RequestGroup(t *testing.T) {
+	tier1 := []string{"PUT", "POST", "COPY", "LIST"}
+	for _, rt := range tier1 {
+		got, ok := s3RequestGroup(rt)
+		assert.True(t, ok, "%s should map", rt)
+		assert.Equal(t, "S3-API-Tier1", got, "%s", rt)
+	}
+	tier2 := []string{"GET", "SELECT"}
+	for _, rt := range tier2 {
+		got, ok := s3RequestGroup(rt)
+		assert.True(t, ok, "%s should map", rt)
+		assert.Equal(t, "S3-API-Tier2", got, "%s", rt)
+	}
+	_, ok := s3RequestGroup("DELETE")
+	assert.False(t, ok, "DELETE has no Tier group (free)")
+}
+
+// TestPriceListItem_Parse verifies the Price List product JSON is parsed the way
+// the AWS Pricing API actually returns it (shape confirmed against the live API).
+func TestPriceListItem_Parse(t *testing.T) {
+	// Trimmed real-world Standard storage product (us-east-1), with two pricing
+	// bands to confirm we can read the first-band ($0.023/GB-Mo) price.
+	raw := `{
+      "product": {"attributes": {"volumeType": "Standard", "regionCode": "us-east-1"}},
+      "terms": {"OnDemand": {"ABC.JRTCKXETXF": {"priceDimensions": {
+        "ABC.JRTCKXETXF.D1": {"beginRange": "0", "unit": "GB-Mo", "pricePerUnit": {"USD": "0.0230000000"}},
+        "ABC.JRTCKXETXF.D2": {"beginRange": "512000", "unit": "GB-Mo", "pricePerUnit": {"USD": "0.0220000000"}}
+      }}}}
+    }`
+
+	var item priceListItem
+	require.NoError(t, json.Unmarshal([]byte(raw), &item))
+	assert.Equal(t, "Standard", item.Product.Attributes["volumeType"])
+
+	term, ok := item.Terms.OnDemand["ABC.JRTCKXETXF"]
+	require.True(t, ok)
+	require.Len(t, term.PriceDimensions, 2)
+	assert.Equal(t, "0.0230000000", term.PriceDimensions["ABC.JRTCKXETXF.D1"].PricePerUnit.USD)
+}


### PR DESCRIPTION
Answers a recurring question: *how much does CargoShip actually save on millions
of small files, vs a naive `aws s3 cp`?* Until now the small-files advantage was
only asserted qualitatively (comparison.md: "request-heavy"); no doc quantified
it, despite it being CargoShip's headline benefit.

## New tutorial: `docs/tutorials/small-files.md`

- **The mechanism** — S3 bills per PUT request, independent of file size. Worked
  math: `$0.005/1k × 5,000,000 files = $25` in request charges alone, before a
  byte of storage.
- **Real numbers** — actual `cargoship cost benchmark-compare` output for 5M
  files / 50 GB: naive `$25.00` PUT cost → CargoShip `$0.0009` (~170 chunks,
  4,999,830 fewer requests), ~88% first-year TCO reduction.
- **Runnable demo** — generates 10,000 tiny files and runs `cargoship estimate
  --show-comparison` (verified: 99% reduction, 9,900 fewer PUTs). Touches no S3.
- **Bonus** — notes the archive-tier minimum-object-size penalty that packing
  also eliminates.
- **Honest scope** — a "when this applies / when it doesn't" section pointing at
  the tool comparison.

Every figure is real command output captured from the built binary (with the
corrected $0.005/1k PUT price from #233), not a marketing number.

## Wiring

- Added to the tutorials index table (top row) and the sidebar.
- Cross-linked from `reference/comparison.md`'s `aws s3 cp` entry.
- Docs build clean, no dead links.

Depends conceptually on #233 (correct PUT price). Companion to #235 (live
pricing) — the tutorial's "these are your prices" note refers to it.