### PR TITLE
ci: drop redundant Test job + run integration with -short

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,26 +13,9 @@ env:
   GO_VERSION: '1.26'
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Download dependencies
-        run: go mod download
-
-      - name: Run tests
-        run: go test ./... -short -timeout=10m
+  # The plain unit-test run lives in the Code Coverage job below, which runs the
+  # identical `go test ./... -short` plus a coverage profile — a separate "Test"
+  # job would be pure duplication, so it's intentionally omitted.
 
   e2e-quickstart:
     name: Quick Start E2E (emulator)
@@ -81,8 +64,13 @@ jobs:
       # (upload → manifest → restore round-trips, DVC workflows, S3 transporter)
       # that unit tests miss. Real-AWS-only assertions self-skip without
       # CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS. (#238)
+      #
+      # -short is deliberate: the emulator integration tests don't gate on it, so
+      # they still run, while the sleep-heavy multiregion failover/perf tests
+      # (~85s, pure timing, no S3) skip — cutting this job's multiregion cost from
+      # ~104s to ~19s. Those perf tests run in their own lane, not here.
       - name: Run integration tests
-        run: go test -tags integration ./... -timeout 15m
+        run: go test -tags integration -short ./... -timeout 15m
 
   test-race:
     name: Test with Race Detector


### PR DESCRIPTION
Addresses the CI-is-slow complaint. Two changes, no coverage loss.

## Diagnosis

The unit suite under `-short` is already fast (<3s per package; multiregion's
slow tests already skip under `-short`). The slowness was two things:

1. **A duplicate job.** The `Test` job ran `go test ./... -short` — the *exact*
   suite the `Code Coverage` job already runs (plus a coverage profile). Two jobs
   doing the same work, competing for limited runners.
2. **The integration job ran without `-short`**, so the sleep-heavy `multiregion`
   failover/performance tests (~85s of pure timing, no S3 involved) ran there —
   `multiregion` alone was ~104s of the job.

## Changes

- **Remove the `Test` job** (kept `Coverage`, which is a superset).
- **Add `-short` to the `Integration (emulator)` job.** The emulator integration
  tests don't gate on `-short` so they still run; only the multiregion perf/
  failover sleeps skip. multiregion in this job drops **~104s → ~19s**.

## Verification

- `go test -tags integration -short ./...` → **42 packages ok, 0 failures**; the
  emulator round-trip / DVC / manifest suites all still execute (confirmed they
  don't have `-short` guards).
- Branch has no protection rules, so removing the `Test` status check breaks
  nothing.

Net: one fewer job, and the integration long-pole shrinks substantially. The
race-detector job stays as-is (its cost is inherent to `-race`).