### PR TITLE
fix: persist project budgets across CLI invocations (Fixes #241)

### DIFF
--- a/pkg/aws/cost/budget.go
+++ b/pkg/aws/cost/budget.go
@@ -298,12 +298,13 @@ func (m *Manager) GetProjectBudgetStatus(projectID string) (*BudgetStatus, error
 	// Get current project spending and volume
 	currentSpend := m.reporter.GetProjectCosts(projectID)
 
-	// Calculate current volume for project
-	projectSummary, err := m.reporter.GetProjectSummary(projectID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get project summary: %w", err)
+	// Calculate current volume for project. A budget can be set before any spend
+	// is recorded (fresh `budget set`), in which case there are no cost records
+	// yet — treat that as zero volume rather than an error. (#241)
+	var currentVolumeGB float64
+	if projectSummary, err := m.reporter.GetProjectSummary(projectID); err == nil {
+		currentVolumeGB = projectSummary.TotalSizeGB
 	}
-	currentVolumeGB := projectSummary.TotalSizeGB
 
 	now := time.Now()
 
@@ -539,6 +540,11 @@ func (m *Manager) SetProjectBudget(projectID string, maxBudget float64, maxVolum
 		VolumeAlertThreshold: volumeAlertThreshold,
 	}
 
+	// Persist so the budget survives across CLI invocations (#241).
+	if err := saveProjectBudgets(m.config.ProjectBudgets); err != nil {
+		return fmt.Errorf("persist project budget: %w", err)
+	}
+
 	m.logger.Info("Project budget updated",
 		"project_id", projectID,
 		"max_budget", maxBudget,
@@ -560,6 +566,11 @@ func (m *Manager) DeleteProjectBudget(projectID string) error {
 	}
 
 	delete(m.config.ProjectBudgets, projectID)
+
+	// Persist the removal (#241).
+	if err := saveProjectBudgets(m.config.ProjectBudgets); err != nil {
+		return fmt.Errorf("persist project budget removal: %w", err)
+	}
 
 	m.logger.Info("Project budget deleted", "project_id", projectID)
 	return nil

--- a/pkg/aws/cost/budget_store.go
+++ b/pkg/aws/cost/budget_store.go
@@ -1,0 +1,100 @@
+package cost
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+)
+
+// budgetStoreEnvOverride lets callers (notably tests) redirect the budget store
+// to a scratch location instead of the user's home directory.
+const budgetStoreEnvOverride = "CARGOSHIP_BUDGET_STORE"
+
+// budgetStorePath returns the path to the persisted project-budgets file:
+//   - $CARGOSHIP_BUDGET_STORE if set (an explicit file path), else
+//   - $XDG_DATA_HOME/cargoship/budgets.json, else
+//   - ~/.cargoship/budgets.json
+//
+// This mirrors the state-dir convention used by the restore and resume packages.
+func budgetStorePath() (string, error) {
+	if override := os.Getenv(budgetStoreEnvOverride); override != "" {
+		return override, nil
+	}
+	base := os.Getenv("XDG_DATA_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("get home dir: %w", err)
+		}
+		base = filepath.Join(home, ".cargoship")
+	} else {
+		base = filepath.Join(base, "cargoship")
+	}
+	return filepath.Join(base, "budgets.json"), nil
+}
+
+// loadProjectBudgets reads persisted project budgets from disk. A missing file
+// is not an error (returns an empty map) — the store simply hasn't been written
+// yet.
+func loadProjectBudgets() (map[string]config.ProjectBudget, error) {
+	path, err := budgetStorePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from home/XDG, not user input
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]config.ProjectBudget{}, nil
+		}
+		return nil, fmt.Errorf("read budget store %q: %w", path, err)
+	}
+	var budgets map[string]config.ProjectBudget
+	if err := json.Unmarshal(data, &budgets); err != nil {
+		return nil, fmt.Errorf("parse budget store %q: %w", path, err)
+	}
+	if budgets == nil {
+		budgets = map[string]config.ProjectBudget{}
+	}
+	return budgets, nil
+}
+
+// saveProjectBudgets writes project budgets to disk atomically (write to a temp
+// file in the same directory, then rename) so a crash mid-write can't corrupt
+// the store. The file is written 0600 since budgets may reference grant numbers.
+func saveProjectBudgets(budgets map[string]config.ProjectBudget) error {
+	path, err := budgetStorePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create budget store dir: %w", err)
+	}
+	data, err := json.MarshalIndent(budgets, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal budgets: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".budgets-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp budget file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp budget file: %w", err)
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp budget file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp budget file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename budget store into place: %w", err)
+	}
+	return nil
+}

--- a/pkg/aws/cost/budget_store_test.go
+++ b/pkg/aws/cost/budget_store_test.go
@@ -1,0 +1,50 @@
+package cost
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBudgetStore_SaveLoadRoundTrip(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+
+	want := map[string]config.ProjectBudget{
+		"proj-a": {ProjectID: "proj-a", MaxBudget: 100, MaxVolumeGB: 50, AlertThreshold: 0.8},
+		"proj-b": {ProjectID: "proj-b", MaxBudget: 250},
+	}
+	require.NoError(t, saveProjectBudgets(want))
+
+	got, err := loadProjectBudgets()
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestBudgetStore_LoadMissingFileIsEmpty(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "does-not-exist.json"))
+
+	got, err := loadProjectBudgets()
+	require.NoError(t, err, "a missing store must not be an error")
+	assert.Empty(t, got)
+}
+
+func TestBudgetStore_SaveOverwrites(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+
+	require.NoError(t, saveProjectBudgets(map[string]config.ProjectBudget{
+		"proj-a": {ProjectID: "proj-a", MaxBudget: 100},
+	}))
+	// A second save with different contents must fully replace the first.
+	require.NoError(t, saveProjectBudgets(map[string]config.ProjectBudget{
+		"proj-b": {ProjectID: "proj-b", MaxBudget: 200},
+	}))
+
+	got, err := loadProjectBudgets()
+	require.NoError(t, err)
+	_, hasA := got["proj-a"]
+	assert.False(t, hasA, "proj-a should have been overwritten")
+	assert.Equal(t, float64(200), got["proj-b"].MaxBudget)
+}

--- a/pkg/aws/cost/budget_test.go
+++ b/pkg/aws/cost/budget_test.go
@@ -13,6 +13,7 @@ import (
 // TestSetProjectBudget tests setting project budgets with cost and volume quotas (Issue #147 Phase 4)
 func TestSetProjectBudget(t *testing.T) {
 	testutil.RequireNoGoroutineLeak(t)
+	isolateBudgetStore(t)
 
 	now := time.Now()
 	cfg := &config.CostControlConfig{
@@ -69,6 +70,7 @@ func TestSetProjectBudget(t *testing.T) {
 // TestSetProjectBudgetValidation tests budget validation (Issue #147 Phase 4)
 func TestSetProjectBudgetValidation(t *testing.T) {
 	testutil.RequireNoGoroutineLeak(t)
+	isolateBudgetStore(t)
 
 	cfg := &config.CostControlConfig{
 		ProjectBudgets: make(map[string]config.ProjectBudget),
@@ -201,6 +203,7 @@ func TestSetProjectBudgetValidation(t *testing.T) {
 // TestRemoveProjectBudget tests removing project budgets (Issue #147 Phase 4)
 func TestRemoveProjectBudget(t *testing.T) {
 	testutil.RequireNoGoroutineLeak(t)
+	isolateBudgetStore(t)
 
 	cfg := &config.CostControlConfig{
 		ProjectBudgets: make(map[string]config.ProjectBudget),
@@ -242,6 +245,7 @@ func TestRemoveProjectBudget(t *testing.T) {
 // TestListProjectBudgets tests listing all project budgets (Issue #147 Phase 4)
 func TestListProjectBudgets(t *testing.T) {
 	testutil.RequireNoGoroutineLeak(t)
+	isolateBudgetStore(t)
 
 	cfg := &config.CostControlConfig{
 		ProjectBudgets: make(map[string]config.ProjectBudget),

--- a/pkg/aws/cost/main_test.go
+++ b/pkg/aws/cost/main_test.go
@@ -1,0 +1,30 @@
+package cost
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain isolates the on-disk project-budget store (#241) so tests never read
+// or write the developer's real ~/.cargoship/budgets.json. Each test that needs
+// a clean slate can still point CARGOSHIP_BUDGET_STORE at its own t.TempDir().
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "cargoship-cost-budget-store")
+	if err != nil {
+		panic("create temp budget store dir: " + err.Error())
+	}
+	_ = os.Setenv(budgetStoreEnvOverride, filepath.Join(dir, "budgets.json"))
+
+	code := m.Run()
+
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// isolateBudgetStore points the persistent budget store (#241) at a fresh file
+// unique to this test, so budget mutations in one test can't leak into another.
+func isolateBudgetStore(t *testing.T) {
+	t.Helper()
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+}

--- a/pkg/aws/cost/manager.go
+++ b/pkg/aws/cost/manager.go
@@ -82,6 +82,22 @@ func NewManager(cfg *config.CostControlConfig, awsCfg aws.Config, logger *slog.L
 	alertConfig := DefaultBudgetAlertConfig()
 	notifier := NewBudgetAlertNotifier(alertConfig, awsCfg)
 
+	// Load persisted project budgets so `budget set` survives across CLI
+	// invocations (#241). Budgets from the config file (if any) take precedence
+	// over the persisted store for the same project ID.
+	if persisted, err := loadProjectBudgets(); err != nil {
+		logger.Warn("failed to load persisted project budgets", "error", err)
+	} else if len(persisted) > 0 {
+		if cfg.ProjectBudgets == nil {
+			cfg.ProjectBudgets = make(map[string]config.ProjectBudget)
+		}
+		for id, b := range persisted {
+			if _, exists := cfg.ProjectBudgets[id]; !exists {
+				cfg.ProjectBudgets[id] = b
+			}
+		}
+	}
+
 	return &Manager{
 		config:        cfg,
 		pricingMgr:    pricingMgr,

--- a/pkg/multiregion/load_balancer_test.go
+++ b/pkg/multiregion/load_balancer_test.go
@@ -386,8 +386,13 @@ func TestDefaultLoadBalancer_WeightedDistribution(t *testing.T) {
 
 	selections := make(map[string]int)
 
-	// Run many selections to test distribution
-	for i := 0; i < 100; i++ {
+	// Run many selections to test distribution. Routing is randomized (80/20
+	// weights → ~4:1 expected), so use a large sample: with 100 samples the
+	// observed ratio occasionally dipped below the 2:1 floor and flaked in CI
+	// (seen at 1.86). 4000 samples shrinks the variance enough that a 2:1 floor
+	// is effectively never breached while still asserting the weighting works.
+	const samples = 4000
+	for i := 0; i < samples; i++ {
 		request := &UploadRequest{
 			FilePath: "/test/file.txt",
 			Size:     1024,
@@ -401,9 +406,9 @@ func TestDefaultLoadBalancer_WeightedDistribution(t *testing.T) {
 	// us-east-1 should be selected more often due to higher weight
 	assert.Greater(t, selections["us-east-1"], selections["us-west-2"])
 
-	// Rough check - us-east-1 should get roughly 4x more selections
+	// Expected ratio is ~4:1; assert a conservative 2:1 floor.
 	ratio := float64(selections["us-east-1"]) / float64(selections["us-west-2"])
-	assert.Greater(t, ratio, 2.0) // At least 2:1 ratio
+	assert.Greater(t, ratio, 2.0, "80/20 weighting should yield >2:1 (expected ~4:1)")
 }
 
 func TestDefaultLoadBalancer_StartSessionCleanup(t *testing.T) {

--- a/tests/e2e/commands_test.go
+++ b/tests/e2e/commands_test.go
@@ -100,11 +100,15 @@ func TestCostBenchmarkCompare(t *testing.T) {
 	}
 }
 
-// TestBudgetSet exercises `budget set`. NOTE: budget state does not persist
-// across processes yet (#241 — cost.Manager storage is a TODO stub), so we only
-// assert the command runs and reports success. Upgrade to a set→status
-// round-trip once #241 lands.
-func TestBudgetSet(t *testing.T) {
+// TestBudgetSetStatus_RoundTrip sets a project budget in one process and reads
+// it back in another, asserting it persisted (#241). Uses an isolated on-disk
+// store via CARGOSHIP_BUDGET_STORE so it doesn't touch the developer's real
+// ~/.cargoship/budgets.json.
+func TestBudgetSetStatus_RoundTrip(t *testing.T) {
+	store := filepath.Join(t.TempDir(), "budgets.json")
+	t.Setenv("CARGOSHIP_BUDGET_STORE", store)
+
+	// Set the budget (one process).
 	out, err := runCargoshipAllowErr(t, "budget", "set", "e2e-proj",
 		"--cost", "100", "--volume", "50")
 	if err != nil {
@@ -112,6 +116,15 @@ func TestBudgetSet(t *testing.T) {
 	}
 	if !strings.Contains(out, "Budget set for project") {
 		t.Fatalf("budget set output missing confirmation:\n%s", out)
+	}
+
+	// Read it back (a fresh process) — it must have persisted.
+	status, err := runCargoshipAllowErr(t, "budget", "status", "e2e-proj")
+	if err != nil {
+		t.Fatalf("budget status failed (did the budget persist?): %v\n%s", err, status)
+	}
+	if !strings.Contains(status, "$100.00") {
+		t.Fatalf("budget status did not report the persisted $100.00 budget:\n%s", status)
 	}
 }
 


### PR DESCRIPTION
Fixes #241.

## The bug

`cargoship budget set <project>` reported success, but `budget status <project>`
in a fresh process failed with "no budget configured" — `cost.Manager` held
`ProjectBudgets` only in memory, and every CLI command builds a new Manager, so
budgets never survived. The documented budget/cost workflow was non-functional
across invocations.

## The fix

- **`pkg/aws/cost/budget_store.go`** (new) — persist the `ProjectBudgets` map to
  `$XDG_DATA_HOME/cargoship/budgets.json` (or `~/.cargoship/budgets.json`),
  matching the `restore`/`resume` state-dir convention. Atomic write (temp file +
  rename), `0600`. `CARGOSHIP_BUDGET_STORE` overrides the path.
- **`SetProjectBudget` / `DeleteProjectBudget`** persist after mutating the map.
- **`NewManager`** loads persisted budgets on construction (config-file budgets
  win over the store for the same project ID).
- **`GetProjectBudgetStatus`** no longer errors when a budget exists but has no
  spend recorded yet (fresh `budget set`) — reports `$0.00` spent instead of
  "no cost records found".

## Tests

- `budget_store_test.go` — save/load round-trip, missing-file-is-empty, overwrite.
- Package `TestMain` isolates the store to a temp dir; the four budget-mutating
  unit tests get a per-test store so they never read the real
  `~/.cargoship/budgets.json` (this is why they'd have flaked otherwise).
- **e2e `TestBudgetSetStatus_RoundTrip`** — set in one process, read back in
  another, assert the `$100` budget persisted. Replaces the prior runs-only
  assertion (which was a placeholder pending this fix).

## Verified

`budget set` → `budget status` across separate processes now shows the budget;
`list`/`remove` persist too. Full `pkg/aws/cost` suite green (72.4% cov); e2e
suite green.

Found during #238 Phase 2.