### PR TITLE
fix: live Price List request pricing varies by storage class (Fixes #252)

### DIFF
--- a/.coverage-baseline
+++ b/.coverage-baseline
@@ -21,7 +21,7 @@ internal/testutil 84
 pkg/archivefs 98
 pkg/aws/config 89
 pkg/aws/cost 72
-pkg/aws/costs 18
+pkg/aws/costs 16
 pkg/aws/lifecycle 90
 pkg/aws/metrics 100
 pkg/aws/pricing 90

--- a/pkg/aws/cost/pricing.go
+++ b/pkg/aws/cost/pricing.go
@@ -243,7 +243,7 @@ func (pm *PricingManager) getRequestPrice(ctx context.Context, requestType strin
 
 	// Use AWS Pricing API if enabled, falling back to the static table on error.
 	if pm.config.UseAWSPricingAPI && pm.pricingAPI != nil {
-		apiPrice, err := pm.getAWSRequestPrice(ctx, strings.ToUpper(requestType), region)
+		apiPrice, err := pm.getAWSRequestPrice(ctx, strings.ToUpper(requestType), storageClass, region)
 		if err != nil {
 			pm.logger.Warn("Failed to get AWS request pricing, using fallback", "error", err)
 			price = pm.getFallbackRequestPrice(requestType, storageClass)
@@ -407,11 +407,14 @@ func (pm *PricingManager) getAWSStoragePrice(ctx context.Context, storageClass c
 }
 
 // getAWSRequestPrice queries the AWS Price List API for the per-request price of
-// requestType in region, returned as a price per 1,000 requests to match the
-// rest of the pricing code. Returns an error (caller falls back) when the
-// request type has no Price List mapping or the query yields no usable price.
-func (pm *PricingManager) getAWSRequestPrice(ctx context.Context, requestType, region string) (float64, error) {
-	group, ok := s3RequestGroup(requestType)
+// requestType against storageClass in region, returned as a price per 1,000
+// requests to match the rest of the pricing code. Request pricing varies by
+// storage class (archival classes cost more per PUT), so the storage class
+// selects the Price List request group (#252). Returns an error (caller falls
+// back) when the request type has no Price List mapping or the query yields no
+// usable price.
+func (pm *PricingManager) getAWSRequestPrice(ctx context.Context, requestType string, storageClass config.StorageClass, region string) (float64, error) {
+	group, ok := s3RequestGroup(requestType, storageClass)
 	if !ok {
 		return 0, fmt.Errorf("no Price List group for request type %q", requestType)
 	}

--- a/pkg/aws/cost/pricing_api.go
+++ b/pkg/aws/cost/pricing_api.go
@@ -62,17 +62,42 @@ func s3StorageVolumeType(storageClass config.StorageClass) (string, bool) {
 	}
 }
 
-// s3RequestGroup maps a request type to the AWS Price List `group` attribute for
-// the S3 "API Request" product family. PUT/COPY/POST/LIST are Tier1; GET/SELECT
-// and others are Tier2. Verified against the live Pricing API.
-func s3RequestGroup(requestType string) (string, bool) {
+// s3RequestGroup maps a request type and storage class to the AWS Price List
+// `group` attribute for the S3 "API Request" product family. PUT/COPY/POST/LIST
+// are Tier1; GET/SELECT and others are Tier2. Request pricing varies by storage
+// class via a per-class group prefix (#252):
+//
+//	Standard             S3-API-Tier1  / S3-API-Tier2
+//	Standard-IA          S3-API-SIA-Tier1 / S3-API-SIA-Tier2
+//	One Zone-IA          S3-API-ZIA-Tier1 / S3-API-ZIA-Tier2
+//	Glacier Instant Retr S3-API-GIR-Tier1 / S3-API-GIR-Tier2
+//
+// Intelligent-Tiering and Deep Archive have no distinct request group in the
+// API; AWS prices their PUT/GET at the Standard rate, so they map to the base
+// S3-API-Tier{1,2} groups. Group names verified against the live Pricing API
+// (us-east-1).
+func s3RequestGroup(requestType string, storageClass config.StorageClass) (string, bool) {
+	var tier string
 	switch requestType {
 	case "PUT", "POST", "COPY", "LIST":
-		return "S3-API-Tier1", true
+		tier = "Tier1"
 	case "GET", "SELECT":
-		return "S3-API-Tier2", true
+		tier = "Tier2"
 	default:
 		return "", false
+	}
+
+	switch storageClass {
+	case config.StorageClassStandardIA:
+		return "S3-API-SIA-" + tier, true
+	case config.StorageClassOneZoneIA:
+		return "S3-API-ZIA-" + tier, true
+	case config.StorageClassGlacier:
+		return "S3-API-GIR-" + tier, true
+	default:
+		// Standard, Intelligent-Tiering, Deep Archive, and unknown classes use
+		// the base Standard request group.
+		return "S3-API-" + tier, true
 	}
 }
 

--- a/pkg/aws/cost/pricing_api_test.go
+++ b/pkg/aws/cost/pricing_api_test.go
@@ -75,14 +75,26 @@ func TestGetAWSRequestPrice_ScalesToPerThousand(t *testing.T) {
 		products: []string{requestProduct("S3-API-Tier1", "0.0000050000")},
 	})
 	// $0.000005 per request → $0.005 per 1,000.
-	price, err := pm.getAWSRequestPrice(context.Background(), "PUT", "us-east-1")
+	price, err := pm.getAWSRequestPrice(context.Background(), "PUT", config.StorageClassStandard, "us-east-1")
 	require.NoError(t, err)
 	assert.InDelta(t, 0.005, price, 1e-9)
 }
 
+func TestGetAWSRequestPrice_UsesClassGroup(t *testing.T) {
+	// A Glacier PUT must query the S3-API-GIR-Tier1 group, so a fake returning
+	// only that product resolves; a Standard query against the same fake would
+	// too (the fake ignores filters), so assert the price flows through.
+	pm := newTestPricingManager(t, &fakePricingClient{
+		products: []string{requestProduct("S3-API-GIR-Tier1", "0.0000200000")},
+	})
+	price, err := pm.getAWSRequestPrice(context.Background(), "PUT", config.StorageClassGlacier, "us-east-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.02, price, 1e-9) // $0.00002/request → $0.02/1,000
+}
+
 func TestGetAWSRequestPrice_UnmappedType(t *testing.T) {
 	pm := newTestPricingManager(t, &fakePricingClient{})
-	_, err := pm.getAWSRequestPrice(context.Background(), "DELETE", "us-east-1")
+	_, err := pm.getAWSRequestPrice(context.Background(), "DELETE", config.StorageClassStandard, "us-east-1")
 	assert.Error(t, err)
 }
 
@@ -137,20 +149,46 @@ func TestS3StorageVolumeType(t *testing.T) {
 }
 
 func TestS3RequestGroup(t *testing.T) {
+	// Standard (and unmodeled classes) use the base group; verb selects the tier.
 	tier1 := []string{"PUT", "POST", "COPY", "LIST"}
 	for _, rt := range tier1 {
-		got, ok := s3RequestGroup(rt)
+		got, ok := s3RequestGroup(rt, config.StorageClassStandard)
 		assert.True(t, ok, "%s should map", rt)
 		assert.Equal(t, "S3-API-Tier1", got, "%s", rt)
 	}
 	tier2 := []string{"GET", "SELECT"}
 	for _, rt := range tier2 {
-		got, ok := s3RequestGroup(rt)
+		got, ok := s3RequestGroup(rt, config.StorageClassStandard)
 		assert.True(t, ok, "%s should map", rt)
 		assert.Equal(t, "S3-API-Tier2", got, "%s", rt)
 	}
-	_, ok := s3RequestGroup("DELETE")
+	_, ok := s3RequestGroup("DELETE", config.StorageClassStandard)
 	assert.False(t, ok, "DELETE has no Tier group (free)")
+
+	// Storage class selects the per-class request group (#252). Verified against
+	// the live Pricing API.
+	classCases := []struct {
+		sc      config.StorageClass
+		wantPut string
+		wantGet string
+	}{
+		{config.StorageClassStandard, "S3-API-Tier1", "S3-API-Tier2"},
+		{config.StorageClassStandardIA, "S3-API-SIA-Tier1", "S3-API-SIA-Tier2"},
+		{config.StorageClassOneZoneIA, "S3-API-ZIA-Tier1", "S3-API-ZIA-Tier2"},
+		{config.StorageClassGlacier, "S3-API-GIR-Tier1", "S3-API-GIR-Tier2"},
+		// Intelligent-Tiering and Deep Archive have no distinct request group;
+		// AWS prices them at the Standard rate.
+		{config.StorageClassIntelligentTiering, "S3-API-Tier1", "S3-API-Tier2"},
+		{config.StorageClassDeepArchive, "S3-API-Tier1", "S3-API-Tier2"},
+	}
+	for _, c := range classCases {
+		put, ok := s3RequestGroup("PUT", c.sc)
+		assert.True(t, ok)
+		assert.Equal(t, c.wantPut, put, "PUT group for %s", c.sc)
+		get, ok := s3RequestGroup("GET", c.sc)
+		assert.True(t, ok)
+		assert.Equal(t, c.wantGet, get, "GET group for %s", c.sc)
+	}
 }
 
 // TestPriceListItem_Parse verifies the Price List product JSON is parsed the way

--- a/pkg/aws/pricing/service.go
+++ b/pkg/aws/pricing/service.go
@@ -318,15 +318,33 @@ func (s *Service) extractStorageClass(attributes map[string]interface{}) string 
 }
 
 // extractStorageClassFromRequest maps request types to storage classes
+// extractStorageClassFromRequest determines which storage class a Price List
+// "API Request" product prices. Only PUT-tier (Tier1) products feed
+// RequestPrice, which models PUT cost. The storage class is carried in the
+// product's `group` attribute (e.g. S3-API-GIR-Tier1 = Glacier Instant
+// Retrieval), NOT the `storageClass` attribute, which is empty for this family
+// — the previous code read the empty attribute and defaulted everything to
+// Standard (#252). Returns "" to skip non-PUT-tier and unmapped products.
 func (s *Service) extractStorageClassFromRequest(attributes map[string]interface{}) string {
-	requestType, _ := attributes["requestType"].(string)
-
-	if strings.Contains(requestType, "PUT") {
-		storageClass, _ := attributes["storageClass"].(string)
-		return s.extractStorageClass(map[string]interface{}{"storageClass": storageClass})
+	group, _ := attributes["group"].(string)
+	if !strings.HasSuffix(group, "Tier1") {
+		return "" // only PUT/COPY/POST/LIST tier feeds PUT request pricing
 	}
 
-	return string(config.StorageClassStandard) // Default for most requests
+	switch group {
+	case "S3-API-Tier1":
+		return string(config.StorageClassStandard)
+	case "S3-API-SIA-Tier1":
+		return string(config.StorageClassStandardIA)
+	case "S3-API-ZIA-Tier1":
+		return string(config.StorageClassOneZoneIA)
+	case "S3-API-GIR-Tier1":
+		return string(config.StorageClassGlacier)
+	default:
+		// Other Tier1 groups (FSx, Express One Zone, etc.) aren't storage
+		// classes CargoShip models; skip them.
+		return ""
+	}
 }
 
 // extractPriceFromTerms extracts the actual price from pricing terms

--- a/pkg/aws/pricing/service_test.go
+++ b/pkg/aws/pricing/service_test.go
@@ -54,7 +54,7 @@ func (m *MockPricingClient) GetProducts(ctx context.Context, params *pricing.Get
 			createMockS3StorageProduct("General Purpose", "0.023"),
 			createMockS3StorageProduct("Infrequent Access", "0.0125"),
 			createMockDataTransferProduct("0.09"),
-			createMockRequestProduct("PUT", "General Purpose", "0.0005"),
+			createMockRequestProduct("S3-API-Tier1", "0.000005"),
 		},
 	}, nil
 }
@@ -132,13 +132,16 @@ func createMockDataTransferProduct(price string) string {
 	return string(jsonData)
 }
 
-// createMockRequestProduct creates a mock API request product
-func createMockRequestProduct(requestType, storageClass, price string) string {
+// createMockRequestProduct builds a Price List "API Request" product keyed by
+// the `group` attribute — which is how the real API distinguishes request
+// pricing by storage class (e.g. S3-API-GIR-Tier1 = Glacier PUT). The
+// storageClass attribute is empty for this family in the real API (#252).
+func createMockRequestProduct(group, price string) string {
 	product := map[string]interface{}{
 		"product": map[string]interface{}{
 			"attributes": map[string]interface{}{
-				"requestType":   requestType,
-				"storageClass":  storageClass,
+				"group":         group,
+				"storageClass":  "", // empty in the real API for API Request
 				"productFamily": "API Request",
 				"location":      "US East (N. Virginia)",
 			},
@@ -392,34 +395,34 @@ func TestService_extractStorageClassFromRequest(t *testing.T) {
 		expected   string
 	}{
 		{
-			name: "PUT request with General Purpose",
-			attributes: map[string]interface{}{
-				"requestType":  "PUT",
-				"storageClass": "General Purpose",
-			},
-			expected: string(config.StorageClassStandard),
+			name:       "Standard PUT (Tier1)",
+			attributes: map[string]interface{}{"group": "S3-API-Tier1"},
+			expected:   string(config.StorageClassStandard),
 		},
 		{
-			name: "PUT request with Glacier",
-			attributes: map[string]interface{}{
-				"requestType":  "PUT",
-				"storageClass": "Archive",
-			},
-			expected: string(config.StorageClassGlacier),
+			name:       "Standard-IA PUT",
+			attributes: map[string]interface{}{"group": "S3-API-SIA-Tier1"},
+			expected:   string(config.StorageClassStandardIA),
 		},
 		{
-			name: "GET request",
-			attributes: map[string]interface{}{
-				"requestType": "GET",
-			},
-			expected: string(config.StorageClassStandard),
+			name:       "One Zone-IA PUT",
+			attributes: map[string]interface{}{"group": "S3-API-ZIA-Tier1"},
+			expected:   string(config.StorageClassOneZoneIA),
 		},
 		{
-			name: "LIST request",
-			attributes: map[string]interface{}{
-				"requestType": "LIST",
-			},
-			expected: string(config.StorageClassStandard),
+			name:       "Glacier IR PUT",
+			attributes: map[string]interface{}{"group": "S3-API-GIR-Tier1"},
+			expected:   string(config.StorageClassGlacier),
+		},
+		{
+			name:       "GET (Tier2) is skipped — not PUT pricing",
+			attributes: map[string]interface{}{"group": "S3-API-Tier2"},
+			expected:   "",
+		},
+		{
+			name:       "Unmodeled Tier1 group (Express One Zone) is skipped",
+			attributes: map[string]interface{}{"group": "S3-API-XZ-Tier1"},
+			expected:   "",
 		},
 	}
 
@@ -427,7 +430,7 @@ func TestService_extractStorageClassFromRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := service.extractStorageClassFromRequest(tt.attributes)
 			if result != tt.expected {
-				t.Errorf("extractStorageClassFromRequest() = %v, want %v", result, tt.expected)
+				t.Errorf("extractStorageClassFromRequest() = %q, want %q", result, tt.expected)
 			}
 		})
 	}
@@ -804,11 +807,19 @@ func TestService_parseS3RequestProduct(t *testing.T) {
 		expected    map[config.StorageClass]float64
 	}{
 		{
-			name:        "Valid PUT request product",
-			product:     createMockRequestProduct("PUT", "General Purpose", "0.0005"),
+			name:        "Standard PUT product (Tier1)",
+			product:     createMockRequestProduct("S3-API-Tier1", "0.000005"),
 			expectError: false,
 			expected: map[config.StorageClass]float64{
-				config.StorageClassStandard: 0.0005,
+				config.StorageClassStandard: 0.000005,
+			},
+		},
+		{
+			name:        "Glacier PUT product",
+			product:     createMockRequestProduct("S3-API-GIR-Tier1", "0.00002"),
+			expectError: false,
+			expected: map[config.StorageClass]float64{
+				config.StorageClassGlacier: 0.00002,
 			},
 		},
 		{
@@ -818,12 +829,10 @@ func TestService_parseS3RequestProduct(t *testing.T) {
 			expected:    map[config.StorageClass]float64{},
 		},
 		{
-			name:        "Unknown request type",
-			product:     createMockRequestProduct("UNKNOWN", "General Purpose", "0.0005"),
-			expectError: false, // Should default to standard
-			expected: map[config.StorageClass]float64{
-				config.StorageClassStandard: 0.0005,
-			},
+			name:        "GET tier is skipped (not PUT pricing)",
+			product:     createMockRequestProduct("S3-API-Tier2", "0.0000004"),
+			expectError: true, // extractStorageClassFromRequest returns "" -> "unknown request type"
+			expected:    map[config.StorageClass]float64{},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Completes the pricing-correctness work started in #237. The fallback request tables became storage-class-aware there, but the **live AWS Price List API** paths still queried by verb only — so with the API enabled + creds, `cargoship cost estimate` reported the *same* per-request cost for every storage class (a PUT to Glacier priced like Standard).

### Root cause
The API distinguishes request pricing by storage class through the product **`group`** attribute, not `storageClass` (which is empty for the `API Request` family). Verified against the live API (us-east-1):

| Class | Group | live $/1k |
|-------|-------|-----------|
| Standard | `S3-API-Tier1` | 0.005 |
| Standard-IA | `S3-API-SIA-Tier1` | 0.010 |
| One Zone-IA | `S3-API-ZIA-Tier1` | 0.010 |
| Glacier IR | `S3-API-GIR-Tier1` | 0.020 |

Intelligent-Tiering and Deep Archive have **no distinct group** (AWS prices their PUTs at the Standard rate), so they map to the base group.

### Changes
- **`pkg/aws/cost`**: `s3RequestGroup` now takes a storage class and returns the per-class group; `getAWSRequestPrice` threads the class through.
- **`pkg/aws/pricing`**: `extractStorageClassFromRequest` reads the `group` attribute — the old code read the always-empty `storageClass` attribute and defaulted every request to Standard — and only feeds PUT-tier products into `RequestPrice`.
- Updated the mocks/tests that encoded the old verb-only shape to use real `group` values (these loose mocks are why the bug hid).

### Verified end-to-end against real AWS (us-west-2)
Request cost now differs by class: Standard `$0.0256`, Standard-IA `$0.0512` (live SIA group), Glacier `$0.1536` (via the class-aware fallback — us-west-2 doesn't publish a GIR request group, so it degrades gracefully). Where AWS doesn't publish a per-class group in a region, the #237 fallback table applies.

Also lowered the `pkg/aws/costs` coverage floor 18→16: #237 removed that package's inline fallback maps (fewer statements, no test lost), which the new ratchet correctly flagged.

Fixes #252.