### PR TITLE
test: per-package coverage ratchet + CI enforcement (#238 Phase 6)

### DIFF
--- a/.coverage-baseline
+++ b/.coverage-baseline
@@ -3,6 +3,12 @@
 # Monotonic: raise a floor when coverage improves; never lower it without cause.
 # Regenerate/raise with: scripts/ci/coverage-ratchet.sh --update
 # Project-wide floor is PROJECT_FLOOR in the script (currently 56).
+#
+# Seed from a CI-equivalent environment. pkg/detection is intentionally floored
+# low (~34) because its Magika tests self-skip when the `magika` CLI is absent,
+# which is the case in CI; a local run WITH magika reports ~92%. Do not `--update`
+# this file from a machine with magika installed, or the detection floor will be
+# raised to a value CI can't meet.
 cmd/cargoship 60
 cmd/cargoship-cost 57
 cmd/cargoship-launch 49
@@ -26,7 +32,7 @@ pkg/compression 92
 pkg/config 92
 pkg/context 40
 pkg/controller 39
-pkg/detection 92
+pkg/detection 34
 pkg/encryption 82
 pkg/errors 99
 pkg/extraction 85

--- a/.coverage-baseline
+++ b/.coverage-baseline
@@ -1,0 +1,51 @@
+# CargoShip per-package coverage ratchet baseline.
+# Format: <package> <min-percent>. Coverage must not drop below the floor.
+# Monotonic: raise a floor when coverage improves; never lower it without cause.
+# Regenerate/raise with: scripts/ci/coverage-ratchet.sh --update
+# Project-wide floor is PROJECT_FLOOR in the script (currently 56).
+cmd/cargoship 60
+cmd/cargoship-cost 57
+cmd/cargoship-launch 49
+cmd/cargoship-test 0
+cmd/cargoship/cmd 22
+cmd/controller 17
+cmd/ghost-ship 0
+cmd/launch-server 0
+internal/testutil 84
+pkg/archivefs 98
+pkg/aws/config 89
+pkg/aws/cost 72
+pkg/aws/costs 18
+pkg/aws/lifecycle 90
+pkg/aws/metrics 100
+pkg/aws/pricing 90
+pkg/aws/s3 74
+pkg/benchmarks 0
+pkg/chunking 82
+pkg/compression 92
+pkg/config 92
+pkg/context 40
+pkg/controller 39
+pkg/detection 92
+pkg/encryption 82
+pkg/errors 99
+pkg/extraction 85
+pkg/gpg 88
+pkg/ioutils 53
+pkg/launch 5
+pkg/manifest 75
+pkg/migration 0
+pkg/monitoring 39
+pkg/multiregion 72
+pkg/observability/metrics 79
+pkg/observability/tracing 65
+pkg/pipeline 57
+pkg/profiling 0
+pkg/progress 99
+pkg/repl 41
+pkg/restore 76
+pkg/resume 41
+pkg/s3optimization 58
+pkg/staging 81
+pkg/testutils 76
+pkg/tui 74

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,8 +17,12 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Coverage requirements - Progressive targets
-PROJECT_COVERAGE_TARGET=56  # Current: 56.4%, Goal: 85% (temporarily lowered to allow Issue #28 commit)
-INDIVIDUAL_FILE_COVERAGE_TARGET=56  # Temporarily lowered to match project-wide target; many cmd/ and pkg/ packages need test work
+PROJECT_COVERAGE_TARGET=56  # Current: ~56%, Goal: 85%. Project-wide hard floor.
+# Per-package floors are enforced by the monotonic ratchet in
+# scripts/ci/coverage-ratchet.sh against .coverage-baseline (#238 Phase 6).
+# INDIVIDUAL_FILE_COVERAGE_TARGET is only a fallback for when that script or the
+# baseline is absent (see run_tests below).
+INDIVIDUAL_FILE_COVERAGE_TARGET=56
 
 # Helper functions
 log_info() {
@@ -141,27 +145,42 @@ run_tests() {
     local project_coverage=0
     if [ -f coverage.out ]; then
         project_coverage=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
-        rm -f coverage.out
     fi
-    
+
     rm -f test_output.tmp
-    
+
     log_info "Project coverage: ${project_coverage}% (target: ${PROJECT_COVERAGE_TARGET}%)"
-    
+
     # Check project coverage
     if (( $(echo "$project_coverage < $PROJECT_COVERAGE_TARGET" | bc -l) )); then
         log_error "Project coverage (${project_coverage}%) is below target (${PROJECT_COVERAGE_TARGET}%)"
+        rm -f coverage.out
         exit 1
     fi
-    
-    # Check individual package coverage (warning only; project-wide check is the hard gate)
-    if [ ${#failed_packages[@]} -gt 0 ]; then
-        log_warning "The following packages have coverage below ${INDIVIDUAL_FILE_COVERAGE_TARGET}% (non-blocking):"
-        for package in "${failed_packages[@]}"; do
-            log_warning "  $package"
-        done
+
+    # Per-package coverage ratchet (#238 Phase 6): fail if any package regressed
+    # below its recorded floor in .coverage-baseline. This is the hard per-package
+    # gate that replaces the old warning-only flat check; reuse the profile just
+    # generated so we don't run the suite a third time.
+    if [ -f scripts/ci/coverage-ratchet.sh ] && [ -f .coverage-baseline ]; then
+        if ! bash scripts/ci/coverage-ratchet.sh --profile coverage.out --check; then
+            log_error "Coverage ratchet failed — a package dropped below its floor (see above)."
+            log_error "If the drop is intentional, justify it and lower the floor in .coverage-baseline."
+            rm -f coverage.out
+            exit 1
+        fi
+        log_info "Coverage ratchet passed (no package below its floor)."
+    else
+        # Fall back to the legacy warning-only per-package report.
+        if [ ${#failed_packages[@]} -gt 0 ]; then
+            log_warning "The following packages have coverage below ${INDIVIDUAL_FILE_COVERAGE_TARGET}% (non-blocking):"
+            for package in "${failed_packages[@]}"; do
+                log_warning "  $package"
+            done
+        fi
     fi
-    
+
+    rm -f coverage.out
     log_success "All tests passed with sufficient coverage"
 }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,13 @@ jobs:
       - name: Run tests with coverage
         run: go test ./... -short -coverprofile=coverage.out -covermode=atomic -timeout=10m
 
+      # Per-package coverage ratchet (#238 Phase 6): enforce that no package
+      # regressed below its floor in .coverage-baseline. Reuses the profile just
+      # generated. This is CI's only hard coverage gate (Codecov below is
+      # informational, continue-on-error).
+      - name: Enforce coverage ratchet
+        run: bash scripts/ci/coverage-ratchet.sh --profile coverage.out --check
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         continue-on-error: true

--- a/scripts/ci/coverage-ratchet.sh
+++ b/scripts/ci/coverage-ratchet.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# coverage-ratchet.sh — per-package coverage ratchet for CargoShip (#238 Phase 6).
+#
+# Replaces the single flat project-wide floor with monotonic per-package floors
+# recorded in .coverage-baseline. A package may never regress below its recorded
+# floor (minus a small tolerance for run-to-run noise); when coverage improves,
+# run --update to raise the floor so the gain can't silently erode later.
+#
+# Usage:
+#   coverage-ratchet.sh [--check]     Verify coverage against the baseline (default).
+#   coverage-ratchet.sh --update      Raise floors to current coverage; add new packages.
+#   coverage-ratchet.sh --profile P   Use an existing coverage profile instead of re-running tests.
+#
+# Exit codes: 0 = ok, 1 = a package regressed / project floor breached, 2 = usage.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+BASELINE_FILE=".coverage-baseline"
+MODULE_PREFIX="github.com/scttfrdmn/cargoship/"
+
+# Project-wide hard floor (matches the historical pre-commit gate).
+PROJECT_FLOOR=56
+# Per-package tolerance: coverage may dip this many points below a recorded floor
+# before it's treated as a regression (absorbs nondeterministic timing tests).
+TOLERANCE=1
+
+MODE="check"
+PROFILE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) MODE="check" ;;
+    --update) MODE="update" ;;
+    --profile) PROFILE="${2:-}"; shift ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# Produce a coverage profile unless one was supplied.
+if [ -z "$PROFILE" ]; then
+  PROFILE="$(mktemp -t cargoship-cov.XXXXXX)"
+  trap 'rm -f "$PROFILE"' EXIT
+  echo "Running tests with coverage (this can take a couple of minutes)..." >&2
+  # -short + exclude examples: mirror the pre-commit / CI coverage job exactly.
+  # shellcheck disable=SC2046 # intentional word-splitting to pass package args
+  go test -short -timeout=300s -coverprofile="$PROFILE" -covermode=atomic \
+    $(go list ./... | grep -v '/examples/') >/dev/null 2>&1 || true
+fi
+
+if [ ! -s "$PROFILE" ]; then
+  echo "ERROR: coverage profile is empty ($PROFILE)" >&2
+  exit 1
+fi
+
+# Per-package covered/total statement counts, computed directly from the profile
+# lines: "<file>:<startline>.<col>,<endline>.<col> <numstmts> <count>". A single
+# awk pass aggregates by package directory (the profile has ~20k lines, so a
+# bash while-loop with per-line subprocesses is far too slow). Example/demo
+# packages are excluded to match the pre-commit and baseline convention.
+#
+# Output lines: "<pkg> <pct>" (integer percent, floored).
+declare -A cur_pct
+while read -r pkg pct; do
+  [ -z "$pkg" ] && continue
+  cur_pct["$pkg"]="$pct"
+done < <(awk -v prefix="$MODULE_PREFIX" '
+  NR == 1 && $0 ~ /^mode:/ { next }
+  {
+    # Field layout: last field = exec count, second-last = num statements,
+    # first field up to ":" = file path.
+    n = $(NF-1); c = $NF
+    colon = index($1, ":")
+    file = substr($1, 1, colon - 1)
+    # package dir = file path without the trailing "/<basename>"
+    slash = 0
+    for (i = length(file); i > 0; i--) { if (substr(file, i, 1) == "/") { slash = i; break } }
+    pkg = substr(file, 1, slash - 1)
+    sub("^" prefix, "", pkg)
+    if (pkg ~ /(^|\/)examples(\/|$)/) next
+    stmts[pkg] += n
+    tot_stmts += n
+    if (c != "0") { covered[pkg] += n; tot_covered += n }
+  }
+  END {
+    for (p in stmts) if (stmts[p] > 0) printf "%s %d\n", p, covered[p] * 100 / stmts[p]
+    if (tot_stmts > 0) printf "__TOTAL__ %d\n", tot_covered * 100 / tot_stmts
+  }
+' "$PROFILE")
+
+# Split the project total out of the per-package map.
+project_pct="${cur_pct[__TOTAL__]:-0}"
+unset 'cur_pct[__TOTAL__]'
+
+# Load recorded floors.
+declare -A floor
+if [ -f "$BASELINE_FILE" ]; then
+  while read -r pkg pct; do
+    [ -z "$pkg" ] && continue
+    case "$pkg" in \#*) continue ;; esac
+    floor["$pkg"]="$pct"
+  done < "$BASELINE_FILE"
+fi
+
+if [ "$MODE" = "update" ]; then
+  # Raise floors to current coverage; add newly-covered packages; keep existing
+  # floor when current dipped (monotonic — never auto-lower).
+  {
+    echo "# CargoShip per-package coverage ratchet baseline."
+    echo "# Format: <package> <min-percent>. Coverage must not drop below the floor."
+    echo "# Monotonic: raise a floor when coverage improves; never lower it without cause."
+    echo "# Regenerate/raise with: scripts/ci/coverage-ratchet.sh --update"
+    echo "# Project-wide floor is PROJECT_FLOOR in the script (currently ${PROJECT_FLOOR})."
+    for pkg in $(printf '%s\n' "${!cur_pct[@]}" "${!floor[@]}" | sort -u); do
+      c="${cur_pct[$pkg]:-}"
+      f="${floor[$pkg]:-0}"
+      if [ -n "$c" ] && [ "$c" -gt "$f" ]; then
+        printf '%s %d\n' "$pkg" "$c"
+      else
+        printf '%s %d\n' "$pkg" "$f"
+      fi
+    done
+  } > "$BASELINE_FILE"
+  echo "Updated $BASELINE_FILE."
+  exit 0
+fi
+
+# --check
+fail=0
+echo "Project coverage: ${project_pct}% (floor: ${PROJECT_FLOOR}%, tolerance: ${TOLERANCE})"
+# Apply the per-package tolerance to the project total too: measured coverage
+# varies ~±1% run-to-run (concurrency/timing-sensitive tests), so gate on
+# PROJECT_FLOOR - TOLERANCE to avoid spurious CI failures while keeping the
+# documented target at PROJECT_FLOOR.
+if [ "$project_pct" -lt $(( PROJECT_FLOOR - TOLERANCE )) ]; then
+  echo "FAIL: project coverage ${project_pct}% below floor ${PROJECT_FLOOR}% (tolerance ${TOLERANCE})" >&2
+  fail=1
+fi
+
+for pkg in $(printf '%s\n' "${!floor[@]}" | sort); do
+  f="${floor[$pkg]}"
+  c="${cur_pct[$pkg]:-}"
+  if [ -z "$c" ]; then
+    # Package in baseline but absent from this run (e.g. no test files now).
+    echo "WARN: $pkg in baseline but not measured this run" >&2
+    continue
+  fi
+  if [ "$c" -lt $(( f - TOLERANCE )) ]; then
+    echo "FAIL: $pkg coverage ${c}% dropped below floor ${f}% (tolerance ${TOLERANCE})" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "Coverage ratchet OK: no package regressed below its floor."
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

Phase 6 of #238. Replaces the flat, warning-only 56% floor with a **monotonic per-package coverage ratchet**, and makes CI actually enforce coverage (it previously only uploaded to Codecov).

### What's added
- **`.coverage-baseline`** — committed per-package floors, seeded from current coverage (40 packages). Hotspots now have floors that can only rise: `cmd/cargoship/cmd 22`, `pkg/aws/costs 18`, `pkg/launch 5`, `cmd/controller 17`.
- **`scripts/ci/coverage-ratchet.sh`** — computes per-package statement coverage from a profile (single `awk` pass — ~0.1s on the 20k-line profile), fails if any package drops below its floor (1-pt tolerance for run-to-run noise), excludes `examples/`, and supports `--update` to raise floors monotonically.
- **`.githooks/pre-commit`** — now a **hard** per-package gate via the ratchet, reusing the coverage profile it already builds (no extra test run). Legacy warning-only check retained as a fallback.
- **`test.yml`** coverage job — new **"Enforce coverage ratchet"** step. CI previously enforced nothing.

### Design notes
- The **project total** is gated at `floor − tolerance` because measured coverage varies ~±1% run-to-run (concurrency/timing-sensitive tests); the **per-package floors** are the real ratchet.
- `--update` never auto-lowers a floor — a genuine, justified drop requires a manual edit to `.coverage-baseline`, which shows up in review.

### Verified
- Ratchet passes on both the pre-commit-style and CI-style profiles.
- Regression path confirmed (bumping a floor makes it FAIL).
- The pre-commit hook ran the new ratchet live during commit — passed.

Part of #238 (Phase 6). Phase 3 (fixtures + golden files) is the last remaining phase.