### PR TITLE
test: e2e coverage for estimate/cost/list/download/sync/dvc + fix 2 bugs

### DIFF
--- a/cmd/cargoship/cmd/download.go
+++ b/cmd/cargoship/cmd/download.go
@@ -165,6 +165,40 @@ Examples:
 			fmt.Printf("📦 Selected %d files (%s uncompressed)\n\n",
 				len(filesToDownload), humanize.Bytes(uint64(totalSize)))
 
+			// Direct-upload manifests have no chunks: each file is its own S3
+			// object (not a tar.zst chunk), so the chunk-download path below can't
+			// extract them. Route through the shared SelectiveExtractor, which
+			// handles direct-upload restore (writing raw object bytes). Mirrors the
+			// restore command's fix. (#228 / #238 Phase 2)
+			if m.TotalChunks == 0 {
+				if dryRun {
+					fmt.Println("🔍 Dry run - would download (direct-upload objects):")
+					for _, file := range filesToDownload {
+						fmt.Printf("    - %s (%s)\n", file.Path, humanize.Bytes(uint64(file.Size)))
+					}
+					fmt.Printf("\nTotal: %d files, %s\n", len(filesToDownload), humanize.Bytes(uint64(totalSize)))
+					return nil
+				}
+				if err := os.MkdirAll(outputDir, 0755); err != nil {
+					return fmt.Errorf("failed to create output directory: %w", err)
+				}
+				targets := make([]string, len(filesToDownload))
+				for i, file := range filesToDownload {
+					targets[i] = file.Path
+				}
+				extractor := manifest.NewSelectiveExtractor(m, s3Client, 0)
+				stats, err := extractor.BatchRestore(ctx, targets, outputDir)
+				if err != nil {
+					return fmt.Errorf("failed to download direct-upload files: %w", err)
+				}
+				fmt.Printf("✅ Downloaded %d files (%s) — %d failed\n",
+					stats.Restored, humanize.Bytes(uint64(stats.Bytes)), stats.Failed)
+				if stats.Failed > 0 {
+					return fmt.Errorf("%d file(s) failed to download", stats.Failed)
+				}
+				return nil
+			}
+
 			// Step 3: Group files by chunk to minimize chunk downloads
 			chunkFiles := make(map[int][]manifest.FileEntry)
 			for _, file := range filesToDownload {

--- a/pkg/archivefs/vfs.go
+++ b/pkg/archivefs/vfs.go
@@ -64,11 +64,14 @@ func New(m *manifest.Manifest) *VirtualFS {
 			dirPath = ""
 		}
 
-		// Register all ancestor directories up to the root.
+		// Register all ancestor directories up to the root. path.Dir("/") == "/"
+		// (and path.Dir of any rooted path bottoms out at "/", never ""), so stop
+		// when the parent stops making progress — otherwise an absolute file path
+		// loops forever here. (direct-upload manifests store absolute paths)
 		cur := dirPath
 		for {
 			vfs.dirSet[cur] = struct{}{}
-			if cur == "" {
+			if cur == "" || cur == "/" {
 				break
 			}
 			parent := path.Dir(cur)
@@ -76,6 +79,9 @@ func New(m *manifest.Manifest) *VirtualFS {
 				parent = ""
 			}
 			ensureDir(parent, path.Base(cur))
+			if parent == cur {
+				break // no progress (e.g. cur == "/"): avoid infinite loop
+			}
 			cur = parent
 		}
 

--- a/pkg/archivefs/vfs_test.go
+++ b/pkg/archivefs/vfs_test.go
@@ -208,3 +208,25 @@ func TestManifest(t *testing.T) {
 	vfs := New(m)
 	require.Same(t, m, vfs.Manifest())
 }
+
+// TestNew_AbsolutePathsNoHang guards against the infinite loop where an absolute
+// file path (as stored in direct-upload manifests) caused New's ancestor walk to
+// spin forever at "/" (path.Dir("/") == "/"). Regression for #238 Phase 2.
+func TestNew_AbsolutePathsNoHang(t *testing.T) {
+	m := &manifest.Manifest{
+		Files: []manifest.FileEntry{
+			{Path: "/var/folders/tmp/data/train.bin"},
+			{Path: "/var/folders/tmp/data/test.bin"},
+		},
+	}
+	done := make(chan *VirtualFS, 1)
+	go func() { done <- New(m) }()
+	select {
+	case vfs := <-done:
+		require.NotNil(t, vfs)
+		// The two files share a parent dir; both must be registered.
+		assert.Len(t, vfs.children["/var/folders/tmp/data"], 2)
+	case <-time.After(5 * time.Second):
+		t.Fatal("archivefs.New hung on absolute file paths")
+	}
+}

--- a/tests/e2e/commands_test.go
+++ b/tests/e2e/commands_test.go
@@ -1,0 +1,220 @@
+//go:build e2e
+
+// Broadens the end-to-end coverage beyond the Quick Start (upload → info →
+// verify → restore) to the other documented CLI workflows, driven through the
+// real cargoship binary against the in-process Substrate S3 emulator. These are
+// the executable form of the command docs: if a documented happy path breaks,
+// the matching test here fails. (#238 Phase 2)
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runCargoshipAllowErr runs the binary and returns combined output + the error
+// (nil on success) without failing the test — for commands whose exit code is
+// the thing under test.
+func runCargoshipAllowErr(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cargoshipBin, args...)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// uploadTree uploads a small directory to the emulator and returns the upload
+// URL (…/uploads/<id>). Shared setup for the S3-backed command tests.
+func uploadTree(t *testing.T, bucket string, files map[string]string) string {
+	t.Helper()
+	if err := createBucket(substrateURL, bucket); err != nil {
+		t.Fatalf("create bucket %s: %v", bucket, err)
+	}
+	src := t.TempDir()
+	for name, content := range files {
+		p := filepath.Join(src, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		writeFile(t, p, content)
+	}
+	out := runCargoship(t, "upload", src, "s3://"+bucket+"/archives", "--region", "us-east-1")
+	id := extractUploadID(t, out)
+	return "s3://" + bucket + "/archives/uploads/" + id
+}
+
+// TestEstimate_Local runs `estimate` on a local tree (no S3) in both table and
+// JSON form, asserting the JSON is well-formed and carries a cost estimate.
+func TestEstimate_Local(t *testing.T) {
+	src := t.TempDir()
+	writeFile(t, filepath.Join(src, "a.txt"), "hello\n")
+	writeFile(t, filepath.Join(src, "b.txt"), "world\n")
+
+	table := runCargoship(t, "estimate", src)
+	if !strings.Contains(table, "Cost Estimate") {
+		t.Fatalf("estimate table output missing 'Cost Estimate':\n%s", table)
+	}
+
+	jsonOut := runCargoship(t, "estimate", src, "--format", "json")
+	// The command prints a config line before the JSON; slice from the first '{'.
+	brace := strings.IndexByte(jsonOut, '{')
+	if brace < 0 {
+		t.Fatalf("no JSON object in estimate --format json output:\n%s", jsonOut)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(jsonOut[brace:]), &parsed); err != nil {
+		t.Fatalf("estimate JSON did not parse: %v\n%s", err, jsonOut[brace:])
+	}
+	if _, ok := parsed["cost_estimate"]; !ok {
+		t.Fatalf("estimate JSON missing cost_estimate key: %v", parsed)
+	}
+}
+
+// TestCostBenchmarkCompare verifies the naive-vs-CargoShip cost comparison
+// (used by the small-files tutorial) emits correct PUT-request pricing.
+func TestCostBenchmarkCompare(t *testing.T) {
+	out := runCargoship(t, "cost", "benchmark-compare",
+		"--tool", "aws-cli", "--size-gb", "1", "--files", "1000")
+	brace := strings.IndexByte(out, '{')
+	if brace < 0 {
+		t.Fatalf("no JSON in benchmark-compare output:\n%s", out)
+	}
+	var r struct {
+		Tool           string  `json:"tool"`
+		PUTRequestCost float64 `json:"put_request_cost"`
+	}
+	if err := json.Unmarshal([]byte(out[brace:]), &r); err != nil {
+		t.Fatalf("benchmark-compare JSON did not parse: %v\n%s", err, out[brace:])
+	}
+	// 1000 files ÷ 1000 × $0.005/1k = $0.005 (guards the #233 pricing fix).
+	if r.PUTRequestCost < 0.0049 || r.PUTRequestCost > 0.0051 {
+		t.Fatalf("PUT request cost = %v, want ~0.005 (1000 files @ $0.005/1k)", r.PUTRequestCost)
+	}
+}
+
+// TestBudgetSet exercises `budget set`. NOTE: budget state does not persist
+// across processes yet (#241 — cost.Manager storage is a TODO stub), so we only
+// assert the command runs and reports success. Upgrade to a set→status
+// round-trip once #241 lands.
+func TestBudgetSet(t *testing.T) {
+	out, err := runCargoshipAllowErr(t, "budget", "set", "e2e-proj",
+		"--cost", "100", "--volume", "50")
+	if err != nil {
+		t.Fatalf("budget set failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Budget set for project") {
+		t.Fatalf("budget set output missing confirmation:\n%s", out)
+	}
+}
+
+// TestList_FromManifest uploads a tree, then lists it back from the manifest.
+func TestList_FromManifest(t *testing.T) {
+	url := uploadTree(t, "list-e2e", map[string]string{
+		"one.txt": "first\n",
+		"two.txt": "second\n",
+	})
+	// url is s3://bucket/archives/uploads/<id>; list takes --bucket/--upload-id
+	// plus the --prefix the upload was written under ("archives"). --verbose
+	// prints full paths (the default view truncates long absolute paths).
+	bucket, uploadID := splitUploadURL(t, url)
+	out := runCargoship(t, "list", "--bucket", bucket, "--upload-id", uploadID,
+		"--prefix", "archives", "--verbose", "--region", "us-east-1")
+	if !strings.Contains(out, "2 files") && !strings.Contains(out, "2 total") {
+		t.Fatalf("list did not report 2 files:\n%s", out)
+	}
+	for _, want := range []string{"one.txt", "two.txt"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("list output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDownload_RoundTrip uploads a tree then downloads the whole upload back,
+// asserting a known file's content survives the round trip.
+func TestDownload_RoundTrip(t *testing.T) {
+	const want = "downloadable content\n"
+	url := uploadTree(t, "download-e2e", map[string]string{"payload.txt": want})
+
+	dest := t.TempDir()
+	runCargoship(t, "download", url, dest, "--region", "us-east-1")
+
+	// The file may land at dest/payload.txt or under a nested path; search for it.
+	var found string
+	_ = filepath.Walk(dest, func(p string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && filepath.Base(p) == "payload.txt" {
+			found = p
+		}
+		return nil
+	})
+	if found == "" {
+		t.Fatalf("payload.txt not found under %s after download", dest)
+	}
+	got, err := os.ReadFile(found)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("downloaded content mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestSync_Incremental uploads a tree, adds a file, and re-syncs — asserting the
+// second run succeeds (incremental upload path).
+func TestSync_Incremental(t *testing.T) {
+	bucket := "sync-e2e"
+	if err := createBucket(substrateURL, bucket); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	src := t.TempDir()
+	writeFile(t, filepath.Join(src, "keep.txt"), "unchanged\n")
+
+	dest := "s3://" + bucket + "/synced"
+	if out, err := runCargoshipAllowErr(t, "sync", src, dest, "--region", "us-east-1"); err != nil {
+		t.Fatalf("initial sync failed: %v\n%s", err, out)
+	}
+
+	// Add a new file and sync again.
+	writeFile(t, filepath.Join(src, "added.txt"), "new file\n")
+	if out, err := runCargoshipAllowErr(t, "sync", src, dest, "--region", "us-east-1"); err != nil {
+		t.Fatalf("incremental sync failed: %v\n%s", err, out)
+	}
+}
+
+// TestDVC_Stages uploads a tree, then runs `dvc stages` against the manifest.
+// `dvc stages` takes the upload S3_URL directly.
+func TestDVC_Stages(t *testing.T) {
+	url := uploadTree(t, "dvc-e2e", map[string]string{
+		"data/train.bin": "train\n",
+		"data/test.bin":  "test\n",
+	})
+	// These files have no DVC metadata, so the output is a valid "no stages"
+	// result — the command must run without error.
+	if out, err := runCargoshipAllowErr(t, "dvc", "stages", url, "--region", "us-east-1"); err != nil {
+		t.Fatalf("dvc stages failed: %v\n%s", err, out)
+	}
+}
+
+// splitUploadURL turns s3://bucket/prefix/uploads/<id> into (bucket, id).
+func splitUploadURL(t *testing.T, url string) (bucket, uploadID string) {
+	t.Helper()
+	trimmed := strings.TrimPrefix(url, "s3://")
+	parts := strings.SplitN(trimmed, "/", 2)
+	if len(parts) != 2 {
+		t.Fatalf("malformed upload URL: %s", url)
+	}
+	bucket = parts[0]
+	idx := strings.LastIndex(url, "/uploads/")
+	if idx < 0 {
+		t.Fatalf("no /uploads/ in URL: %s", url)
+	}
+	uploadID = url[idx+len("/uploads/"):]
+	return bucket, uploadID
+}


### PR DESCRIPTION
**#238 Phase 2.** Extends the e2e suite beyond Quick Start to the other
documented CLI workflows, driven through the real `cargoship` binary against the
in-process Substrate emulator (no AWS creds). Writing these surfaced **two real
product bugs**, both fixed here — which is exactly the point of the exercise.

## New e2e tests (`tests/e2e/commands_test.go`)

`estimate` (local, table + JSON), `cost benchmark-compare` (guards the #233 PUT
price), `budget set`, `list` (from manifest), `download` (round-trip), `sync`
(incremental), `dvc stages`.

## Bugs found & fixed

**1. `download` broken for direct-upload archives** (`cmd/.../download.go`) —
`download` had its own chunk-extraction path and returned **0 files** for
direct-upload manifests (0 chunks): "⚠️ chunk 0 not found in manifest". Same
class as #228 (which fixed `restore`, but `download` was never updated). Now
routes direct-upload manifests through the shared `manifest.SelectiveExtractor`.

**2. `archivefs.New` infinite loop on absolute paths** (`pkg/archivefs/vfs.go`) —
the ancestor-directory walk uses `path.Dir` until `cur == ""`, but
`path.Dir("/") == "/"` never reaches `""`, so **any absolute file path spun
forever**. Direct-upload manifests store absolute paths, so `dvc stages` **hung**
(60s → killed); `shell` and `browse` use the same code. Stop the walk at `/`.
Added a regression test.

## Known gap (tracked, not fixed here)

`budget` state doesn't persist across processes — `cost.Manager` storage is a
TODO stub (**#241**). `TestBudgetSet` asserts only that the command runs and
reports success; upgrade to a real set→status round-trip once #241 lands.

## Verification

All 8 e2e tests pass against the emulator; `pkg/archivefs` suite green incl. the
new regression test. Both fixes verified end-to-end (download now restores
direct-upload content; `dvc stages` completes in 0.03s vs hanging).

Part of #238. Also filed this phase: #241 (budget persistence).