### PR TITLE
feat: S3-backed budget store with optimistic-concurrency writes (#246 Phase B, PR1)

### DIFF
--- a/cmd/cargoship/cmd/budget.go
+++ b/cmd/cargoship/cmd/budget.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -55,6 +56,13 @@ Examples:
 			return cmd.Help()
 		},
 	}
+
+	// --store selects where budgets persist (#246 Phase B). Default (empty) is
+	// the local file; an s3://bucket/prefix value stores budgets in S3 with
+	// optimistic-concurrency writes so they're durable and shareable across
+	// machines. Persistent so every subcommand inherits it.
+	cmd.PersistentFlags().StringVar(&budgetStoreFlag, "store", "",
+		"Budget store location: local (default) or s3://bucket/prefix for a shared, durable store")
 
 	// Add subcommands
 	cmd.AddCommand(newBudgetStatusCmd())
@@ -410,6 +418,11 @@ func isDVCProject(id string) bool {
 	return id == "dvc_cache" || strings.HasPrefix(id, "dvc_")
 }
 
+// budgetStoreFlag holds the value of the `--store` persistent flag on the budget
+// command. Empty means "use the default" (config key, then CARGOSHIP_BUDGET_STORE
+// env, then the local file).
+var budgetStoreFlag string
+
 // Helper function to load cost manager
 func loadCostManager(ctx context.Context) (*cost.Manager, error) {
 	// Load AWS config
@@ -421,8 +434,20 @@ func loadCostManager(ctx context.Context) (*cost.Manager, error) {
 	// Load CargoShip config (use default for now)
 	cargoConfig := cargoconfig.DefaultAWSConfig()
 
+	// Resolve the budget-store location (#246 Phase B). Precedence: --store flag,
+	// then the config key, then the CARGOSHIP_BUDGET_STORE env (which may be an
+	// s3:// URL or a local path), then the local default. An empty spec selects
+	// the local store.
+	spec := budgetStoreFlag
+	if spec == "" {
+		spec = cargoConfig.CostControl.BudgetStoreLocation
+	}
+	if spec == "" {
+		spec = os.Getenv("CARGOSHIP_BUDGET_STORE")
+	}
+
 	// Create cost manager
-	manager, err := cost.NewManager(&cargoConfig.CostControl, awsCfg, nil)
+	manager, err := cost.NewManagerWithStoreSpec(ctx, &cargoConfig.CostControl, awsCfg, nil, spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cost manager: %w", err)
 	}

--- a/pkg/aws/config/config.go
+++ b/pkg/aws/config/config.go
@@ -75,6 +75,13 @@ type CostControlConfig struct {
 	// If not set, projects use the global budget period
 	ProjectBudgets map[string]ProjectBudget `yaml:"project_budgets,omitempty" json:"project_budgets,omitempty"`
 
+	// BudgetStoreLocation selects where budgets persist (#246 Phase B). Empty
+	// means the local file (~/.cargoship/budgets.json); an "s3://bucket/prefix"
+	// value uses an S3-backed store with optimistic-concurrency writes so
+	// budgets are durable and shareable across machines. Overridden by the
+	// `budget --store` flag and the CARGOSHIP_BUDGET_STORE env var.
+	BudgetStoreLocation string `yaml:"budget_store_location,omitempty" json:"budget_store_location,omitempty"`
+
 	// Enable automatic cost optimization
 	AutoOptimize bool `yaml:"auto_optimize" json:"auto_optimize"`
 

--- a/pkg/aws/cost/budget.go
+++ b/pkg/aws/cost/budget.go
@@ -515,6 +515,12 @@ func (m *Manager) SetProjectBudget(projectID string, maxBudget float64, maxVolum
 	if projectID == "" {
 		return fmt.Errorf("project ID cannot be empty")
 	}
+	// The project ID becomes part of an S3 object key when using the S3-backed
+	// store (#246); reject separators and control characters so it can't inject
+	// a key prefix or a malformed key.
+	if err := validateProjectID(projectID); err != nil {
+		return err
+	}
 	if maxBudget < 0 {
 		return fmt.Errorf("max budget cannot be negative (use 0 for unlimited)")
 	}

--- a/pkg/aws/cost/manager.go
+++ b/pkg/aws/cost/manager.go
@@ -58,6 +58,40 @@ func NewManager(cfg *config.CostControlConfig, awsCfg aws.Config, logger *slog.L
 	return newManagerWithStore(cfg, awsCfg, logger, localStore{})
 }
 
+// NewManagerWithStoreSpec creates a cost manager backed by the budget store
+// named by spec (#246 Phase B). An empty spec, a local path, or a
+// non-s3:// value selects the local store (default, back-compat); an
+// "s3://bucket/prefix" spec selects the S3-backed store with optimistic-
+// concurrency writes and a local write-through cache. ctx is used for the S3
+// client and its requests.
+func NewManagerWithStoreSpec(ctx context.Context, cfg *config.CostControlConfig, awsCfg aws.Config, logger *slog.Logger, spec string) (*Manager, error) {
+	store, err := newStoreForSpec(ctx, spec, awsCfg)
+	if err != nil {
+		return nil, err
+	}
+	return newManagerWithStore(cfg, awsCfg, logger, store)
+}
+
+// newStoreForSpec resolves a store spec to a BudgetStore. Empty/local specs
+// return localStore{}; an s3:// spec returns an s3Store wired to a cached S3
+// client with a local write-through mirror.
+func newStoreForSpec(ctx context.Context, spec string, awsCfg aws.Config) (BudgetStore, error) {
+	isS3, bucket, prefix, err := parseStoreSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	if !isS3 {
+		return localStore{}, nil
+	}
+	client, err := config.GetOrCreateS3Client(ctx, bucket, awsCfg.Region, "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create s3 client for budget store: %w", err)
+	}
+	// Mirror to the local store so `budget status` still works offline.
+	mirror := localStore{}
+	return newS3Store(ctx, client, bucket, prefix, &mirror), nil
+}
+
 // newManagerWithStore is the injectable constructor used by tests to supply a
 // custom BudgetStore. Production code uses NewManager.
 func newManagerWithStore(cfg *config.CostControlConfig, awsCfg aws.Config, logger *slog.Logger, store BudgetStore) (*Manager, error) {

--- a/pkg/aws/cost/s3_store.go
+++ b/pkg/aws/cost/s3_store.go
@@ -1,0 +1,576 @@
+package cost
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+)
+
+// s3API is the subset of *s3.Client that s3Store uses. Extracted as an interface
+// so the compare-and-swap loop can be exercised by a fake client in unit tests
+// (mirrors the pricingAPIClient pattern in pricing_api.go). *s3.Client satisfies it.
+type s3API interface {
+	GetObject(ctx context.Context, in *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	PutObject(ctx context.Context, in *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	ListObjectsV2(ctx context.Context, in *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+const (
+	globalObjectName   = "global.json"
+	projectsPrefix     = "projects/"
+	defaultStorePrefix = ".cargoship/"
+	defaultMaxCASRetry = 5
+	defaultCASBaseWait = 50 * time.Millisecond
+	casMaxWait         = 2 * time.Second
+)
+
+// s3Store is an S3-backed BudgetStore. It persists one object per project plus a
+// global object, and uses S3 conditional writes (If-Match / If-None-Match) for
+// optimistic-concurrency compare-and-swap so concurrent writers from different
+// machines converge without lost updates (#246 Phase B).
+//
+// The BudgetStore interface stays whole-document (Load returns the full
+// LedgerState); the per-object layout and CAS live entirely inside this type.
+// The opaque Token carries a serialized map of per-object ETags (s3Token).
+type s3Store struct {
+	client   s3API
+	bucket   string
+	prefix   string // normalized to end with "/"
+	ctx      context.Context
+	maxRetry int
+	baseWait time.Duration
+	now      func() time.Time
+	randf    func() float64 // jitter source in [0,1); injectable for deterministic tests
+
+	// mirror is an optional local write-through cache used to serve reads when S3
+	// is unreachable. Nil disables mirroring.
+	mirror *localStore
+
+	// lastLoaded is the LedgerState returned by the most recent Load, used by
+	// Save to compute which records are new (this process's appends) so a 412
+	// re-GET can union-merge instead of clobbering a concurrent writer's records.
+	lastLoaded *LedgerState
+
+	// loadedGlobalBudget is the raw global_budget blob observed at Load time.
+	// PR1 never sets a global budget; carrying it through keeps a PR2-written
+	// value from being wiped by a PR1 save (forward-compat).
+	loadedGlobalBudget json.RawMessage
+}
+
+// s3Token is the concrete payload serialized into the opaque cost.Token. It maps
+// each persisted object to the ETag observed at Load time. An empty ETag for a
+// key means the object did not exist (first write uses If-None-Match:*).
+type s3Token struct {
+	Global   string            `json:"global"`
+	Projects map[string]string `json:"projects"`
+}
+
+func encodeToken(t s3Token) Token {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return ""
+	}
+	return Token(b)
+}
+
+// decodeToken is tolerant: an empty or malformed token decodes to the zero value,
+// which drives every object down the "unknown ETag" path (re-GET before write)
+// rather than risking an unsafe unconditional overwrite.
+func decodeToken(tok Token) s3Token {
+	t := s3Token{Projects: map[string]string{}}
+	if tok == "" {
+		return t
+	}
+	_ = json.Unmarshal([]byte(tok), &t)
+	if t.Projects == nil {
+		t.Projects = map[string]string{}
+	}
+	return t
+}
+
+// projectDoc is the per-project S3 object: one budget plus that project's ledger.
+type projectDoc struct {
+	Version int                  `json:"version"`
+	Budget  config.ProjectBudget `json:"budget"`
+	Records []CostRecord         `json:"records,omitempty"`
+}
+
+// globalDoc is the global.json S3 object: the global budget plus records that
+// aren't attributable to a project with its own object.
+type globalDoc struct {
+	Version int          `json:"version"`
+	Records []CostRecord `json:"records,omitempty"`
+	// GlobalBudget is populated in PR2 (persisted global/team budget); kept here
+	// as raw JSON for forward-compat so a PR2-written object round-trips through
+	// a PR1 binary without data loss.
+	GlobalBudget json.RawMessage `json:"global_budget,omitempty"`
+}
+
+// parseStoreSpec classifies a budget-store location. An empty spec, or any value
+// that isn't an s3:// URL, means "use the local store" (the caller falls back to
+// localStore / the CARGOSHIP_BUDGET_STORE path). An s3://bucket/prefix spec
+// selects the S3 store; the prefix is normalized to end with "/" and defaults to
+// ".cargoship/" when only a bucket is given.
+func parseStoreSpec(spec string) (isS3 bool, bucket, prefix string, err error) {
+	if spec == "" || !strings.HasPrefix(spec, "s3://") {
+		return false, "", "", nil
+	}
+	rest := strings.TrimPrefix(spec, "s3://")
+	if rest == "" {
+		return false, "", "", fmt.Errorf("invalid s3 store spec %q: missing bucket", spec)
+	}
+	bucket, prefix, _ = strings.Cut(rest, "/")
+	if bucket == "" {
+		return false, "", "", fmt.Errorf("invalid s3 store spec %q: missing bucket", spec)
+	}
+	prefix = strings.Trim(prefix, "/")
+	if prefix == "" {
+		prefix = strings.TrimSuffix(defaultStorePrefix, "/")
+	}
+	return true, bucket, prefix + "/", nil
+}
+
+// newS3Store builds an S3-backed store. client must be non-nil (*s3.Client in
+// production, a fake in tests). mirror may be nil to disable the local cache.
+func newS3Store(ctx context.Context, client s3API, bucket, prefix string, mirror *localStore) *s3Store {
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return &s3Store{
+		client:   client,
+		bucket:   bucket,
+		prefix:   prefix,
+		ctx:      ctx,
+		maxRetry: defaultMaxCASRetry,
+		baseWait: defaultCASBaseWait,
+		now:      time.Now,
+		randf:    pseudoRand(),
+		mirror:   mirror,
+	}
+}
+
+func (s *s3Store) globalKey() string { return s.prefix + globalObjectName }
+
+func (s *s3Store) projectKey(projectID string) string {
+	return s.prefix + projectsPrefix + url.PathEscape(projectID) + ".json"
+}
+
+// Load lists and fetches every store object, reassembling the whole LedgerState
+// and a composite token of per-object ETags. A missing/empty store is not an
+// error (empty state). When S3 is unreachable and a mirror is configured, it
+// serves the cached state with an empty token (which forces a real S3 Load
+// before any subsequent Save, so we never CAS-write off stale cache).
+func (s *s3Store) Load() (LedgerState, Token, error) {
+	state, tok, err := s.loadFromS3()
+	if err != nil {
+		if s.mirror != nil {
+			if ms, _, mErr := s.mirror.Load(); mErr == nil {
+				cached := ms
+				s.lastLoaded = &cached
+				return ms, "", nil // empty token: reads OK, writes must re-Load from S3
+			}
+		}
+		return LedgerState{}, "", err
+	}
+	cached := state
+	s.lastLoaded = &cached
+	return state, tok, nil
+}
+
+func (s *s3Store) loadFromS3() (LedgerState, Token, error) {
+	keys, err := s.listKeys()
+	if err != nil {
+		return LedgerState{}, "", err
+	}
+
+	state := LedgerState{Version: StoreVersion, ProjectBudgets: map[string]config.ProjectBudget{}}
+	tokenData := s3Token{Projects: map[string]string{}}
+
+	// Global object.
+	if hasKey(keys, s.globalKey()) {
+		body, etag, gErr := s.getObject(s.globalKey())
+		if gErr != nil {
+			return LedgerState{}, "", gErr
+		}
+		if body != nil {
+			var gd globalDoc
+			if uErr := json.Unmarshal(body, &gd); uErr != nil {
+				return LedgerState{}, "", fmt.Errorf("parse %s: %w", s.globalKey(), uErr)
+			}
+			state.Records = append(state.Records, gd.Records...)
+			tokenData.Global = etag
+			s.loadedGlobalBudget = gd.GlobalBudget
+		}
+	}
+
+	// Project objects.
+	pfx := s.prefix + projectsPrefix
+	for _, key := range keys {
+		if !strings.HasPrefix(key, pfx) || !strings.HasSuffix(key, ".json") {
+			continue
+		}
+		body, etag, gErr := s.getObject(key)
+		if gErr != nil {
+			return LedgerState{}, "", gErr
+		}
+		if body == nil {
+			continue
+		}
+		var pd projectDoc
+		if uErr := json.Unmarshal(body, &pd); uErr != nil {
+			return LedgerState{}, "", fmt.Errorf("parse %s: %w", key, uErr)
+		}
+		id := pd.Budget.ProjectID
+		if id == "" {
+			// Recover the ID from the key if the doc didn't carry it.
+			id = projectIDFromKey(key, pfx)
+		}
+		if id != "" {
+			state.ProjectBudgets[id] = pd.Budget
+			tokenData.Projects[id] = etag
+		}
+		state.Records = append(state.Records, pd.Records...)
+	}
+
+	return state, encodeToken(tokenData), nil
+}
+
+// Save splits the whole LedgerState into per-object docs and writes each changed
+// object with a conditional PUT (CAS). Records new since the last Load are
+// union-merged into concurrently-updated objects on a 412, so no writer's
+// records are lost.
+func (s *s3Store) Save(state LedgerState, token Token) error {
+	prev := decodeToken(token)
+
+	// Records this process added since Load (used for loss-free merge on 412).
+	newRecords := s.recordsAddedSince(state.Records)
+
+	// Route records to their owning object: a record whose ProjectID has a budget
+	// goes in that project's object; everything else goes to global.json.
+	projRecords, globalRecords := routeRecords(state.Records, state.ProjectBudgets)
+
+	// Write each project object.
+	for id, budget := range state.ProjectBudgets {
+		doc := projectDoc{Version: StoreVersion, Budget: budget, Records: projRecords[id]}
+		mine := recordsForProject(newRecords, id, state.ProjectBudgets)
+		if err := s.saveObject(s.projectKey(id), prev.Projects[id], doc, mine); err != nil {
+			return err
+		}
+	}
+
+	// Write global object (records + preserved forward-compat global budget blob).
+	gdoc := globalDoc{Version: StoreVersion, Records: globalRecords, GlobalBudget: s.loadedGlobalBudget}
+	mineGlobal := recordsForProject(newRecords, "", state.ProjectBudgets)
+	if err := s.saveObject(s.globalKey(), prev.Global, gdoc, mineGlobal); err != nil {
+		return err
+	}
+
+	// Delete project objects that existed before but are gone now (budget removed).
+	for id := range prev.Projects {
+		if _, still := state.ProjectBudgets[id]; !still {
+			_, _ = s.client.DeleteObject(s.ctx, &s3.DeleteObjectInput{
+				Bucket: aws.String(s.bucket),
+				Key:    aws.String(s.projectKey(id)),
+			})
+		}
+	}
+
+	// Best-effort write-through to the local mirror so reads work offline.
+	if s.mirror != nil {
+		if err := s.mirror.Save(state, ""); err != nil {
+			// non-fatal: the authoritative S3 write already succeeded
+			_ = err
+		}
+	}
+	return nil
+}
+
+// saveObject marshals doc and writes it under a per-object CAS loop. mineRecords
+// are the records this process contributed to this object, re-merged on conflict.
+func (s *s3Store) saveObject(key, knownETag string, doc any, mineRecords []CostRecord) error {
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", key, err)
+	}
+	_, err = s.putConditional(key, data, knownETag, doc, mineRecords)
+	return err
+}
+
+// putConditional writes data to key with a conditional PUT, retrying on a 412
+// PreconditionFailed by re-reading the object, union-merging this process's own
+// records onto the fresh state, and backing off. Returns the new ETag.
+func (s *s3Store) putConditional(key string, data []byte, knownETag string, doc any, mineRecords []CostRecord) (string, error) {
+	for attempt := 0; ; attempt++ {
+		in := &s3.PutObjectInput{
+			Bucket: aws.String(s.bucket),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader(data),
+		}
+		if knownETag == "" {
+			in.IfNoneMatch = aws.String("*") // create-only: fail if it already exists
+		} else {
+			in.IfMatch = aws.String(knownETag) // update: fail if changed under us
+		}
+		out, err := s.client.PutObject(s.ctx, in)
+		if err == nil {
+			return aws.ToString(out.ETag), nil
+		}
+		if !isPreconditionFailed(err) || attempt >= s.maxRetry {
+			return "", fmt.Errorf("conditional put %s: %w", key, err)
+		}
+		// Conflict: re-read the object, merge our records onto the fresh state,
+		// recompute the bytes + ETag, back off, and retry.
+		freshBody, freshETag, gErr := s.getObject(key)
+		if gErr != nil {
+			return "", gErr
+		}
+		merged, mErr := mergeDoc(doc, freshBody, mineRecords)
+		if mErr != nil {
+			return "", mErr
+		}
+		data = merged
+		knownETag = freshETag
+		s.backoff(attempt)
+	}
+}
+
+// mergeDoc re-applies this process's records onto the freshly-read object body.
+// For a project or global doc, the merged record set is (fresh records ∪ ours)
+// deduped by identity, so concurrent appends are loss-free; non-record fields
+// (the budget) keep the value from doc (last-writer-wins, fine for human edits).
+func mergeDoc(doc any, freshBody []byte, mineRecords []CostRecord) ([]byte, error) {
+	switch d := doc.(type) {
+	case projectDoc:
+		var fresh projectDoc
+		if freshBody != nil {
+			if err := json.Unmarshal(freshBody, &fresh); err != nil {
+				return nil, fmt.Errorf("merge project doc: %w", err)
+			}
+		}
+		d.Records = unionRecords(fresh.Records, mineRecords)
+		return json.MarshalIndent(d, "", "  ")
+	case globalDoc:
+		var fresh globalDoc
+		if freshBody != nil {
+			if err := json.Unmarshal(freshBody, &fresh); err != nil {
+				return nil, fmt.Errorf("merge global doc: %w", err)
+			}
+		}
+		d.Records = unionRecords(fresh.Records, mineRecords)
+		if len(d.GlobalBudget) == 0 {
+			d.GlobalBudget = fresh.GlobalBudget
+		}
+		return json.MarshalIndent(d, "", "  ")
+	default:
+		return nil, fmt.Errorf("mergeDoc: unsupported doc type %T", doc)
+	}
+}
+
+// recordsAddedSince returns records present in current but not in the LedgerState
+// returned by the last Load (this process's appends), keyed by record identity.
+func (s *s3Store) recordsAddedSince(current []CostRecord) []CostRecord {
+	seen := map[string]bool{}
+	if s.lastLoaded != nil {
+		for _, r := range s.lastLoaded.Records {
+			seen[recordKey(r)] = true
+		}
+	}
+	var added []CostRecord
+	for _, r := range current {
+		if !seen[recordKey(r)] {
+			added = append(added, r)
+		}
+	}
+	return added
+}
+
+// getObject fetches an object body and ETag. A NoSuchKey / 404 is reported as a
+// nil body with an empty ETag (absent), not an error.
+func (s *s3Store) getObject(key string) ([]byte, string, error) {
+	out, err := s.client.GetObject(s.ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, "", nil
+		}
+		return nil, "", fmt.Errorf("get %s: %w", key, err)
+	}
+	defer func() { _ = out.Body.Close() }()
+	body, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read %s: %w", key, err)
+	}
+	return body, aws.ToString(out.ETag), nil
+}
+
+func (s *s3Store) listKeys() ([]string, error) {
+	var keys []string
+	var token *string
+	for {
+		out, err := s.client.ListObjectsV2(s.ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(s.bucket),
+			Prefix:            aws.String(s.prefix),
+			ContinuationToken: token,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list %s: %w", s.prefix, err)
+		}
+		for _, obj := range out.Contents {
+			keys = append(keys, aws.ToString(obj.Key))
+		}
+		if out.IsTruncated == nil || !*out.IsTruncated {
+			break
+		}
+		token = out.NextContinuationToken
+	}
+	return keys, nil
+}
+
+func (s *s3Store) backoff(attempt int) {
+	wait := s.baseWait << attempt
+	if wait > casMaxWait || wait <= 0 {
+		wait = casMaxWait
+	}
+	jitter := s.randf()
+	time.Sleep(time.Duration(float64(wait) * jitter))
+}
+
+// --- helpers ---
+
+// routeRecords partitions records: those whose ProjectID has a budget object go
+// under that project; everything else (including empty ProjectID) goes global.
+func routeRecords(records []CostRecord, budgets map[string]config.ProjectBudget) (perProject map[string][]CostRecord, global []CostRecord) {
+	perProject = map[string][]CostRecord{}
+	for _, r := range records {
+		if _, ok := budgets[r.ProjectID]; ok && r.ProjectID != "" {
+			perProject[r.ProjectID] = append(perProject[r.ProjectID], r)
+		} else {
+			global = append(global, r)
+		}
+	}
+	return perProject, global
+}
+
+// recordsForProject filters a record slice to those routed to project id (or to
+// global when id == "").
+func recordsForProject(records []CostRecord, id string, budgets map[string]config.ProjectBudget) []CostRecord {
+	var out []CostRecord
+	for _, r := range records {
+		_, hasBudget := budgets[r.ProjectID]
+		routed := ""
+		if hasBudget && r.ProjectID != "" {
+			routed = r.ProjectID
+		}
+		if routed == id {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// unionRecords returns the set union of two record slices, deduped by identity,
+// preserving a stable order (existing first, then new).
+func unionRecords(existing, added []CostRecord) []CostRecord {
+	seen := map[string]bool{}
+	out := make([]CostRecord, 0, len(existing)+len(added))
+	for _, r := range existing {
+		k := recordKey(r)
+		if !seen[k] {
+			seen[k] = true
+			out = append(out, r)
+		}
+	}
+	for _, r := range added {
+		k := recordKey(r)
+		if !seen[k] {
+			seen[k] = true
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// recordKey is the identity used to dedupe records across concurrent writers.
+func recordKey(r CostRecord) string {
+	return r.JobID + "\x00" + r.FileName + "\x00" + r.Timestamp.UTC().Format(time.RFC3339Nano)
+}
+
+// validateProjectID rejects project IDs that would be unsafe as an S3 object key
+// component: path separators and control characters. Normal manifest upload IDs
+// (e.g. "20251206-abc123") and typical user labels pass.
+func validateProjectID(id string) error {
+	if strings.ContainsAny(id, "/\\") {
+		return fmt.Errorf("project ID %q must not contain path separators", id)
+	}
+	for _, r := range id {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("project ID %q must not contain control characters", id)
+		}
+	}
+	return nil
+}
+
+func projectIDFromKey(key, pfx string) string {
+	name := strings.TrimSuffix(strings.TrimPrefix(key, pfx), ".json")
+	if id, err := url.PathUnescape(name); err == nil {
+		return id
+	}
+	return name
+}
+
+func hasKey(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// isPreconditionFailed reports whether err is an S3 412 PreconditionFailed. This
+// status is NOT a modeled SDK error type, so detect it via the generic smithy
+// APIError code.
+func isPreconditionFailed(err error) bool {
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == "PreconditionFailed"
+}
+
+// isNotFound reports whether err is a NoSuchKey (modeled) or a generic 404.
+func isNotFound(err error) bool {
+	var nsk *s3types.NoSuchKey
+	if errors.As(err, &nsk) {
+		return true
+	}
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && (apiErr.ErrorCode() == "NoSuchKey" || apiErr.ErrorCode() == "NotFound")
+}
+
+// pseudoRand returns a deterministic-enough jitter source without pulling in
+// math/rand global state; it walks a simple LCG seeded from a fixed value. Tests
+// override s.randf for determinism, and jitter needn't be cryptographic.
+func pseudoRand() func() float64 {
+	state := uint64(0x2545F4914F6CDD1D)
+	return func() float64 {
+		state = state*6364136223846793005 + 1442695040888963407
+		// use the top 53 bits for a [0,1) float; keep it in (0.5,1] so backoff
+		// never collapses to zero wait.
+		v := float64(state>>11) / float64(1<<53)
+		return 0.5 + v/2
+	}
+}

--- a/pkg/aws/cost/s3_store_integration_test.go
+++ b/pkg/aws/cost/s3_store_integration_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+package cost
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssdkconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the S3-backed budget store against a REAL S3 bucket.
+// They self-skip unless CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS=1 and AWS config
+// loads. Bucket from CARGOSHIP_TEST_BUCKET, region from AWS_REGION; credentials
+// via AWS_PROFILE (local) or the default chain (CI/OIDC). They run in the
+// nightly real-AWS lane (.github/workflows/nightly-aws.yml).
+
+func realS3StoreClient(t *testing.T) (*s3.Client, string) {
+	t.Helper()
+	if os.Getenv("CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS") != "1" {
+		t.Skip("Skipping real-AWS budget store test; set CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS=1 to run")
+	}
+	bucket := os.Getenv("CARGOSHIP_TEST_BUCKET")
+	if bucket == "" {
+		t.Skip("CARGOSHIP_TEST_BUCKET not set")
+	}
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "us-west-2"
+	}
+	ctx := context.Background()
+	opts := []func(*awssdkconfig.LoadOptions) error{awssdkconfig.WithRegion(region)}
+	if profile := os.Getenv("AWS_PROFILE"); profile != "" {
+		opts = append(opts, awssdkconfig.WithSharedConfigProfile(profile))
+	}
+	cfg, err := awssdkconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		t.Skipf("AWS config not available: %v", err)
+	}
+	return s3.NewFromConfig(cfg), bucket
+}
+
+// TestS3Store_TwoConcurrentWritersConverge proves loss-free convergence: two
+// independent stores each record a distinct upload for the same project
+// concurrently; after both settle, a fresh Load contains BOTH records — the
+// If-Match CAS + union-merge handled the 412 conflict without dropping either.
+func TestS3Store_TwoConcurrentWritersConverge(t *testing.T) {
+	client, bucket := realS3StoreClient(t)
+	ctx := context.Background()
+	// Unique prefix per run so concurrent CI runs don't collide.
+	prefix := fmt.Sprintf(".cargoship-itest/%d/", time.Now().UnixNano())
+	t.Cleanup(func() { cleanupPrefix(ctx, client, bucket, prefix) })
+
+	writer := func(jobID string) error {
+		s := newS3Store(ctx, client, bucket, prefix, nil)
+		_, tok, err := s.Load()
+		if err != nil {
+			return err
+		}
+		state := LedgerState{
+			Version:        StoreVersion,
+			ProjectBudgets: map[string]config.ProjectBudget{"proj": {ProjectID: "proj", MaxBudget: 100}},
+			Records: []CostRecord{{
+				Timestamp: time.Now().UTC(), ProjectID: "proj",
+				JobID: jobID, FileName: jobID + ".dat", Cost: 1.0, SizeGB: 1.0,
+			}},
+		}
+		return s.Save(state, tok)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for _, id := range []string{"writerA", "writerB"} {
+		wg.Add(1)
+		go func(jobID string) {
+			defer wg.Done()
+			errs <- writer(jobID)
+		}(id)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err, "concurrent writer should converge via CAS")
+	}
+
+	// Fresh load must contain both records.
+	s := newS3Store(ctx, client, bucket, prefix, nil)
+	got, _, err := s.Load()
+	require.NoError(t, err)
+	jobs := map[string]bool{}
+	for _, r := range got.Records {
+		jobs[r.JobID] = true
+	}
+	require.Truef(t, jobs["writerA"] && jobs["writerB"],
+		"both records must survive concurrent writes; got %v", jobs)
+}
+
+func cleanupPrefix(ctx context.Context, client *s3.Client, bucket, prefix string) {
+	out, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket), Prefix: aws.String(prefix),
+	})
+	if err != nil {
+		return
+	}
+	for _, obj := range out.Contents {
+		_, _ = client.DeleteObject(ctx, &s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: obj.Key})
+	}
+}

--- a/pkg/aws/cost/s3_store_test.go
+++ b/pkg/aws/cost/s3_store_test.go
@@ -1,0 +1,401 @@
+package cost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeS3 is an in-memory s3API with per-key ETags and a hook to inject a
+// PreconditionFailed on the Nth PutObject to a given key (to exercise the CAS
+// retry loop deterministically).
+type fakeS3 struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+	etags   map[string]string
+	seq     int
+
+	putCount map[string]int
+	// fail412On[key] = attempt number (1-based) that should return 412.
+	fail412On map[string]int
+	// alwaysFail412[key] = true returns 412 on every PutObject to key.
+	alwaysFail412 map[string]bool
+
+	puts, gets, lists, deletes int
+}
+
+func newFakeS3() *fakeS3 {
+	return &fakeS3{
+		objects:       map[string][]byte{},
+		etags:         map[string]string{},
+		putCount:      map[string]int{},
+		fail412On:     map[string]int{},
+		alwaysFail412: map[string]bool{},
+	}
+}
+
+func preconditionErr() error {
+	return &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "At least one of the pre-conditions you specified did not hold"}
+}
+
+func (f *fakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.gets++
+	key := aws.ToString(in.Key)
+	body, ok := f.objects[key]
+	if !ok {
+		return nil, &s3types.NoSuchKey{}
+	}
+	return &s3.GetObjectOutput{
+		Body: io.NopCloser(strings.NewReader(string(body))),
+		ETag: aws.String(f.etags[key]),
+	}, nil
+}
+
+func (f *fakeS3) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.puts++
+	key := aws.ToString(in.Key)
+	f.putCount[key]++
+
+	if f.alwaysFail412[key] {
+		return nil, preconditionErr()
+	}
+	if want, ok := f.fail412On[key]; ok && want == f.putCount[key] {
+		return nil, preconditionErr()
+	}
+
+	cur, exists := f.objects[key]
+	_ = cur
+	// Enforce conditional semantics.
+	if in.IfNoneMatch != nil && exists {
+		return nil, preconditionErr() // create-only but object exists
+	}
+	if in.IfMatch != nil && aws.ToString(in.IfMatch) != f.etags[key] {
+		return nil, preconditionErr() // update but ETag changed
+	}
+
+	body, _ := io.ReadAll(in.Body)
+	f.objects[key] = body
+	f.seq++
+	etag := fmt.Sprintf("\"etag-%d\"", f.seq)
+	f.etags[key] = etag
+	return &s3.PutObjectOutput{ETag: aws.String(etag)}, nil
+}
+
+func (f *fakeS3) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lists++
+	prefix := aws.ToString(in.Prefix)
+	var contents []s3types.Object
+	for k := range f.objects {
+		if strings.HasPrefix(k, prefix) {
+			contents = append(contents, s3types.Object{Key: aws.String(k)})
+		}
+	}
+	return &s3.ListObjectsV2Output{Contents: contents}, nil
+}
+
+func (f *fakeS3) DeleteObject(_ context.Context, in *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletes++
+	key := aws.ToString(in.Key)
+	delete(f.objects, key)
+	delete(f.etags, key)
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+// newTestS3Store wires an s3Store to a fake client with deterministic, fast
+// backoff (no real sleeps of consequence).
+func newTestS3Store(f *fakeS3) *s3Store {
+	s := newS3Store(context.Background(), f, "test-bucket", ".cargoship/", nil)
+	s.baseWait = time.Microsecond
+	s.randf = func() float64 { return 1.0 }
+	return s
+}
+
+func TestParseStoreSpec(t *testing.T) {
+	cases := []struct {
+		spec       string
+		wantS3     bool
+		wantBucket string
+		wantPrefix string
+		wantErr    bool
+	}{
+		{"", false, "", "", false},
+		{"/local/path/budgets.json", false, "", "", false},
+		{"s3://mybucket", true, "mybucket", ".cargoship/", false},
+		{"s3://mybucket/", true, "mybucket", ".cargoship/", false},
+		{"s3://mybucket/team/budgets", true, "mybucket", "team/budgets/", false},
+		{"s3://", false, "", "", true},
+	}
+	for _, c := range cases {
+		isS3, bucket, prefix, err := parseStoreSpec(c.spec)
+		if c.wantErr {
+			assert.Error(t, err, "spec %q", c.spec)
+			continue
+		}
+		require.NoError(t, err, "spec %q", c.spec)
+		assert.Equal(t, c.wantS3, isS3, "spec %q isS3", c.spec)
+		assert.Equal(t, c.wantBucket, bucket, "spec %q bucket", c.spec)
+		assert.Equal(t, c.wantPrefix, prefix, "spec %q prefix", c.spec)
+	}
+}
+
+func TestS3Token_RoundTripAndTolerant(t *testing.T) {
+	tok := encodeToken(s3Token{Global: "g1", Projects: map[string]string{"p": "e1"}})
+	got := decodeToken(tok)
+	assert.Equal(t, "g1", got.Global)
+	assert.Equal(t, "e1", got.Projects["p"])
+
+	// Empty and garbage decode to a usable zero value (non-nil map).
+	assert.NotNil(t, decodeToken("").Projects)
+	assert.NotNil(t, decodeToken("not json").Projects)
+}
+
+func TestS3Store_LoadEmptyBucket(t *testing.T) {
+	s := newTestS3Store(newFakeS3())
+	state, tok, err := s.Load()
+	require.NoError(t, err)
+	assert.Equal(t, StoreVersion, state.Version)
+	assert.Empty(t, state.ProjectBudgets)
+	assert.Empty(t, state.Records)
+	// Empty store → token with no per-object etags.
+	assert.Empty(t, decodeToken(tok).Global)
+}
+
+func TestS3Store_SaveThenLoadRoundTrip(t *testing.T) {
+	f := newFakeS3()
+	s := newTestS3Store(f)
+
+	// Seed a fresh load so lastLoaded is set.
+	_, tok, err := s.Load()
+	require.NoError(t, err)
+
+	state := LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{"proj-a": {ProjectID: "proj-a", MaxBudget: 100}},
+		Records: []CostRecord{
+			{Timestamp: time.Unix(1, 0).UTC(), ProjectID: "proj-a", JobID: "j1", FileName: "f1", Cost: 1.5, SizeGB: 3},
+			{Timestamp: time.Unix(2, 0).UTC(), ProjectID: "", JobID: "j2", FileName: "f2", Cost: 0.5, SizeGB: 1}, // global
+		},
+	}
+	require.NoError(t, s.Save(state, tok))
+
+	// Objects landed at the expected keys.
+	_, hasProj := f.objects[".cargoship/projects/proj-a.json"]
+	_, hasGlobal := f.objects[".cargoship/global.json"]
+	assert.True(t, hasProj, "project object should exist")
+	assert.True(t, hasGlobal, "global object should exist")
+
+	// A fresh store reloads the whole state.
+	s2 := newTestS3Store(f)
+	got, _, err := s2.Load()
+	require.NoError(t, err)
+	assert.Equal(t, 100.0, got.ProjectBudgets["proj-a"].MaxBudget)
+	require.Len(t, got.Records, 2)
+	// Records reassembled from both objects (order: global first, then project).
+	var jobIDs []string
+	for _, r := range got.Records {
+		jobIDs = append(jobIDs, r.JobID)
+	}
+	assert.ElementsMatch(t, []string{"j1", "j2"}, jobIDs)
+}
+
+func TestS3Store_FirstWriteUsesIfNoneMatch(t *testing.T) {
+	f := newFakeS3()
+	s := newTestS3Store(f)
+	_, tok, _ := s.Load()
+
+	// Track conditional headers via a wrapper.
+	var sawIfNoneMatch, sawIfMatch bool
+	wrapped := &headerSpyS3{fakeS3: f, onPut: func(in *s3.PutObjectInput) {
+		if in.IfNoneMatch != nil {
+			sawIfNoneMatch = true
+		}
+		if in.IfMatch != nil {
+			sawIfMatch = true
+		}
+	}}
+	s.client = wrapped
+
+	require.NoError(t, s.Save(LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{"p": {ProjectID: "p", MaxBudget: 10}},
+	}, tok))
+	assert.True(t, sawIfNoneMatch, "first write must use If-None-Match:*")
+	assert.False(t, sawIfMatch, "first write must not use If-Match")
+}
+
+func TestS3Store_UpdateUsesIfMatch(t *testing.T) {
+	f := newFakeS3()
+	// First write via one store.
+	s1 := newTestS3Store(f)
+	_, tok1, _ := s1.Load()
+	require.NoError(t, s1.Save(LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{"p": {ProjectID: "p", MaxBudget: 10}},
+	}, tok1))
+
+	// Second store loads (gets real etags), updates → must use If-Match.
+	s2 := newTestS3Store(f)
+	_, tok2, _ := s2.Load()
+	var sawIfMatch bool
+	s2.client = &headerSpyS3{fakeS3: f, onPut: func(in *s3.PutObjectInput) {
+		if in.IfMatch != nil {
+			sawIfMatch = true
+		}
+	}}
+	require.NoError(t, s2.Save(LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{"p": {ProjectID: "p", MaxBudget: 20}},
+	}, tok2))
+	assert.True(t, sawIfMatch, "update of an existing object must use If-Match")
+}
+
+func TestS3Store_CASRetryOn412(t *testing.T) {
+	f := newFakeS3()
+	// Fail the first PutObject to the project key with a 412, succeed on retry.
+	f.fail412On[".cargoship/projects/p.json"] = 1
+
+	s := newTestS3Store(f)
+	_, tok, _ := s.Load()
+	err := s.Save(LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{"p": {ProjectID: "p", MaxBudget: 10}},
+	}, tok)
+	require.NoError(t, err, "CAS should recover after a single 412")
+	assert.GreaterOrEqual(t, f.putCount[".cargoship/projects/p.json"], 2, "should have retried the PUT")
+}
+
+func TestS3Store_CASGivesUpAfterMaxRetry(t *testing.T) {
+	f := newFakeS3()
+	s := newTestS3Store(f)
+	s.maxRetry = 2
+	_, tok, _ := s.Load()
+
+	// Always 412 on this key.
+	f.alwaysFail412[".cargoship/projects/p.json"] = true
+
+	err := s.Save(LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{"p": {ProjectID: "p", MaxBudget: 10}},
+	}, tok)
+	require.Error(t, err, "persistent 412 should surface an error after maxRetry")
+	assert.Contains(t, err.Error(), "conditional put")
+}
+
+// TestS3Store_RecordUnionMergeOnConflict proves the loss-free-append property:
+// when a concurrent writer changes the object between our Load and Save, the
+// 412 re-GET union-merges records so the other writer's record survives.
+func TestS3Store_RecordUnionMergeOnConflict(t *testing.T) {
+	f := newFakeS3()
+	key := ".cargoship/projects/p.json"
+
+	// Pre-existing object with the budget and one record from "writer B".
+	writerB := projectDoc{
+		Version: StoreVersion,
+		Budget:  config.ProjectBudget{ProjectID: "p", MaxBudget: 10},
+		Records: []CostRecord{{Timestamp: time.Unix(1, 0).UTC(), ProjectID: "p", JobID: "B", FileName: "b", Cost: 1}},
+	}
+	seedObject(f, key, writerB)
+
+	// Our store loaded an EARLIER (empty) view, then appends its own record and
+	// saves against a stale/absent etag → 412 → re-GET merges.
+	s := newTestS3Store(f)
+	// Simulate: we loaded when the object didn't exist (empty token), and our
+	// in-memory ledger has only our record.
+	s.lastLoaded = &LedgerState{Version: StoreVersion, ProjectBudgets: map[string]config.ProjectBudget{}}
+	ourRecord := CostRecord{Timestamp: time.Unix(2, 0).UTC(), ProjectID: "p", JobID: "A", FileName: "a", Cost: 2}
+	err := s.Save(LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{"p": {ProjectID: "p", MaxBudget: 10}},
+		Records:        []CostRecord{ourRecord},
+	}, encodeToken(s3Token{Projects: map[string]string{}})) // empty etag → If-None-Match → 412 (object exists)
+	require.NoError(t, err)
+
+	// Reload: BOTH records must be present.
+	s2 := newTestS3Store(f)
+	got, _, err := s2.Load()
+	require.NoError(t, err)
+	var jobs []string
+	for _, r := range got.Records {
+		jobs = append(jobs, r.JobID)
+	}
+	assert.ElementsMatch(t, []string{"A", "B"}, jobs, "both writers' records must survive the conflict")
+}
+
+func TestS3Store_NoSuchKeyIsAbsent(t *testing.T) {
+	f := newFakeS3()
+	s := newTestS3Store(f)
+	body, etag, err := s.getObject(".cargoship/missing.json")
+	require.NoError(t, err)
+	assert.Nil(t, body)
+	assert.Empty(t, etag)
+}
+
+func TestUnionRecords_Dedup(t *testing.T) {
+	a := CostRecord{Timestamp: time.Unix(1, 0).UTC(), JobID: "j", FileName: "f"}
+	b := CostRecord{Timestamp: time.Unix(2, 0).UTC(), JobID: "k", FileName: "g"}
+	// a appears in both slices → deduped to one.
+	out := unionRecords([]CostRecord{a}, []CostRecord{a, b})
+	assert.Len(t, out, 2)
+}
+
+func TestValidateProjectID(t *testing.T) {
+	require.NoError(t, validateProjectID("20251206-abc123"))
+	require.NoError(t, validateProjectID("team_project.1"))
+	assert.Error(t, validateProjectID("a/b"))
+	assert.Error(t, validateProjectID("a\x00b"))
+}
+
+func TestNewStoreForSpec_DefaultsLocal(t *testing.T) {
+	store, err := newStoreForSpec(context.Background(), "", aws.Config{})
+	require.NoError(t, err)
+	_, isLocal := store.(localStore)
+	assert.True(t, isLocal, "empty spec must select the local store")
+}
+
+// --- test helpers ---
+
+// headerSpyS3 wraps a fakeS3 to observe PutObject conditional headers.
+type headerSpyS3 struct {
+	*fakeS3
+	onPut func(*s3.PutObjectInput)
+}
+
+func (h *headerSpyS3) PutObject(ctx context.Context, in *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if h.onPut != nil {
+		h.onPut(in)
+	}
+	return h.fakeS3.PutObject(ctx, in, optFns...)
+}
+
+func seedObject(f *fakeS3, key string, doc any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	f.objects[key] = b
+	f.seq++
+	f.etags[key] = fmt.Sprintf("\"seed-%d\"", f.seq)
+}


### PR DESCRIPTION
## Summary

Phase A (#257) made the budget spend-ledger durable **locally**. This makes it durable and **shareable across machines** — the original point of #246. Point the budget store at S3 and a laptop, CI runner, and teammates all converge on one ledger without lost updates, using **S3 conditional writes (ETag / If-Match) for compare-and-swap**.

```
cargoship cost budget set myproj --cost 1000 --store s3://mybucket/.cargoship/
cargoship cost budget status myproj --store s3://mybucket/.cargoship/   # from any machine
```
Also settable via `CostControl.BudgetStoreLocation` config or `CARGOSHIP_BUDGET_STORE`. **Default stays local — zero behavior change** for users who don't opt in.

## Design
Phase A's whole-document `BudgetStore` interface is **unchanged**; all new granularity lives inside the new `s3Store`. The opaque `Token` now carries a serialized map of per-object ETags (`localStore` still ignores it), so **every Phase A test passes untouched**.

- **`s3_store.go`** — layout is one object per project (`projects/<id>.json`) + `global.json` (low CAS contention). `Load` = `ListObjectsV2` + fan-out `GetObject` → flat `LedgerState` + composite ETag token. `Save` writes each changed object with a conditional PUT (`If-None-Match:*` create, `If-Match:<etag>` update). On a **412** (detected via `smithy.APIError` code — not a modeled SDK type), it re-GETs, **union-merges this process's new records** onto the fresh object by identity (`JobID+FileName+Timestamp`), backs off (exp+jitter), and retries — so concurrent appends **never lose a record**. Optional local write-through **mirror** serves offline reads (with an empty token, so an offline write can't clobber off stale cache).
- **`manager.go`** — `NewManagerWithStoreSpec`/`newStoreForSpec` resolve a spec to `localStore` (default) or `s3Store`, reusing the existing `newManagerWithStore` seam. `NewManager` unchanged.
- **`config.go`** — `CostControlConfig.BudgetStoreLocation`.
- **`budget.go` CLI** — `--store` persistent flag; `loadCostManager` resolves `--store` > config > env > local. `SetProjectBudget` validates project IDs (no path separators / control chars) since they become S3 keys.

## Testing
- **Unit** (fake `s3API`, no AWS): CAS-retry-on-412, give-up-after-maxRetry, **record union-merge on conflict** (loser's record survives), first-write `If-None-Match` / update `If-Match`, token codec + tolerance, `parseStoreSpec`, `NoSuchKey`→absent, store selection, round-trip. `pkg/aws/cost` coverage **73.4%** (floor 72).
- **Integration** (`//go:build integration`, gated on `CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS`, runs in the nightly-aws lane): **two concurrent writers converge** against real S3 If-Match 412s with **both records surviving**. Verified locally 5× + a manual `budget set/status --store s3://…` round-trip against a real bucket.
- Back-compat: existing `store_test.go` / `budget_store_test.go` pass unmodified. Full pre-commit gate green (A+).

## Scope
PR1 of Phase B. **PR2 (follow-up):** persisted global/team budget — `config.GlobalBudget`, explicit ceiling checks in `checkGlobalBudget`/`checkGlobalVolumeQuota`, `budget set --global`. The `global.json` object + a forward-compat `global_budget` passthrough are already in place here so PR2 slots in cleanly.

Part of #246.