### PR TITLE
test: nightly real-AWS CI job + CI-runnable real-AWS suites (#238 Phase 5)

### DIFF
--- a/.github/workflows/nightly-aws.yml
+++ b/.github/workflows/nightly-aws.yml
@@ -1,0 +1,84 @@
+name: Nightly Real-AWS Integration
+
+# Phase 5 of #238: run the credential-gated real-AWS integration suites against
+# a real S3 bucket in a sandbox account. This is intentionally NOT a PR job —
+# it needs real credentials and mutates a real bucket, so it runs on a schedule
+# (and on demand) instead of slowing every pull request. The emulator-based
+# integration job in test.yml already guards PRs credential-free.
+#
+# Credentials are obtained via GitHub OIDC (no long-lived keys). The job is a
+# no-op unless the repository provides the role + bucket, so forks and clones
+# without the secrets configured don't fail:
+#   - secret AWS_NIGHTLY_ROLE_ARN — IAM role to assume via OIDC
+#   - variable AWS_NIGHTLY_REGION — region (defaults to us-west-2)
+#   - variable AWS_NIGHTLY_BUCKET — pre-existing test bucket
+
+on:
+  schedule:
+    # 07:00 UTC daily (~midnight US Pacific), off the PR critical path.
+    - cron: '0 7 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write # required for OIDC role assumption
+  contents: read
+
+env:
+  GO_VERSION: '1.26'
+
+jobs:
+  real-aws:
+    name: Real-AWS integration (sandbox)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check for AWS role configuration
+        id: guard
+        env:
+          ROLE_ARN: ${{ secrets.AWS_NIGHTLY_ROLE_ARN }}
+        run: |
+          if [ -z "$ROLE_ARN" ]; then
+            echo "AWS_NIGHTLY_ROLE_ARN not set — skipping real-AWS suite (expected on forks)."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.guard.outputs.configured == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        if: steps.guard.outputs.configured == 'true'
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.guard.outputs.configured == 'true'
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_NIGHTLY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_NIGHTLY_REGION || 'us-west-2' }}
+
+      - name: Download dependencies
+        if: steps.guard.outputs.configured == 'true'
+        run: go mod download
+
+      # Runs the //go:build integration suites with the real-AWS gate enabled.
+      # Suites that don't touch S3 (or gate on the emulator) self-skip; the
+      # real-AWS suites resolve credentials from the default chain (provided by
+      # the OIDC step above — no AWS_PROFILE) and the bucket from
+      # CARGOSHIP_TEST_BUCKET. The large-file suite stays opt-in (it needs tens
+      # of GB); enable it explicitly here since this lane has the time budget.
+      - name: Run real-AWS integration tests
+        if: steps.guard.outputs.configured == 'true'
+        env:
+          CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS: '1'
+          CARGOSHIP_ENABLE_AWS_INTEGRATION_TESTS: 'true'
+          CARGOSHIP_ENABLE_LARGE_FILE_TESTS: '1'
+          CARGOSHIP_QUICK_LARGE_FILE_TEST: 'true'
+          CARGOSHIP_TEST_BUCKET: ${{ vars.AWS_NIGHTLY_BUCKET }}
+          AWS_REGION: ${{ vars.AWS_NIGHTLY_REGION || 'us-west-2' }}
+        run: go test -tags integration ./... -timeout 40m

--- a/pkg/aws/s3/real_aws_integration_test.go
+++ b/pkg/aws/s3/real_aws_integration_test.go
@@ -24,19 +24,32 @@ import (
 	"github.com/scttfrdmn/cargoship/pkg/s3optimization"
 )
 
-const (
-	transpTestProfile = "aws"
-	transpTestRegion  = "us-west-2"
-	transpTestBucket  = "cargoship-integration-test"
-	transpTestPrefix  = "transporter-test"
+const transpTestPrefix = "transporter-test"
+
+// Region and bucket are resolved from the standard env knobs so the suite runs
+// both locally (AWS_PROFILE=aws, defaults below) and in CI (creds from the
+// default chain, bucket from CARGOSHIP_TEST_BUCKET).
+var (
+	transpTestRegion = firstNonEmpty(os.Getenv("AWS_REGION"), "us-west-2")
+	transpTestBucket = firstNonEmpty(os.Getenv("CARGOSHIP_TEST_BUCKET"), "cargoship-integration-test")
 )
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
 
 // TestCargoShipTransporterIntegration tests all CargoShip transporters with real AWS S3.
 //
-// This is a REAL-AWS test: it needs the shared "aws" profile, real credentials,
-// and a real bucket. It is not part of the emulator PR job — it self-skips unless
-// CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS=1 and the profile actually loads. It runs
-// in the nightly real-AWS job. (#238 Phase 5)
+// This is a REAL-AWS test: it needs real credentials and a real bucket. It is
+// not part of the emulator PR job — it self-skips unless
+// CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS=1 and AWS config actually loads. It runs
+// in the scheduled nightly real-AWS workflow (.github/workflows/nightly-aws.yml,
+// #238 Phase 5), and locally via AWS_PROFILE=aws.
 func TestCargoShipTransporterIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -48,13 +61,15 @@ func TestCargoShipTransporterIntegration(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	// Load AWS config (real credentials via the shared profile).
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithSharedConfigProfile(transpTestProfile),
-		config.WithRegion(transpTestRegion),
-	)
+	// Use AWS_PROFILE when set (local dev, e.g. "aws"); otherwise fall back to
+	// the default credential chain (env/OIDC), which is how CI supplies creds.
+	opts := []func(*config.LoadOptions) error{config.WithRegion(transpTestRegion)}
+	if profile := os.Getenv("AWS_PROFILE"); profile != "" {
+		opts = append(opts, config.WithSharedConfigProfile(profile))
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
-		t.Skipf("Skipping: real AWS profile %q not available: %v", transpTestProfile, err)
+		t.Skipf("Skipping: AWS config not available: %v", err)
 	}
 
 	s3Client := s3.NewFromConfig(cfg)

--- a/pkg/s3optimization/integration_test.go
+++ b/pkg/s3optimization/integration_test.go
@@ -38,7 +38,18 @@ var (
 
 func TestMain(m *testing.M) {
 	if os.Getenv("CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS") == "1" {
-		testRegion = "us-west-2" // real AWS path uses existing values
+		// Real AWS path. Honor the standard env knobs so the suite is runnable
+		// both locally (AWS_PROFILE=aws) and in CI (creds from the default chain,
+		// bucket from CARGOSHIP_TEST_BUCKET). Fall back to the historical
+		// hardcoded values when unset.
+		if b := os.Getenv("CARGOSHIP_TEST_BUCKET"); b != "" {
+			testBucket = b
+		}
+		if r := os.Getenv("AWS_REGION"); r != "" {
+			testRegion = r
+		} else {
+			testRegion = "us-west-2"
+		}
 	} else {
 		url, cancel, err := launchSubstrate()
 		if err != nil {
@@ -124,11 +135,14 @@ func getTestS3Client(ctx context.Context) *s3.Client {
 		}
 		return s3.NewFromConfig(cfg, func(o *s3.Options) { o.UsePathStyle = true })
 	}
-	// Real AWS path
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithSharedConfigProfile("aws"),
-		config.WithRegion(testRegion),
-	)
+	// Real AWS path. Use AWS_PROFILE when set (local dev, e.g. "aws"); otherwise
+	// fall back to the default credential chain (env/OIDC), which is how CI
+	// supplies credentials.
+	opts := []func(*config.LoadOptions) error{config.WithRegion(testRegion)}
+	if profile := os.Getenv("AWS_PROFILE"); profile != "" {
+		opts = append(opts, config.WithSharedConfigProfile(profile))
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
 		panic(fmt.Sprintf("failed to load AWS config: %v", err))
 	}


### PR DESCRIPTION
## Summary

Phase 5 of #238. Adds a scheduled real-AWS integration job so emulator/real-S3 divergence gets caught without slowing PRs.

### New workflow — `.github/workflows/nightly-aws.yml`
- Runs `07:00 UTC` daily + `workflow_dispatch`, **not** on PRs (needs real creds, mutates a real bucket).
- Credentials via **GitHub OIDC** (`aws-actions/configure-aws-credentials`, SHA-pinned) — no long-lived keys.
- **No-ops gracefully** if `AWS_NIGHTLY_ROLE_ARN` secret isn't set (forks/clones don't fail).
- Runs `go test -tags integration ./...` with the real-AWS gates on; also enables the (quick) large-file suite since this lane has the time budget.

### Made two real-AWS suites CI-runnable
`pkg/aws/s3/real_aws_integration_test.go` and `pkg/s3optimization/integration_test.go` hardcoded `WithSharedConfigProfile("aws")` + bucket `cargoship-integration-test` — fine locally, unrunnable in CI (no "aws" profile there). Normalized both to the env-driven pattern already used by the manifest/dvc suites:
- `AWS_PROFILE` when set (local dev) → else default credential chain (CI/OIDC)
- bucket from `CARGOSHIP_TEST_BUCKET`, region from `AWS_REGION`

Also fixed a stale comment in `real_aws_integration_test.go` that claimed a nightly job existed before one did.

## Testing
- Both suites **pass against real S3** (us-west-2, env-driven creds/bucket) — verified locally.
- Both suites **still pass against the emulator** (unchanged path).
- No product code touched; test/CI only. Pre-commit gates green (A+).

## Maintainer setup required to activate
The job stays dormant until the repo provides:
- secret `AWS_NIGHTLY_ROLE_ARN` — IAM role trusting this repo's OIDC
- variables `AWS_NIGHTLY_BUCKET` (pre-existing test bucket) and optionally `AWS_NIGHTLY_REGION` (default `us-west-2`)

Part of #238 (Phase 5). Phases 3, 4, 6 follow in separate PRs.