### PR TITLE
refactor: unify S3 fallback pricing + fix archival PUT pricing (Fixes #237)

### DIFF
--- a/pkg/aws/cost/pricing.go
+++ b/pkg/aws/cost/pricing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/pricing"
 	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/aws/pricingfallback"
 )
 
 // PricingManager handles cost calculations with AWS Pricing API integration
@@ -245,14 +246,14 @@ func (pm *PricingManager) getRequestPrice(ctx context.Context, requestType strin
 		apiPrice, err := pm.getAWSRequestPrice(ctx, strings.ToUpper(requestType), region)
 		if err != nil {
 			pm.logger.Warn("Failed to get AWS request pricing, using fallback", "error", err)
-			price = pm.getFallbackRequestPrice(requestType)
+			price = pm.getFallbackRequestPrice(requestType, storageClass)
 			pm.setCachedPrice(cacheKey, price, "fallback")
 		} else {
 			price = apiPrice
 			pm.setCachedPrice(cacheKey, price, "aws_api")
 		}
 	} else {
-		price = pm.getFallbackRequestPrice(requestType)
+		price = pm.getFallbackRequestPrice(requestType, storageClass)
 		pm.setCachedPrice(cacheKey, price, "fallback")
 	}
 
@@ -426,39 +427,19 @@ func (pm *PricingManager) getAWSRequestPrice(ctx context.Context, requestType, r
 	return perRequest * 1000, nil
 }
 
-// Fallback pricing methods
+// Fallback pricing methods delegate to the canonical pricingfallback tables so
+// the numbers are defined in exactly one place (#237).
 func (pm *PricingManager) getFallbackStoragePrice(storageClass config.StorageClass) float64 {
-	// These are approximate AWS S3 prices as of 2024 (USD per GB per month)
-	switch storageClass {
-	case config.StorageClassStandard:
-		return 0.023
-	case config.StorageClassStandardIA:
-		return 0.0125
-	case config.StorageClassOneZoneIA:
-		return 0.01
-	case config.StorageClassIntelligentTiering:
-		return 0.023 // Same as Standard + monitoring
-	case config.StorageClassGlacier:
-		return 0.004
-	case config.StorageClassDeepArchive:
-		return 0.00099
-	default:
-		return 0.023
-	}
+	return pricingfallback.StoragePrice(storageClass)
 }
 
-func (pm *PricingManager) getFallbackRequestPrice(requestType string) float64 {
-	// Approximate AWS S3 request prices (USD per 1000 requests), STANDARD tier.
-	switch strings.ToUpper(requestType) {
-	case "PUT", "POST", "COPY", "LIST":
-		return 0.005 // $0.005 per 1,000 PUT/COPY/POST/LIST requests
-	case "GET", "SELECT":
-		return 0.0004 // $0.0004 per 1,000 GET/SELECT requests
-	case "DELETE":
-		return 0.0
-	default:
-		return 0.005
-	}
+// getFallbackRequestPrice returns the per-1000 request price for a verb and
+// storage class. PUT/COPY/POST/LIST prices vary by storage class (archival
+// classes cost far more per request than Standard); GET/SELECT and DELETE are
+// verb-only. Previously this ignored storageClass and priced every PUT at the
+// Standard rate, undercounting Glacier/Deep-Archive uploads (#237).
+func (pm *PricingManager) getFallbackRequestPrice(requestType string, storageClass config.StorageClass) float64 {
+	return pricingfallback.RequestPrice(requestType, storageClass)
 }
 
 // Cache management methods

--- a/pkg/aws/costs/calculator.go
+++ b/pkg/aws/costs/calculator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/scttfrdmn/cargoship/pkg/aws/config"
 	"github.com/scttfrdmn/cargoship/pkg/aws/pricing"
+	"github.com/scttfrdmn/cargoship/pkg/aws/pricingfallback"
 	"github.com/scttfrdmn/cargoship/pkg/aws/s3"
 )
 
@@ -177,22 +178,8 @@ func (c *Calculator) calculateStorageCost(ctx context.Context, sizeGB float64, s
 		// Note: In production, consider more sophisticated error handling
 	}
 
-	// Fallback pricing (original static prices)
-	pricePerGB := map[config.StorageClass]float64{
-		config.StorageClassStandard:           0.023,   // $0.023/GB
-		config.StorageClassStandardIA:         0.0125,  // $0.0125/GB
-		config.StorageClassOneZoneIA:          0.01,    // $0.01/GB
-		config.StorageClassIntelligentTiering: 0.0225,  // $0.0225/GB + monitoring
-		config.StorageClassGlacier:            0.004,   // $0.004/GB
-		config.StorageClassDeepArchive:        0.00099, // $0.00099/GB
-	}
-
-	price, exists := pricePerGB[storageClass]
-	if !exists {
-		price = pricePerGB[config.StorageClassStandard] // Default fallback
-	}
-
-	return sizeGB * price
+	// Fallback pricing from the canonical table (#237).
+	return sizeGB * pricingfallback.StoragePrice(storageClass)
 }
 
 // calculateTransferCost calculates data transfer cost (first 1GB free)
@@ -227,22 +214,8 @@ func (c *Calculator) calculateRequestCost(ctx context.Context, numRequests int, 
 		}
 	}
 
-	// Fallback pricing per 1,000 requests
-	pricePerThousand := map[config.StorageClass]float64{
-		config.StorageClassStandard:           0.005, // $0.005/1K requests
-		config.StorageClassStandardIA:         0.01,  // $0.01/1K requests
-		config.StorageClassOneZoneIA:          0.01,  // $0.01/1K requests
-		config.StorageClassIntelligentTiering: 0.005, // $0.005/1K requests
-		config.StorageClassGlacier:            0.03,  // $0.03/1K requests
-		config.StorageClassDeepArchive:        0.05,  // $0.05/1K requests
-	}
-
-	price, exists := pricePerThousand[storageClass]
-	if !exists {
-		price = pricePerThousand[config.StorageClassStandard]
-	}
-
-	return (float64(numRequests) / 1000.0) * price
+	// Fallback pricing per 1,000 PUT requests from the canonical table (#237).
+	return (float64(numRequests) / 1000.0) * pricingfallback.PutRequestPrice(storageClass)
 }
 
 // generateRecommendations creates cost optimization recommendations

--- a/pkg/aws/pricing/service.go
+++ b/pkg/aws/pricing/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/pricing/types"
 
 	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/aws/pricingfallback"
 )
 
 // PricingClient interface for AWS pricing operations
@@ -409,26 +410,20 @@ func (s *Service) setFallbackStoragePricing(priceData *PriceData, region string)
 		multiplier = 1.1 // 10% higher for most non-US regions
 	}
 
-	priceData.StoragePrice = map[config.StorageClass]float64{
-		config.StorageClassStandard:           0.023 * multiplier,
-		config.StorageClassStandardIA:         0.0125 * multiplier,
-		config.StorageClassOneZoneIA:          0.01 * multiplier,
-		config.StorageClassIntelligentTiering: 0.0225 * multiplier,
-		config.StorageClassGlacier:            0.004 * multiplier,
-		config.StorageClassDeepArchive:        0.00099 * multiplier,
+	// Base numbers come from the canonical fallback table (#237); the regional
+	// multiplier is applied on top.
+	priceData.StoragePrice = pricingfallback.StoragePriceTable()
+	for sc, p := range priceData.StoragePrice {
+		priceData.StoragePrice[sc] = p * multiplier
 	}
 }
 
-// setFallbackRequestPricing sets fallback request pricing
+// setFallbackRequestPricing sets fallback request pricing from the canonical
+// table. This previously carried its own copy of the request prices that was
+// 10x too low across the board (Standard 0.0005 vs the correct 0.005) — the same
+// class of bug as #233, in a third location (#237).
 func (s *Service) setFallbackRequestPricing(priceData *PriceData) {
-	priceData.RequestPrice = map[config.StorageClass]float64{
-		config.StorageClassStandard:           0.0005,
-		config.StorageClassStandardIA:         0.001,
-		config.StorageClassOneZoneIA:          0.001,
-		config.StorageClassIntelligentTiering: 0.0005,
-		config.StorageClassGlacier:            0.003,
-		config.StorageClassDeepArchive:        0.005,
-	}
+	priceData.RequestPrice = pricingfallback.PutRequestPriceTable()
 }
 
 // InvalidateCache clears the pricing cache for a region

--- a/pkg/aws/pricing/service_test.go
+++ b/pkg/aws/pricing/service_test.go
@@ -640,6 +640,19 @@ func TestService_setFallbackRequestPricing(t *testing.T) {
 			t.Errorf("setFallbackRequestPricing() invalid price %v for %v", price, class)
 		}
 	}
+
+	// Pin the corrected canonical values (#237). This table was previously 10x
+	// too low here (Standard 0.0005); a >0 check let that bug survive.
+	wantExact := map[config.StorageClass]float64{
+		config.StorageClassStandard:    0.005,
+		config.StorageClassGlacier:     0.03,
+		config.StorageClassDeepArchive: 0.05,
+	}
+	for class, want := range wantExact {
+		if got := priceData.RequestPrice[class]; got != want {
+			t.Errorf("setFallbackRequestPricing()[%v] = %v, want %v", class, got, want)
+		}
+	}
 }
 
 func TestService_InvalidateCache(t *testing.T) {

--- a/pkg/aws/pricingfallback/fallback.go
+++ b/pkg/aws/pricingfallback/fallback.go
@@ -1,0 +1,119 @@
+// Package pricingfallback holds the single canonical table of S3 fallback
+// prices used when the live AWS Price List API is unavailable or disabled.
+//
+// It exists to resolve #237: CargoShip previously had three independent fallback
+// tables (in pkg/aws/cost, pkg/aws/costs, and pkg/aws/pricing) that computed the
+// same prices from separate code and drifted — including two separate instances
+// of the 10x PUT-price error (#233). All pricing stacks now resolve fallback
+// prices through this leaf package, so each number is defined exactly once.
+//
+// This package depends only on pkg/aws/config (a leaf), so every pricing stack
+// can import it without creating a cycle. Numbers are approximate AWS us-east-1
+// list prices; the live Price List API overrides them when enabled.
+package pricingfallback
+
+import (
+	"strings"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+)
+
+// StoragePrice returns the storage price in USD per GB-month for a storage class.
+func StoragePrice(storageClass config.StorageClass) float64 {
+	switch storageClass {
+	case config.StorageClassStandard:
+		return 0.023
+	case config.StorageClassStandardIA:
+		return 0.0125
+	case config.StorageClassOneZoneIA:
+		return 0.01
+	case config.StorageClassIntelligentTiering:
+		// Intelligent-Tiering frequent-access tier is priced at Standard; the
+		// small monitoring/automation fee is not modeled here. (Reconciled to
+		// 0.0225 across the former stacks — #237.)
+		return 0.0225
+	case config.StorageClassGlacier:
+		return 0.004
+	case config.StorageClassDeepArchive:
+		return 0.00099
+	default:
+		return 0.023
+	}
+}
+
+// RequestPrice returns the request price in USD per 1,000 requests for a verb
+// and storage class.
+//
+// PUT/COPY/POST/LIST prices vary by storage class — writing to archival classes
+// costs far more per request than Standard. GET/SELECT and DELETE do not vary by
+// class (DELETE is free). This models real S3 pricing; pricing a PUT to Glacier
+// at the Standard rate (the old pkg/aws/cost behavior) undercounted archival
+// upload cost, and pkg/aws/pricing carried a 10x-too-low copy of this table
+// entirely (#237).
+func RequestPrice(requestType string, storageClass config.StorageClass) float64 {
+	switch strings.ToUpper(requestType) {
+	case "PUT", "POST", "COPY", "LIST":
+		return PutRequestPrice(storageClass)
+	case "GET", "SELECT":
+		return 0.0004 // $0.0004 per 1,000 GET/SELECT requests (all classes)
+	case "DELETE":
+		return 0.0 // DELETE requests are free
+	default:
+		return PutRequestPrice(storageClass)
+	}
+}
+
+// PutRequestPrice returns the per-1,000 PUT-class request price for a storage
+// class (the tier shared by PUT/COPY/POST/LIST).
+func PutRequestPrice(storageClass config.StorageClass) float64 {
+	switch storageClass {
+	case config.StorageClassStandard:
+		return 0.005 // $0.005 per 1,000 (the #233 fix)
+	case config.StorageClassStandardIA:
+		return 0.01
+	case config.StorageClassOneZoneIA:
+		return 0.01
+	case config.StorageClassIntelligentTiering:
+		return 0.005
+	case config.StorageClassGlacier:
+		return 0.03
+	case config.StorageClassDeepArchive:
+		return 0.05
+	default:
+		return 0.005
+	}
+}
+
+// StoragePriceTable returns the full storage fallback table as a fresh map, for
+// callers (e.g. the live-pricing service's cached PriceData) that populate a map
+// keyed by storage class.
+func StoragePriceTable() map[config.StorageClass]float64 {
+	classes := allClasses()
+	m := make(map[config.StorageClass]float64, len(classes))
+	for _, c := range classes {
+		m[c] = StoragePrice(c)
+	}
+	return m
+}
+
+// PutRequestPriceTable returns the full PUT-class request fallback table as a
+// fresh map keyed by storage class.
+func PutRequestPriceTable() map[config.StorageClass]float64 {
+	classes := allClasses()
+	m := make(map[config.StorageClass]float64, len(classes))
+	for _, c := range classes {
+		m[c] = PutRequestPrice(c)
+	}
+	return m
+}
+
+func allClasses() []config.StorageClass {
+	return []config.StorageClass{
+		config.StorageClassStandard,
+		config.StorageClassStandardIA,
+		config.StorageClassOneZoneIA,
+		config.StorageClassIntelligentTiering,
+		config.StorageClassGlacier,
+		config.StorageClassDeepArchive,
+	}
+}

--- a/pkg/aws/pricingfallback/fallback_test.go
+++ b/pkg/aws/pricingfallback/fallback_test.go
@@ -1,0 +1,85 @@
+package pricingfallback
+
+import (
+	"testing"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+)
+
+// TestStoragePrice pins the canonical storage fallback table so a change to any
+// number is deliberate and reviewed (the fallback tables previously diverged
+// across three stacks — #237).
+func TestStoragePrice(t *testing.T) {
+	cases := map[config.StorageClass]float64{
+		config.StorageClassStandard:           0.023,
+		config.StorageClassStandardIA:         0.0125,
+		config.StorageClassOneZoneIA:          0.01,
+		config.StorageClassIntelligentTiering: 0.0225, // reconciled from 0.023 (#237)
+		config.StorageClassGlacier:            0.004,
+		config.StorageClassDeepArchive:        0.00099,
+	}
+	for sc, want := range cases {
+		if got := StoragePrice(sc); got != want {
+			t.Errorf("StoragePrice(%s) = %v, want %v", sc, got, want)
+		}
+	}
+	if got := StoragePrice(config.StorageClass("BOGUS")); got != 0.023 {
+		t.Errorf("StoragePrice(unknown) = %v, want 0.023 (Standard default)", got)
+	}
+}
+
+// TestRequestPrice pins the request fallback table, including the key #237 fix:
+// PUT prices vary by storage class (archival classes cost more), where the cost
+// stack priced every PUT at the Standard rate and the pricing stack carried a
+// 10x-too-low table.
+func TestRequestPrice(t *testing.T) {
+	type key struct {
+		verb string
+		sc   config.StorageClass
+	}
+	cases := map[key]float64{
+		{"PUT", config.StorageClassStandard}:           0.005,
+		{"PUT", config.StorageClassStandardIA}:         0.01,
+		{"PUT", config.StorageClassOneZoneIA}:          0.01,
+		{"PUT", config.StorageClassIntelligentTiering}: 0.005,
+		{"PUT", config.StorageClassGlacier}:            0.03,
+		{"PUT", config.StorageClassDeepArchive}:        0.05,
+		{"COPY", config.StorageClassGlacier}:           0.03, // COPY/POST/LIST share the PUT tier
+		{"LIST", config.StorageClassDeepArchive}:       0.05,
+		{"GET", config.StorageClassStandard}:           0.0004, // GET/SELECT/DELETE don't vary by class
+		{"GET", config.StorageClassGlacier}:            0.0004,
+		{"SELECT", config.StorageClassDeepArchive}:     0.0004,
+		{"DELETE", config.StorageClassStandard}:        0.0,
+		{"DELETE", config.StorageClassGlacier}:         0.0,
+	}
+	for k, want := range cases {
+		if got := RequestPrice(k.verb, k.sc); got != want {
+			t.Errorf("RequestPrice(%s, %s) = %v, want %v", k.verb, k.sc, got, want)
+		}
+	}
+	if got := RequestPrice("put", config.StorageClassGlacier); got != 0.03 {
+		t.Errorf("lowercase verb not normalized: got %v", got)
+	}
+	if got := RequestPrice("WEIRD", config.StorageClassStandard); got != 0.005 {
+		t.Errorf("unknown verb should default to PUT tier: got %v", got)
+	}
+}
+
+// TestTables verifies the map helpers cover every storage class and agree with
+// the scalar accessors — so a caller populating a PriceData map can't silently
+// miss a class.
+func TestTables(t *testing.T) {
+	st := StoragePriceTable()
+	rt := PutRequestPriceTable()
+	for _, c := range allClasses() {
+		if st[c] != StoragePrice(c) {
+			t.Errorf("StoragePriceTable[%s]=%v != StoragePrice=%v", c, st[c], StoragePrice(c))
+		}
+		if rt[c] != PutRequestPrice(c) {
+			t.Errorf("PutRequestPriceTable[%s]=%v != PutRequestPrice=%v", c, rt[c], PutRequestPrice(c))
+		}
+	}
+	if len(st) != len(allClasses()) || len(rt) != len(allClasses()) {
+		t.Errorf("tables incomplete: storage=%d request=%d want=%d", len(st), len(rt), len(allClasses()))
+	}
+}


### PR DESCRIPTION
## Summary

CargoShip had **three independent S3 fallback price tables** (`pkg/aws/cost`, `pkg/aws/costs`, `pkg/aws/pricing`) computing the same numbers from separate code. They drifted — this is the root cause behind the #233 10× PUT-price bug, and the recon for this issue found **the same 10× bug still live in a third location**: `pkg/aws/pricing`'s request table was uniformly 10× too low (Standard `0.0005` vs the correct `0.005`), undetected because its test only checked `price > 0`.

### The fix
New leaf package **`pkg/aws/pricingfallback`** is the single source of truth for S3 fallback storage + request prices. It depends only on `pkg/aws/config` (a leaf), so all three stacks import it without an import cycle:
- `pkg/aws/cost` — `getFallback{Storage,Request}Price` delegate to it.
- `pkg/aws/costs/calculator.go` — inline maps removed.
- `pkg/aws/pricing/service.go` — `setFallback*` use it (fixes the 10× request bug; storage keeps its regional multiplier on top).

### Intended behavior change
Request pricing is now **storage-class-aware** in the `cost` stack, which previously priced *every* PUT at the Standard rate regardless of class — undercounting archival uploads. On the fallback path, `cargoship cost estimate` now reports (verified end-to-end):

| Class | Request cost (500 GB) | vs Standard |
|-------|----------------------|-------------|
| STANDARD | $0.0256 | 1× |
| GLACIER | $0.1536 | 6× |
| DEEP_ARCHIVE | $0.2560 | 10× |

Also reconciled Intelligent-Tiering storage to `0.0225` (was `0.023` in the cost stack).

### Correctness pinning
The recon's core lesson — loose assertions let the 10× bug survive — is addressed: `pkg/aws/pricingfallback` tests assert **exact** numbers for every class/verb, and the `pkg/aws/pricing` fallback test now pins the corrected values instead of `>0`.

### Scope / follow-up
The **live AWS Price List API** paths still query request pricing by verb only, so with the API enabled + creds the per-class difference isn't yet reflected. That's a distinct, larger change (reworking the Price List query with storage-class filters), filed as **#252**. This PR fixes the duplication root cause + the fallback tables; no live-API query changes.

All pricing/cost/estimate suites pass; pre-commit green (A+). Fixes #237.