### PR TITLE
feat: durable budget spend-ledger + record spend on upload (#246 Phase A)

### DIFF
--- a/cmd/cargoship/cmd/upload.go
+++ b/cmd/cargoship/cmd/upload.go
@@ -684,6 +684,16 @@ Examples:
 				return fmt.Errorf("pipeline completed with %d errors", len(result.Errors))
 			}
 
+			// #246: record this upload's cost against its project budget so
+			// `cargoship budget status <project>` reflects real spend and it
+			// persists across runs. Gated on --project so plain uploads (no
+			// budgeting opt-in) don't write a budget store. Best-effort: the
+			// upload already succeeded, so a recording/enforcement error is a
+			// warning, never a command failure.
+			if dvcProject != "" {
+				recordUploadCost(ctx, cmd, dvcProject, storageClass, region, result, uploadTagMap)
+			}
+
 			// v0.13.0: DVC auto-annotation — annotate each FileEntry with its DVC stage
 			// by parsing dvc.yaml, then re-upload the manifest to S3 so that
 			// cargoship dvc stages / restore --dvc-stage work correctly.
@@ -917,6 +927,30 @@ func promptForResume(state *resume.UploadState) bool {
 
 	// Empty or "y" means yes
 	return response == "" || response == "y" || response == "Y"
+}
+
+// recordUploadCost records a completed upload's cost against its project budget
+// so `cargoship budget status <project>` reflects real spend and persists it
+// across runs (#246). Best-effort: any failure is a warning to stderr, never a
+// command error — the upload has already succeeded.
+func recordUploadCost(ctx context.Context, cmd *cobra.Command, projectID, storageClass, region string, result *pipeline.Result, tags map[string]string) {
+	mgr, err := loadCostManager(ctx)
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.OutOrStderr(), "⚠️  cost tracking skipped: %v\n", err)
+		return
+	}
+	if err := mgr.RecordCompletedUpload(
+		ctx,
+		result.UploadID,
+		result.TotalBytes,
+		cargoconfig.StorageClass(storageClass),
+		region,
+		result.UploadID,
+		projectID,
+		tags,
+	); err != nil {
+		_, _ = fmt.Fprintf(cmd.OutOrStderr(), "⚠️  cost tracking failed: %v\n", err)
+	}
 }
 
 // formatDuration formats a duration in a human-readable way

--- a/cmd/cargoship/cmd/upload_cost_test.go
+++ b/cmd/cargoship/cmd/upload_cost_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/cargoship/pkg/pipeline"
+)
+
+// TestRecordUploadCost_PersistsAcrossManagers verifies the #246 upload hook:
+// recordUploadCost writes a completed upload's spend to the budget store, and a
+// freshly loaded cost manager sees it (durable across "processes").
+func TestRecordUploadCost_PersistsAcrossManagers(t *testing.T) {
+	t.Setenv("CARGOSHIP_BUDGET_STORE", filepath.Join(t.TempDir(), "budgets.json"))
+	ctx := context.Background()
+
+	cmd := &cobra.Command{}
+	result := &pipeline.Result{
+		UploadID:   "20260101-abc123",
+		TotalBytes: 10 * 1024 * 1024 * 1024, // 10 GB
+		TotalFiles: 3,
+		Success:    true,
+	}
+	recordUploadCost(ctx, cmd, "proj-record", "STANDARD", "us-east-1", result, nil)
+
+	// A fresh cost manager must see the persisted spend.
+	mgr, err := loadCostManager(ctx)
+	require.NoError(t, err)
+	spend := mgr.GetReporter().GetProjectCosts("proj-record")
+	assert.Greater(t, spend, 0.0, "recorded upload spend must persist and reload")
+	assert.InDelta(t, 10.0, mgr.GetReporter().GetProjectVolume("proj-record"), 1e-6)
+}

--- a/pkg/aws/cost/budget.go
+++ b/pkg/aws/cost/budget.go
@@ -540,8 +540,9 @@ func (m *Manager) SetProjectBudget(projectID string, maxBudget float64, maxVolum
 		VolumeAlertThreshold: volumeAlertThreshold,
 	}
 
-	// Persist so the budget survives across CLI invocations (#241).
-	if err := saveProjectBudgets(m.config.ProjectBudgets); err != nil {
+	// Persist so the budget survives across CLI invocations (#241), carrying the
+	// recorded ledger through untouched so a limits update can't clobber it (#246).
+	if err := m.saveState(); err != nil {
 		return fmt.Errorf("persist project budget: %w", err)
 	}
 
@@ -567,8 +568,8 @@ func (m *Manager) DeleteProjectBudget(projectID string) error {
 
 	delete(m.config.ProjectBudgets, projectID)
 
-	// Persist the removal (#241).
-	if err := saveProjectBudgets(m.config.ProjectBudgets); err != nil {
+	// Persist the removal (#241), preserving the recorded ledger (#246).
+	if err := m.saveState(); err != nil {
 		return fmt.Errorf("persist project budget removal: %w", err)
 	}
 

--- a/pkg/aws/cost/budget_store.go
+++ b/pkg/aws/cost/budget_store.go
@@ -13,7 +13,7 @@ import (
 // to a scratch location instead of the user's home directory.
 const budgetStoreEnvOverride = "CARGOSHIP_BUDGET_STORE"
 
-// budgetStorePath returns the path to the persisted project-budgets file:
+// budgetStorePath returns the path to the persisted budget store file:
 //   - $CARGOSHIP_BUDGET_STORE if set (an explicit file path), else
 //   - $XDG_DATA_HOME/cargoship/budgets.json, else
 //   - ~/.cargoship/budgets.json
@@ -36,45 +36,93 @@ func budgetStorePath() (string, error) {
 	return filepath.Join(base, "budgets.json"), nil
 }
 
-// loadProjectBudgets reads persisted project budgets from disk. A missing file
-// is not an error (returns an empty map) — the store simply hasn't been written
-// yet.
-func loadProjectBudgets() (map[string]config.ProjectBudget, error) {
+// localStore is the default BudgetStore: a single JSON document on the local
+// filesystem at budgetStorePath, written atomically. It ignores the concurrency
+// token (whole-document read/modify/write); the S3 store added in Phase B (#246)
+// uses the token for ETag/If-Match conditional writes.
+type localStore struct{}
+
+// Load reads the persisted budget document. A missing file is not an error —
+// it returns an empty, current-version state (the store simply hasn't been
+// written yet). Legacy pre-versioning files (a bare
+// map[string]config.ProjectBudget) are migrated in memory to the current shape;
+// they're rewritten in the new shape on the next Save.
+func (localStore) Load() (LedgerState, Token, error) {
 	path, err := budgetStorePath()
 	if err != nil {
-		return nil, err
+		return LedgerState{}, "", err
 	}
 	data, err := os.ReadFile(path) //nolint:gosec // path is derived from home/XDG, not user input
 	if err != nil {
 		if os.IsNotExist(err) {
-			return map[string]config.ProjectBudget{}, nil
+			return LedgerState{Version: StoreVersion, ProjectBudgets: map[string]config.ProjectBudget{}}, "", nil
 		}
-		return nil, fmt.Errorf("read budget store %q: %w", path, err)
+		return LedgerState{}, "", fmt.Errorf("read budget store %q: %w", path, err)
 	}
-	var budgets map[string]config.ProjectBudget
-	if err := json.Unmarshal(data, &budgets); err != nil {
-		return nil, fmt.Errorf("parse budget store %q: %w", path, err)
+	state, err := decodeLedgerState(data)
+	if err != nil {
+		return LedgerState{}, "", fmt.Errorf("parse budget store %q: %w", path, err)
 	}
-	if budgets == nil {
-		budgets = map[string]config.ProjectBudget{}
-	}
-	return budgets, nil
+	return state, "", nil
 }
 
-// saveProjectBudgets writes project budgets to disk atomically (write to a temp
-// file in the same directory, then rename) so a crash mid-write can't corrupt
-// the store. The file is written 0600 since budgets may reference grant numbers.
-func saveProjectBudgets(budgets map[string]config.ProjectBudget) error {
+// Save writes the budget document atomically (temp file in the same dir, then
+// rename) so a crash mid-write can't corrupt the store. The file is written
+// 0600 since budgets may reference grant numbers. The token is ignored.
+func (localStore) Save(state LedgerState, _ Token) error {
+	if state.Version == 0 {
+		state.Version = StoreVersion
+	}
+	if state.ProjectBudgets == nil {
+		state.ProjectBudgets = map[string]config.ProjectBudget{}
+	}
 	path, err := budgetStorePath()
 	if err != nil {
 		return err
 	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal budget store: %w", err)
+	}
+	return atomicWriteFile(path, data)
+}
+
+// decodeLedgerState parses budget-store bytes, migrating the legacy format
+// (a bare map[string]config.ProjectBudget with no "version" field) to the
+// current LedgerState shape. Detection: a versioned document has a top-level
+// "version" key; a legacy document's top-level keys are all project IDs.
+func decodeLedgerState(data []byte) (LedgerState, error) {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return LedgerState{}, err
+	}
+	// New format: has "version" (and/or "project_budgets").
+	if _, ok := probe["version"]; ok {
+		var state LedgerState
+		if err := json.Unmarshal(data, &state); err != nil {
+			return LedgerState{}, err
+		}
+		if state.ProjectBudgets == nil {
+			state.ProjectBudgets = map[string]config.ProjectBudget{}
+		}
+		return state, nil
+	}
+	// Legacy format: a bare map of project ID -> ProjectBudget.
+	var legacy map[string]config.ProjectBudget
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return LedgerState{}, err
+	}
+	if legacy == nil {
+		legacy = map[string]config.ProjectBudget{}
+	}
+	return LedgerState{Version: StoreVersion, ProjectBudgets: legacy}, nil
+}
+
+// atomicWriteFile writes data to path via a temp file in the same directory
+// followed by a rename, creating the parent dir 0700 and the file 0600.
+func atomicWriteFile(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return fmt.Errorf("create budget store dir: %w", err)
-	}
-	data, err := json.MarshalIndent(budgets, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal budgets: %w", err)
 	}
 	tmp, err := os.CreateTemp(filepath.Dir(path), ".budgets-*.tmp")
 	if err != nil {
@@ -97,4 +145,31 @@ func saveProjectBudgets(budgets map[string]config.ProjectBudget) error {
 		return fmt.Errorf("rename budget store into place: %w", err)
 	}
 	return nil
+}
+
+// loadProjectBudgets reads persisted project budgets (limits only). A missing
+// file is not an error (returns an empty map). Retained as a thin adapter over
+// localStore for callers that only need the limits view.
+func loadProjectBudgets() (map[string]config.ProjectBudget, error) {
+	state, _, err := localStore{}.Load()
+	if err != nil {
+		return nil, err
+	}
+	if state.ProjectBudgets == nil {
+		return map[string]config.ProjectBudget{}, nil
+	}
+	return state.ProjectBudgets, nil
+}
+
+// saveProjectBudgets writes project budgets (limits only), preserving any
+// existing recorded ledger in the store so a limits update can't clobber spend
+// history (#246). Retained as a thin adapter over localStore.
+func saveProjectBudgets(budgets map[string]config.ProjectBudget) error {
+	store := localStore{}
+	state, tok, err := store.Load()
+	if err != nil {
+		return err
+	}
+	state.ProjectBudgets = budgets
+	return store.Save(state, tok)
 }

--- a/pkg/aws/cost/manager.go
+++ b/pkg/aws/cost/manager.go
@@ -12,6 +12,11 @@ import (
 	"github.com/scttfrdmn/cargoship/pkg/aws/config"
 )
 
+// maxLedgerRecords bounds the persisted cost ledger. When the recorded history
+// exceeds this, the oldest records are dropped (FIFO) before a save so the store
+// file can't grow without limit (#246).
+const maxLedgerRecords = 10000
+
 // Manager provides integrated cost management functionality
 type Manager struct {
 	config        *config.CostControlConfig
@@ -19,6 +24,7 @@ type Manager struct {
 	reporter      *CostReporter
 	budgetTracker *BudgetTracker
 	notifier      *BudgetAlertNotifier // Issue #133: Budget alert notifier
+	store         BudgetStore          // #246: durable budget limits + cost ledger
 	logger        *slog.Logger
 	awsConfig     aws.Config // Issue #147 Phase 4: Needed for alert notification
 }
@@ -46,14 +52,24 @@ type CostApprovalRequest struct {
 	DeniedReason   string     `json:"denied_reason,omitempty"`
 }
 
-// NewManager creates a new cost management manager
+// NewManager creates a new cost management manager backed by the default local
+// budget store (~/.cargoship/budgets.json).
 func NewManager(cfg *config.CostControlConfig, awsCfg aws.Config, logger *slog.Logger) (*Manager, error) {
+	return newManagerWithStore(cfg, awsCfg, logger, localStore{})
+}
+
+// newManagerWithStore is the injectable constructor used by tests to supply a
+// custom BudgetStore. Production code uses NewManager.
+func newManagerWithStore(cfg *config.CostControlConfig, awsCfg aws.Config, logger *slog.Logger, store BudgetStore) (*Manager, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("cost control config cannot be nil")
 	}
 
 	if logger == nil {
 		logger = slog.Default()
+	}
+	if store == nil {
+		store = localStore{}
 	}
 
 	// Initialize pricing manager
@@ -82,20 +98,25 @@ func NewManager(cfg *config.CostControlConfig, awsCfg aws.Config, logger *slog.L
 	alertConfig := DefaultBudgetAlertConfig()
 	notifier := NewBudgetAlertNotifier(alertConfig, awsCfg)
 
-	// Load persisted project budgets so `budget set` survives across CLI
-	// invocations (#241). Budgets from the config file (if any) take precedence
-	// over the persisted store for the same project ID.
-	if persisted, err := loadProjectBudgets(); err != nil {
-		logger.Warn("failed to load persisted project budgets", "error", err)
-	} else if len(persisted) > 0 {
-		if cfg.ProjectBudgets == nil {
-			cfg.ProjectBudgets = make(map[string]config.ProjectBudget)
-		}
-		for id, b := range persisted {
-			if _, exists := cfg.ProjectBudgets[id]; !exists {
-				cfg.ProjectBudgets[id] = b
+	// Load persisted budget state so `budget set` survives across CLI
+	// invocations (#241) and recorded spend is rehydrated across restarts (#246).
+	// Budgets from the config file (if any) take precedence over the persisted
+	// store for the same project ID; the recorded ledger seeds the reporter so
+	// `budget status` reflects prior uploads.
+	if state, _, err := store.Load(); err != nil {
+		logger.Warn("failed to load persisted budget store", "error", err)
+	} else {
+		if len(state.ProjectBudgets) > 0 {
+			if cfg.ProjectBudgets == nil {
+				cfg.ProjectBudgets = make(map[string]config.ProjectBudget)
+			}
+			for id, b := range state.ProjectBudgets {
+				if _, exists := cfg.ProjectBudgets[id]; !exists {
+					cfg.ProjectBudgets[id] = b
+				}
 			}
 		}
+		reporter.SeedRecords(state.Records)
 	}
 
 	return &Manager{
@@ -104,9 +125,45 @@ func NewManager(cfg *config.CostControlConfig, awsCfg aws.Config, logger *slog.L
 		reporter:      reporter,
 		budgetTracker: budgetTracker,
 		notifier:      notifier,
+		store:         store,
 		logger:        logger.With("component", "cost-manager"),
 		awsConfig:     awsCfg, // Issue #147 Phase 4: For alert notification
 	}, nil
+}
+
+// saveState writes the current project budgets and recorded cost ledger to the
+// store as one document (both halves together, so a limits update never clobbers
+// the recorded ledger and vice versa — #246). FIFO rotation bounds the ledger.
+func (m *Manager) saveState() error {
+	if m.store == nil {
+		m.store = localStore{}
+	}
+	records := m.reporter.SnapshotRecords()
+	if len(records) > maxLedgerRecords {
+		records = records[len(records)-maxLedgerRecords:]
+	}
+	state := LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: m.config.ProjectBudgets,
+		Records:        records,
+	}
+	// Load the current token first so a Phase B S3 store can do a CAS write; the
+	// local store ignores it. A load error still attempts an unconditional save.
+	_, tok, err := m.store.Load()
+	if err != nil {
+		m.logger.Warn("budget store load before save failed", "error", err)
+		tok = ""
+	}
+	return m.store.Save(state, tok)
+}
+
+// persistLedger is the best-effort variant of saveState used on the
+// operation-recording path: a storage failure is logged, not returned, so it
+// can't fail an operation whose work already completed (#246).
+func (m *Manager) persistLedger() {
+	if err := m.saveState(); err != nil {
+		m.logger.Warn("failed to persist budget ledger", "error", err)
+	}
 }
 
 // EstimateOperationCost estimates the cost of an operation before execution
@@ -211,6 +268,10 @@ func (m *Manager) RecordOperationCost(ctx context.Context, operation string, fil
 		return fmt.Errorf("failed to record cost: %w", err)
 	}
 
+	// Persist the recorded ledger so `budget status` reflects this upload across
+	// process restarts (#246). Best-effort.
+	m.persistLedger()
+
 	// Update legacy budget tracking (for backward compatibility)
 	if estimate != nil {
 		m.budgetTracker.currentSpend += estimate.TotalCost
@@ -221,6 +282,23 @@ func (m *Manager) RecordOperationCost(ctx context.Context, operation string, fil
 		m.logger.Error("Failed to check budget alerts", "error", err)
 	}
 
+	return nil
+}
+
+// RecordCompletedUpload records the cost of an upload that has ALREADY finished,
+// then persists the ledger. Unlike RecordOperationCost it does not enforce
+// budgets (there is nothing left to block — the bytes are in S3), so an
+// over-budget upload is still recorded rather than silently dropped (#246).
+// It still fires budget alerts so an over-budget condition is surfaced. Returns
+// an error only if the cost couldn't be recorded at all.
+func (m *Manager) RecordCompletedUpload(ctx context.Context, fileName string, sizeBytes int64, storageClass config.StorageClass, region string, jobID string, projectID string, tags map[string]string) error {
+	if err := m.reporter.RecordArchivalCost(ctx, fileName, sizeBytes, storageClass, region, jobID, projectID, tags); err != nil {
+		return fmt.Errorf("failed to record cost: %w", err)
+	}
+	m.persistLedger()
+	if err := m.checkAndSendBudgetAlerts(ctx); err != nil {
+		m.logger.Error("Failed to check budget alerts", "error", err)
+	}
 	return nil
 }
 

--- a/pkg/aws/cost/reporting.go
+++ b/pkg/aws/cost/reporting.go
@@ -146,6 +146,29 @@ func (cr *CostReporter) RecordCost(record CostRecord) {
 		"size_gb", record.SizeGB)
 }
 
+// SeedRecords replaces the in-memory cost ledger with the given records. Used
+// at startup to rehydrate persisted spend history so GetProjectCosts and the
+// other cr.costs readers reflect prior uploads across process restarts (#246).
+func (cr *CostReporter) SeedRecords(records []CostRecord) {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	if records == nil {
+		cr.costs = make([]CostRecord, 0)
+		return
+	}
+	cr.costs = records
+}
+
+// SnapshotRecords returns a copy of the current cost ledger, safe to hand to the
+// budget store for persistence without racing concurrent RecordCost calls (#246).
+func (cr *CostReporter) SnapshotRecords() []CostRecord {
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	out := make([]CostRecord, len(cr.costs))
+	copy(out, cr.costs)
+	return out
+}
+
 // RecordArchivalCost records cost for an archival operation
 func (cr *CostReporter) RecordArchivalCost(ctx context.Context, fileName string, sizeBytes int64, storageClass config.StorageClass, region string, jobID string, projectID string, tags map[string]string) error {
 	sizeGB := float64(sizeBytes) / (1024 * 1024 * 1024)

--- a/pkg/aws/cost/store.go
+++ b/pkg/aws/cost/store.go
@@ -1,0 +1,43 @@
+package cost
+
+import "github.com/scttfrdmn/cargoship/pkg/aws/config"
+
+// StoreVersion is the current on-disk schema version for the budget store.
+// Version 1 introduced the LedgerState wrapper (project budgets + recorded cost
+// ledger); legacy files (a bare map[string]config.ProjectBudget with no version
+// field) are migrated to this shape on load. See localStore.Load.
+const StoreVersion = 1
+
+// LedgerState is the full persisted budget document: the project budget limits
+// and the recorded cost ledger, versioned so future schema changes can migrate.
+type LedgerState struct {
+	// Version is the schema version (StoreVersion). Zero means a legacy,
+	// pre-versioning document that Load migrates in memory.
+	Version int `json:"version"`
+
+	// ProjectBudgets maps project ID (manifest upload ID) to its budget limits.
+	ProjectBudgets map[string]config.ProjectBudget `json:"project_budgets"`
+
+	// Records is the recorded cost ledger — the running history of upload costs
+	// that backs `budget status` spend/volume totals. Bounded by the caller
+	// (FIFO rotation) so the file can't grow without limit.
+	Records []CostRecord `json:"records,omitempty"`
+}
+
+// Token is an opaque optimistic-concurrency token returned by Load and passed
+// back to Save. The local file store does not use it (returns ""); the S3 store
+// added in Phase B (#246) carries the object ETag here for If-Match writes.
+type Token string
+
+// BudgetStore abstracts durable persistence of budget limits and the cost
+// ledger. Load returns the current state plus a concurrency token; Save writes
+// state, passing back the token from the prior Load so a compare-and-swap
+// implementation can reject a stale write.
+//
+// The local implementation (localStore) is whole-document read/modify/write and
+// ignores the token. Phase B adds an S3-backed implementation that uses it for
+// ETag/If-Match conditional writes.
+type BudgetStore interface {
+	Load() (LedgerState, Token, error)
+	Save(state LedgerState, token Token) error
+}

--- a/pkg/aws/cost/store_test.go
+++ b/pkg/aws/cost/store_test.go
@@ -1,0 +1,185 @@
+package cost
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCostConfig returns a minimal CostControlConfig that uses the static
+// fallback pricing table (no AWS Pricing API calls) so tests are hermetic.
+func testCostConfig() *config.CostControlConfig {
+	return &config.CostControlConfig{
+		Pricing: config.PricingConfig{
+			UseAWSPricingAPI:     false,
+			Currency:             "USD",
+			PricingCacheDuration: "24h",
+		},
+	}
+}
+
+func TestLedgerStore_RoundTrip(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+
+	want := LedgerState{
+		Version: StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{
+			"proj-a": {ProjectID: "proj-a", MaxBudget: 100, MaxVolumeGB: 50},
+		},
+		Records: []CostRecord{
+			{Timestamp: time.Unix(1000, 0).UTC(), Operation: "upload", ProjectID: "proj-a", Cost: 1.5, SizeGB: 10},
+		},
+	}
+	store := localStore{}
+	require.NoError(t, store.Save(want, ""))
+
+	got, tok, err := store.Load()
+	require.NoError(t, err)
+	assert.Equal(t, Token(""), tok, "local store uses no concurrency token")
+	assert.Equal(t, StoreVersion, got.Version)
+	assert.Equal(t, want.ProjectBudgets, got.ProjectBudgets)
+	require.Len(t, got.Records, 1)
+	assert.Equal(t, 1.5, got.Records[0].Cost)
+}
+
+func TestLedgerStore_MissingFileIsEmpty(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "nope.json"))
+
+	got, _, err := localStore{}.Load()
+	require.NoError(t, err)
+	assert.Equal(t, StoreVersion, got.Version)
+	assert.Empty(t, got.ProjectBudgets)
+	assert.Empty(t, got.Records)
+}
+
+// TestLedgerStore_MigratesLegacyFormat writes a pre-#246 bare-map file and
+// asserts Load migrates it to the versioned shape without losing limits, then
+// the next Save rewrites it in the new format.
+func TestLedgerStore_MigratesLegacyFormat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "budgets.json")
+	t.Setenv(budgetStoreEnvOverride, path)
+
+	// Legacy on-disk shape: a bare map[string]ProjectBudget, no "version" key.
+	legacy := map[string]config.ProjectBudget{
+		"proj-a": {ProjectID: "proj-a", MaxBudget: 100},
+		"proj-b": {ProjectID: "proj-b", MaxBudget: 250, MaxVolumeGB: 30},
+	}
+	data, err := json.MarshalIndent(legacy, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+
+	store := localStore{}
+	got, _, err := store.Load()
+	require.NoError(t, err)
+	assert.Equal(t, StoreVersion, got.Version, "legacy file migrated to current version")
+	assert.Equal(t, legacy, got.ProjectBudgets, "limits preserved through migration")
+	assert.Empty(t, got.Records)
+
+	// Persisting rewrites the file in the new versioned shape.
+	require.NoError(t, store.Save(got, ""))
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var probe map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &probe))
+	_, hasVersion := probe["version"]
+	assert.True(t, hasVersion, "rewritten file must carry a version field")
+}
+
+// TestManager_RehydratesLedger seeds a store with records and asserts a freshly
+// constructed Manager surfaces the persisted spend/volume.
+func TestManager_RehydratesLedger(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+
+	seed := LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{"proj-x": {ProjectID: "proj-x", MaxBudget: 100}},
+		Records: []CostRecord{
+			{Timestamp: time.Unix(1, 0).UTC(), Operation: "upload", ProjectID: "proj-x", Cost: 2.0, SizeGB: 5},
+			{Timestamp: time.Unix(2, 0).UTC(), Operation: "upload", ProjectID: "proj-x", Cost: 3.0, SizeGB: 7},
+		},
+	}
+	require.NoError(t, localStore{}.Save(seed, ""))
+
+	mgr, err := NewManager(testCostConfig(), aws.Config{}, nil)
+	require.NoError(t, err)
+	assert.InDelta(t, 5.0, mgr.reporter.GetProjectCosts("proj-x"), 1e-9)
+	assert.InDelta(t, 12.0, mgr.reporter.GetProjectVolume("proj-x"), 1e-9)
+}
+
+// TestManager_LedgerSurvivesSetProjectBudget guards the clobber trap: recording
+// spend then setting a budget for another project must not drop the ledger.
+func TestManager_LedgerSurvivesSetProjectBudget(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+
+	// Seed a record for proj-x directly, then persist via a Manager.
+	require.NoError(t, localStore{}.Save(LedgerState{
+		Version: StoreVersion,
+		Records: []CostRecord{{Timestamp: time.Unix(1, 0).UTC(), ProjectID: "proj-x", Cost: 4.0, SizeGB: 8}},
+	}, ""))
+
+	mgr, err := NewManager(testCostConfig(), aws.Config{}, nil)
+	require.NoError(t, err)
+	// Set a budget for a DIFFERENT project — must preserve proj-x's records.
+	require.NoError(t, mgr.SetProjectBudget("proj-y", 500, 0, 0.8, 0.75))
+
+	got, _, err := localStore{}.Load()
+	require.NoError(t, err)
+	require.Len(t, got.Records, 1, "recorded ledger must survive a budget set")
+	assert.Equal(t, "proj-x", got.Records[0].ProjectID)
+	_, hasY := got.ProjectBudgets["proj-y"]
+	assert.True(t, hasY, "new budget must be persisted alongside the ledger")
+}
+
+// TestManager_TwoProcessDurability proves spend recorded by one Manager is
+// visible to a fresh Manager reading the same store — the core #246 promise.
+func TestManager_TwoProcessDurability(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+	ctx := context.Background()
+
+	// "Process 1": record a completed upload for proj-x.
+	mgrA, err := NewManager(testCostConfig(), aws.Config{}, nil)
+	require.NoError(t, err)
+	const sizeBytes = int64(20 * 1024 * 1024 * 1024) // 20 GB
+	require.NoError(t, mgrA.RecordCompletedUpload(ctx, "upload-1", sizeBytes, config.StorageClassStandard, "us-east-1", "upload-1", "proj-x", nil))
+	spentA := mgrA.reporter.GetProjectCosts("proj-x")
+	require.Greater(t, spentA, 0.0, "recording should produce non-zero spend")
+
+	// "Process 2": a fresh Manager reloads from disk and sees the same spend.
+	mgrB, err := NewManager(testCostConfig(), aws.Config{}, nil)
+	require.NoError(t, err)
+	assert.InDelta(t, spentA, mgrB.reporter.GetProjectCosts("proj-x"), 1e-9,
+		"spend must be durable across Manager instances (process restarts)")
+	assert.InDelta(t, 20.0, mgrB.reporter.GetProjectVolume("proj-x"), 1e-6)
+}
+
+// TestManager_LedgerRotation asserts the persisted ledger is capped (FIFO).
+func TestManager_LedgerRotation(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+
+	// Seed just over the cap with monotonically increasing markers.
+	records := make([]CostRecord, maxLedgerRecords+5)
+	for i := range records {
+		records[i] = CostRecord{Timestamp: time.Unix(int64(i), 0).UTC(), ProjectID: "p", Cost: float64(i)}
+	}
+	require.NoError(t, localStore{}.Save(LedgerState{Version: StoreVersion, Records: records}, ""))
+
+	mgr, err := NewManager(testCostConfig(), aws.Config{}, nil)
+	require.NoError(t, err)
+	// Trigger a save (which applies rotation) via SetProjectBudget.
+	require.NoError(t, mgr.SetProjectBudget("p", 1, 0, 0.8, 0.75))
+
+	got, _, err := localStore{}.Load()
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(got.Records), maxLedgerRecords, "ledger must be capped")
+	// The newest record (highest marker) must be retained; the oldest dropped.
+	last := got.Records[len(got.Records)-1]
+	assert.Equal(t, float64(maxLedgerRecords+4), last.Cost, "newest record retained after FIFO rotation")
+}


### PR DESCRIPTION
## Summary

Phase A of #246. Two verified gaps made `cargoship budget status <project>` useless:

1. **Uploads never recorded spend** — `RecordOperationCost` had no caller from the upload command, so the cost ledger was always empty in production.
2. **Spend was never persisted** — even when recorded it lived only in an in-memory `CostReporter.costs` slice that died at process exit.

Net effect: `budget status` always showed **$0 spent**. This makes the ledger real and durable **locally**, end-to-end — behind a `BudgetStore` interface whose signature is Phase-B-ready so Phase B (S3 + ETag CAS + persisted global/team budget) only adds an `s3Store`.

## Changes
- **`store.go` (new):** `BudgetStore` interface (`Load`/`Save` with an opaque `Token` for Phase B's CAS), versioned `LedgerState{Version, ProjectBudgets, Records}`.
- **`budget_store.go`:** `localStore` implements `BudgetStore` over the existing atomic temp+rename write; **lazy migration** of the legacy bare-map `budgets.json` to v1 (limits preserved, rewritten on next save). `load/saveProjectBudgets` retained as ledger-preserving shims.
- **`reporting.go`:** `CostReporter.SeedRecords`/`SnapshotRecords` for rehydration + race-safe persistence snapshots.
- **`manager.go`:** `store` field + `newManagerWithStore` test seam; `NewManager` loads & seeds the ledger; **`RecordCompletedUpload`** records an already-finished upload (no enforcement early-return, so over-budget spend is still recorded) and persists; `saveState` writes limits+ledger **together** (FIFO-capped at 10k) so a `budget set` can't clobber spend history.
- **`budget.go`:** `SetProjectBudget`/`DeleteProjectBudget` persist via `saveState`.
- **`upload.go`:** after a successful upload, **gated on `--project`**, record spend (best-effort — a failure warns, never fails the command). Plain uploads with no `--project` write nothing → **default behavior unchanged**.

## Testing
- Unit: store round-trip, legacy→v1 migration, missing-file, FIFO rotation, ledger rehydration, **clobber guard** (`budget set` preserves records), **two-process durability** (spend recorded by one Manager is seen by a fresh one), and the upload-hook end-to-end.
- `pkg/aws/cost` coverage **73.2%** (floor 72); coverage ratchet + full pre-commit gate green (A+).
- Manual (real binary): `budget set`/`status` round-trip with `version:1` store; legacy file migrates on read and rewrites v1 on next `set`; `--project` gating confirmed.

## Scope
Phase A only. **Phase B** (S3-backed store, `If-Match` CAS, persisted global/team budget, `budget set --store s3://…`) is the separate follow-up tracked in #246. Pre-flight enforcement that *blocks* an over-budget upload and accurate partial-upload attribution are out of scope (documented).

Part of #246.