### PR TITLE
feat: persisted global/team budget with cross-project ceiling (#246 Phase B, PR2)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -144,7 +144,7 @@ run_tests() {
     timeout 120s go test -short -timeout=100s -p=4 -parallel=4 -coverprofile=coverage.out $(go list ./... | grep -v '/examples/') > /dev/null 2>&1
     local project_coverage=0
     if [ -f coverage.out ]; then
-        project_coverage=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+        project_coverage=$(go tool cover -func=coverage.out | grep '^total:' | awk '{print $3}' | sed 's/%//')
     fi
 
     rm -f test_output.tmp

--- a/cmd/cargoship/cmd/budget.go
+++ b/cmd/cargoship/cmd/budget.go
@@ -74,7 +74,10 @@ Examples:
 }
 
 func newBudgetStatusCmd() *cobra.Command {
-	var jsonOutput bool
+	var (
+		jsonOutput bool
+		global     bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "status <project-id>",
@@ -96,15 +99,27 @@ Examples:
 
   # Status as JSON
   cargoship budget status project1 --json
+
+  # Show the org/team-wide budget status
+  cargoship budget status --global
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			projectID := args[0]
-			return runBudgetStatus(cmd.Context(), projectID, jsonOutput)
+			if global {
+				if len(args) != 0 {
+					return fmt.Errorf("--global shows the org-wide budget; do not also pass a project ID")
+				}
+				return runGlobalBudgetStatus(cmd.Context(), jsonOutput)
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("a project ID is required (or use --global for the org-wide budget)")
+			}
+			return runBudgetStatus(cmd.Context(), args[0], jsonOutput)
 		},
 	}
 
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&global, "global", false, "Show the org/team-wide budget status instead of a project's")
 
 	return cmd
 }
@@ -115,6 +130,7 @@ func newBudgetSetCmd() *cobra.Command {
 		volumeQuota          float64
 		costAlertThreshold   float64
 		volumeAlertThreshold float64
+		global               bool
 	)
 
 	cmd := &cobra.Command{
@@ -144,11 +160,22 @@ Examples:
 
   # Set unlimited
   cargoship budget set project1 --cost 0 --volume 0
+
+  # Set the org/team-wide budget ceiling (across all projects)
+  cargoship budget set --global --cost 10000 --volume 5000
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			projectID := args[0]
-			return runBudgetSet(cmd.Context(), projectID, costBudget, volumeQuota, costAlertThreshold, volumeAlertThreshold)
+			if global {
+				if len(args) != 0 {
+					return fmt.Errorf("--global sets the org-wide budget; do not also pass a project ID")
+				}
+				return runGlobalBudgetSet(cmd.Context(), costBudget, volumeQuota, costAlertThreshold, volumeAlertThreshold)
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("a project ID is required (or use --global for the org-wide budget)")
+			}
+			return runBudgetSet(cmd.Context(), args[0], costBudget, volumeQuota, costAlertThreshold, volumeAlertThreshold)
 		},
 	}
 
@@ -156,6 +183,7 @@ Examples:
 	cmd.Flags().Float64Var(&volumeQuota, "volume", 0, "Maximum volume quota in GB (0 = unlimited)")
 	cmd.Flags().Float64Var(&costAlertThreshold, "cost-alert", 0.8, "Cost alert threshold (0.0-1.0, default 0.8)")
 	cmd.Flags().Float64Var(&volumeAlertThreshold, "volume-alert", 0.75, "Volume alert threshold (0.0-1.0, default 0.75)")
+	cmd.Flags().BoolVar(&global, "global", false, "Set the org/team-wide budget ceiling (across all projects) instead of a per-project budget")
 
 	return cmd
 }
@@ -320,6 +348,61 @@ func runBudgetSet(ctx context.Context, projectID string, costBudget, volumeQuota
 		fmt.Println("   Volume Quota:     unlimited")
 	}
 
+	return nil
+}
+
+// runGlobalBudgetSet sets the org/team-wide budget ceiling (#246 PR2).
+func runGlobalBudgetSet(ctx context.Context, costBudget, volumeQuota, costAlert, volumeAlert float64) error {
+	manager, err := loadCostManager(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load cost manager: %w", err)
+	}
+
+	if err := manager.SetGlobalBudget(costBudget, volumeQuota, costAlert, volumeAlert); err != nil {
+		return fmt.Errorf("failed to set global budget: %w", err)
+	}
+
+	fmt.Println("✅ Global (org/team-wide) budget set")
+	if costBudget > 0 {
+		fmt.Printf("   Cost Budget:      $%.2f (alert at %.0f%%)\n", costBudget, costAlert*100)
+	} else {
+		fmt.Println("   Cost Budget:      unlimited")
+	}
+	if volumeQuota > 0 {
+		fmt.Printf("   Volume Quota:     %.2f GB (alert at %.0f%%)\n", volumeQuota, volumeAlert*100)
+	} else {
+		fmt.Println("   Volume Quota:     unlimited")
+	}
+	return nil
+}
+
+// runGlobalBudgetStatus prints the org/team-wide budget status (#246 PR2).
+func runGlobalBudgetStatus(ctx context.Context, jsonOutput bool) error {
+	manager, err := loadCostManager(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load cost manager: %w", err)
+	}
+
+	status := manager.GetGlobalTeamBudgetStatus()
+	if jsonOutput {
+		data, err := json.MarshalIndent(status, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal status: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Printf("📊 Global (org/team-wide) Budget Status\n\n")
+	fmt.Println("=== Cost Budget ===")
+	if status.MaxBudget > 0 {
+		fmt.Printf("  Maximum Budget:    $%.2f\n", status.MaxBudget)
+		fmt.Printf("  Current Spending:  $%.2f\n", status.CurrentSpend)
+		fmt.Printf("  Remaining:         $%.2f\n", status.BudgetRemaining)
+		fmt.Printf("  Usage:             %.1f%%\n", status.BudgetUsed*100)
+	} else {
+		fmt.Println("  No global cost budget set (unlimited)")
+	}
 	return nil
 }
 

--- a/pkg/aws/config/config.go
+++ b/pkg/aws/config/config.go
@@ -54,6 +54,31 @@ type S3Config struct {
 	HTTPTransport *HTTPTransportConfig `yaml:"http_transport,omitempty" json:"http_transport,omitempty"`
 }
 
+// GlobalBudget is a persisted organization/team-wide budget ceiling (#246
+// Phase B PR2). It is distinct from a per-project ProjectBudget and from the
+// legacy BudgetPeriods system: it caps aggregate spend/volume across ALL
+// projects and is enforced as a ceiling in addition to any per-project cap.
+// All fields are optional; a zero MaxBudget/MaxVolumeGB means "unlimited" for
+// that dimension.
+type GlobalBudget struct {
+	// MaxBudget is the aggregate cost ceiling in USD across all projects
+	// (0 = unlimited).
+	MaxBudget float64 `yaml:"max_budget,omitempty" json:"max_budget,omitempty"`
+
+	// MaxVolumeGB is the aggregate volume ceiling in GB across all projects
+	// (0 = unlimited).
+	MaxVolumeGB float64 `yaml:"max_volume_gb,omitempty" json:"max_volume_gb,omitempty"`
+
+	// AlertThreshold is the cost alert fraction (0.0-1.0).
+	AlertThreshold float64 `yaml:"alert_threshold,omitempty" json:"alert_threshold,omitempty"`
+
+	// VolumeAlertThreshold is the volume alert fraction (0.0-1.0).
+	VolumeAlertThreshold float64 `yaml:"volume_alert_threshold,omitempty" json:"volume_alert_threshold,omitempty"`
+
+	// Description is an optional label (e.g. a grant or team name).
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}
+
 // CostControlConfig holds cost management settings
 type CostControlConfig struct {
 	// DEPRECATED: Maximum monthly budget (USD) - Use BudgetPeriods instead for flexible periods
@@ -81,6 +106,11 @@ type CostControlConfig struct {
 	// budgets are durable and shareable across machines. Overridden by the
 	// `budget --store` flag and the CARGOSHIP_BUDGET_STORE env var.
 	BudgetStoreLocation string `yaml:"budget_store_location,omitempty" json:"budget_store_location,omitempty"`
+
+	// GlobalBudget is the persisted org/team-wide budget ceiling (#246 Phase B
+	// PR2), enforced across all projects in addition to any per-project cap.
+	// Nil means no global budget is set.
+	GlobalBudget *GlobalBudget `yaml:"global_budget,omitempty" json:"global_budget,omitempty"`
 
 	// Enable automatic cost optimization
 	AutoOptimize bool `yaml:"auto_optimize" json:"auto_optimize"`

--- a/pkg/aws/cost/budget.go
+++ b/pkg/aws/cost/budget.go
@@ -183,6 +183,12 @@ func (m *Manager) CheckProjectVolumeQuota(projectID string, additionalGB float64
 
 // checkGlobalVolumeQuota checks if an operation would exceed the global volume quota
 func (m *Manager) checkGlobalVolumeQuota(additionalGB float64) error {
+	// Persisted global/team volume ceiling across all projects (#246 PR2),
+	// enforced in addition to any budget-period quota.
+	if err := m.checkGlobalVolumeCeiling(additionalGB); err != nil {
+		return err
+	}
+
 	// Check if budget periods are configured (new system)
 	if len(m.config.BudgetPeriods) > 0 {
 		return m.checkBudgetPeriodVolume(additionalGB)
@@ -234,6 +240,12 @@ func (m *Manager) checkBudgetPeriodVolume(additionalGB float64) error {
 
 // checkGlobalBudget checks if an operation would exceed the global budget
 func (m *Manager) checkGlobalBudget(additionalCost float64) error {
+	// Persisted global/team cost ceiling across all projects (#246 PR2),
+	// enforced in addition to any budget-period cap.
+	if err := m.checkGlobalBudgetCeiling(additionalCost); err != nil {
+		return err
+	}
+
 	// Check if budget periods are configured (new system)
 	if len(m.config.BudgetPeriods) > 0 {
 		return m.checkBudgetPeriod(additionalCost)
@@ -586,4 +598,132 @@ func (m *Manager) DeleteProjectBudget(projectID string) error {
 // RemoveProjectBudget is an alias for DeleteProjectBudget for CLI compatibility
 func (m *Manager) RemoveProjectBudget(projectID string) error {
 	return m.DeleteProjectBudget(projectID)
+}
+
+// SetGlobalBudget creates or updates the persisted org/team-wide budget ceiling
+// (#246 Phase B PR2). It caps aggregate spend/volume across ALL projects and is
+// enforced in addition to any per-project cap. maxBudget/maxVolumeGB of 0 mean
+// unlimited for that dimension.
+func (m *Manager) SetGlobalBudget(maxBudget, maxVolumeGB, costAlertThreshold, volumeAlertThreshold float64) error {
+	if maxBudget < 0 {
+		return fmt.Errorf("max budget cannot be negative (use 0 for unlimited)")
+	}
+	if maxVolumeGB < 0 {
+		return fmt.Errorf("max volume cannot be negative (use 0 for unlimited)")
+	}
+	if costAlertThreshold < 0 || costAlertThreshold > 1 {
+		return fmt.Errorf("cost alert threshold must be between 0.0 and 1.0")
+	}
+	if volumeAlertThreshold < 0 || volumeAlertThreshold > 1 {
+		return fmt.Errorf("volume alert threshold must be between 0.0 and 1.0")
+	}
+
+	m.config.GlobalBudget = &config.GlobalBudget{
+		MaxBudget:            maxBudget,
+		MaxVolumeGB:          maxVolumeGB,
+		AlertThreshold:       costAlertThreshold,
+		VolumeAlertThreshold: volumeAlertThreshold,
+	}
+
+	if err := m.saveState(); err != nil {
+		return fmt.Errorf("persist global budget: %w", err)
+	}
+
+	m.logger.Info("Global budget updated",
+		"max_budget", maxBudget,
+		"max_volume_gb", maxVolumeGB,
+		"cost_alert_threshold", costAlertThreshold,
+		"volume_alert_threshold", volumeAlertThreshold)
+	return nil
+}
+
+// GetGlobalTeamBudgetStatus returns the status of the persisted global/team
+// budget ceiling (#246 PR2) — aggregate spend/volume across all projects
+// against the GlobalBudget caps. Distinct from GetGlobalBudgetStatus, which
+// reports the legacy BudgetPeriods-based global status. Returns a status with
+// zero maxima when no global budget is set.
+func (m *Manager) GetGlobalTeamBudgetStatus() *BudgetStatus {
+	status := &BudgetStatus{
+		BudgetType:   "global",
+		Currency:     m.config.Pricing.Currency,
+		CurrentSpend: m.totalSpend(),
+	}
+	gb := m.config.GlobalBudget
+	if gb == nil {
+		return status
+	}
+	status.MaxBudget = gb.MaxBudget
+	status.AlertThreshold = gb.AlertThreshold
+	if gb.MaxBudget > 0 {
+		status.BudgetRemaining = gb.MaxBudget - status.CurrentSpend
+		status.BudgetUsed = status.CurrentSpend / gb.MaxBudget
+		status.OverBudget = status.CurrentSpend > gb.MaxBudget
+		status.AlertTriggered = gb.AlertThreshold > 0 && status.BudgetUsed >= gb.AlertThreshold
+	}
+	return status
+}
+
+// totalSpend returns the aggregate recorded cost across all projects (and
+// un-projected records) — the basis for the global/team ceiling.
+func (m *Manager) totalSpend() float64 {
+	total := 0.0
+	for _, r := range m.reporter.SnapshotRecords() {
+		total += r.Cost
+	}
+	return total
+}
+
+// totalVolumeGB returns the aggregate recorded volume across all projects.
+func (m *Manager) totalVolumeGB() float64 {
+	total := 0.0
+	for _, r := range m.reporter.SnapshotRecords() {
+		total += r.SizeGB
+	}
+	return total
+}
+
+// checkGlobalBudgetCeiling enforces the persisted GlobalBudget cost ceiling
+// across all projects (#246 PR2). Returns a BudgetExceededError when the
+// additional cost would push aggregate spend over the ceiling.
+func (m *Manager) checkGlobalBudgetCeiling(additionalCost float64) error {
+	gb := m.config.GlobalBudget
+	if gb == nil || gb.MaxBudget <= 0 {
+		return nil // no global cost ceiling set
+	}
+	current := m.totalSpend()
+	projected := current + additionalCost
+	if projected > gb.MaxBudget {
+		return &BudgetExceededError{
+			BudgetType:     "global",
+			MaxBudget:      gb.MaxBudget,
+			CurrentSpend:   current,
+			AdditionalCost: additionalCost,
+			ProjectedSpend: projected,
+			Overage:        projected - gb.MaxBudget,
+			Currency:       m.config.Pricing.Currency,
+		}
+	}
+	return nil
+}
+
+// checkGlobalVolumeCeiling enforces the persisted GlobalBudget volume ceiling
+// across all projects (#246 PR2).
+func (m *Manager) checkGlobalVolumeCeiling(additionalGB float64) error {
+	gb := m.config.GlobalBudget
+	if gb == nil || gb.MaxVolumeGB <= 0 {
+		return nil // no global volume ceiling set
+	}
+	current := m.totalVolumeGB()
+	projected := current + additionalGB
+	if projected > gb.MaxVolumeGB {
+		return &VolumeQuotaExceededError{
+			QuotaType:       "global",
+			MaxVolumeGB:     gb.MaxVolumeGB,
+			CurrentVolumeGB: current,
+			AdditionalGB:    additionalGB,
+			ProjectedVolume: projected,
+			Overage:         projected - gb.MaxVolumeGB,
+		}
+	}
+	return nil
 }

--- a/pkg/aws/cost/global_budget_test.go
+++ b/pkg/aws/cost/global_budget_test.go
@@ -1,0 +1,107 @@
+package cost
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetGlobalBudget_Persists verifies the global/team budget round-trips
+// through the store and is visible to a fresh manager (#246 PR2).
+func TestSetGlobalBudget_Persists(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+
+	mgr, err := NewManager(testCostConfig(), aws.Config{}, nil)
+	require.NoError(t, err)
+	require.NoError(t, mgr.SetGlobalBudget(1000, 500, 0.8, 0.75))
+
+	// A fresh manager reloads the persisted global budget.
+	mgr2, err := NewManager(testCostConfig(), aws.Config{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, mgr2.config.GlobalBudget)
+	assert.Equal(t, 1000.0, mgr2.config.GlobalBudget.MaxBudget)
+	assert.Equal(t, 500.0, mgr2.config.GlobalBudget.MaxVolumeGB)
+
+	st := mgr2.GetGlobalTeamBudgetStatus()
+	assert.Equal(t, 1000.0, st.MaxBudget)
+	assert.Equal(t, "global", st.BudgetType)
+}
+
+// TestLedgerState_GlobalBudgetBackCompat confirms a document without a global
+// budget round-trips with GlobalBudget nil (pre-PR2 files unaffected).
+func TestLedgerState_GlobalBudgetBackCompat(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+	store := localStore{}
+	require.NoError(t, store.Save(LedgerState{
+		Version:        StoreVersion,
+		ProjectBudgets: map[string]config.ProjectBudget{"p": {ProjectID: "p", MaxBudget: 10}},
+	}, ""))
+
+	got, _, err := store.Load()
+	require.NoError(t, err)
+	assert.Nil(t, got.GlobalBudget, "absent global budget must stay nil")
+}
+
+// TestGlobalBudget_EnforcedAsCeiling proves the global ceiling blocks an upload
+// that is under (or has no) project cap but would push aggregate spend over the
+// org-wide budget (#246 PR2).
+func TestGlobalBudget_EnforcedAsCeiling(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+	ctx := context.Background()
+
+	mgr, err := NewManager(testCostConfig(), aws.Config{}, nil)
+	require.NoError(t, err)
+
+	// Tiny global cost ceiling, no project budget at all.
+	require.NoError(t, mgr.SetGlobalBudget(0.01, 0, 0.8, 0.75))
+
+	// A sizeable upload with no project id → falls through to the global check.
+	const big = int64(50 * 1024 * 1024 * 1024) // 50 GB, well over $0.01
+	err = mgr.RecordOperationCost(ctx, "upload", "f", big, config.StorageClassStandard, "us-east-1", "job", "", nil)
+	require.Error(t, err, "upload over the global cost ceiling must be blocked")
+	assert.Contains(t, err.Error(), "budget")
+}
+
+// TestGlobalVolumeCeiling_EnforcedAcrossProjects proves the global VOLUME
+// ceiling is enforced on top of a passing per-project check.
+func TestGlobalVolumeCeiling_EnforcedAcrossProjects(t *testing.T) {
+	t.Setenv(budgetStoreEnvOverride, filepath.Join(t.TempDir(), "budgets.json"))
+	ctx := context.Background()
+
+	mgr, err := NewManager(testCostConfig(), aws.Config{}, nil)
+	require.NoError(t, err)
+	// Project with a generous volume quota, but a tiny global volume ceiling.
+	require.NoError(t, mgr.SetProjectBudget("proj", 0, 10000, 0.8, 0.75))
+	require.NoError(t, mgr.SetGlobalBudget(0, 1, 0.8, 0.75)) // 1 GB org-wide
+
+	const twoGB = int64(2 * 1024 * 1024 * 1024)
+	err = mgr.RecordOperationCost(ctx, "upload", "f", twoGB, config.StorageClassStandard, "us-east-1", "job", "proj", nil)
+	require.Error(t, err, "upload over the global volume ceiling must be blocked even when the project quota allows it")
+	assert.Contains(t, err.Error(), "quota")
+}
+
+// TestS3Store_GlobalBudgetRoundTrip verifies the S3 store persists and reloads
+// the global budget in global.json.
+func TestS3Store_GlobalBudgetRoundTrip(t *testing.T) {
+	f := newFakeS3()
+	s := newTestS3Store(f)
+	_, tok, err := s.Load()
+	require.NoError(t, err)
+
+	require.NoError(t, s.Save(LedgerState{
+		Version:      StoreVersion,
+		GlobalBudget: &config.GlobalBudget{MaxBudget: 2500, MaxVolumeGB: 1000},
+	}, tok))
+
+	s2 := newTestS3Store(f)
+	got, _, err := s2.Load()
+	require.NoError(t, err)
+	require.NotNil(t, got.GlobalBudget)
+	assert.Equal(t, 2500.0, got.GlobalBudget.MaxBudget)
+	assert.Equal(t, 1000.0, got.GlobalBudget.MaxVolumeGB)
+}

--- a/pkg/aws/cost/manager.go
+++ b/pkg/aws/cost/manager.go
@@ -150,6 +150,11 @@ func newManagerWithStore(cfg *config.CostControlConfig, awsCfg aws.Config, logge
 				}
 			}
 		}
+		// Seed the persisted global/team budget (#246 PR2) unless the config file
+		// already specifies one (config takes precedence, matching projects).
+		if state.GlobalBudget != nil && cfg.GlobalBudget == nil {
+			cfg.GlobalBudget = state.GlobalBudget
+		}
 		reporter.SeedRecords(state.Records)
 	}
 
@@ -180,6 +185,7 @@ func (m *Manager) saveState() error {
 		Version:        StoreVersion,
 		ProjectBudgets: m.config.ProjectBudgets,
 		Records:        records,
+		GlobalBudget:   m.config.GlobalBudget,
 	}
 	// Load the current token first so a Phase B S3 store can do a CAS write; the
 	// local store ignores it. A load error still attempts an unconditional save.

--- a/pkg/aws/cost/s3_store.go
+++ b/pkg/aws/cost/s3_store.go
@@ -65,10 +65,9 @@ type s3Store struct {
 	// re-GET can union-merge instead of clobbering a concurrent writer's records.
 	lastLoaded *LedgerState
 
-	// loadedGlobalBudget is the raw global_budget blob observed at Load time.
-	// PR1 never sets a global budget; carrying it through keeps a PR2-written
-	// value from being wiped by a PR1 save (forward-compat).
-	loadedGlobalBudget json.RawMessage
+	// loadedGlobalBudget is the global budget observed at Load time, carried
+	// through a Save so a records-only write doesn't wipe it.
+	loadedGlobalBudget *config.GlobalBudget
 }
 
 // s3Token is the concrete payload serialized into the opaque cost.Token. It maps
@@ -112,12 +111,9 @@ type projectDoc struct {
 // globalDoc is the global.json S3 object: the global budget plus records that
 // aren't attributable to a project with its own object.
 type globalDoc struct {
-	Version int          `json:"version"`
-	Records []CostRecord `json:"records,omitempty"`
-	// GlobalBudget is populated in PR2 (persisted global/team budget); kept here
-	// as raw JSON for forward-compat so a PR2-written object round-trips through
-	// a PR1 binary without data loss.
-	GlobalBudget json.RawMessage `json:"global_budget,omitempty"`
+	Version      int                  `json:"version"`
+	Records      []CostRecord         `json:"records,omitempty"`
+	GlobalBudget *config.GlobalBudget `json:"global_budget,omitempty"`
 }
 
 // parseStoreSpec classifies a budget-store location. An empty spec, or any value
@@ -214,6 +210,7 @@ func (s *s3Store) loadFromS3() (LedgerState, Token, error) {
 			state.Records = append(state.Records, gd.Records...)
 			tokenData.Global = etag
 			s.loadedGlobalBudget = gd.GlobalBudget
+			state.GlobalBudget = gd.GlobalBudget
 		}
 	}
 
@@ -272,8 +269,13 @@ func (s *s3Store) Save(state LedgerState, token Token) error {
 		}
 	}
 
-	// Write global object (records + preserved forward-compat global budget blob).
-	gdoc := globalDoc{Version: StoreVersion, Records: globalRecords, GlobalBudget: s.loadedGlobalBudget}
+	// Write global object. Use the caller's GlobalBudget when set; otherwise
+	// carry through whatever we loaded so a records-only save doesn't wipe it.
+	gb := state.GlobalBudget
+	if gb == nil {
+		gb = s.loadedGlobalBudget
+	}
+	gdoc := globalDoc{Version: StoreVersion, Records: globalRecords, GlobalBudget: gb}
 	mineGlobal := recordsForProject(newRecords, "", state.ProjectBudgets)
 	if err := s.saveObject(s.globalKey(), prev.Global, gdoc, mineGlobal); err != nil {
 		return err
@@ -371,7 +373,7 @@ func mergeDoc(doc any, freshBody []byte, mineRecords []CostRecord) ([]byte, erro
 			}
 		}
 		d.Records = unionRecords(fresh.Records, mineRecords)
-		if len(d.GlobalBudget) == 0 {
+		if d.GlobalBudget == nil {
 			d.GlobalBudget = fresh.GlobalBudget
 		}
 		return json.MarshalIndent(d, "", "  ")

--- a/pkg/aws/cost/store.go
+++ b/pkg/aws/cost/store.go
@@ -22,6 +22,11 @@ type LedgerState struct {
 	// that backs `budget status` spend/volume totals. Bounded by the caller
 	// (FIFO rotation) so the file can't grow without limit.
 	Records []CostRecord `json:"records,omitempty"`
+
+	// GlobalBudget is the persisted org/team-wide budget ceiling (#246 Phase B
+	// PR2). Pointer + omitempty so pre-PR2 documents (and every local file
+	// written before this) round-trip unchanged: absent → nil.
+	GlobalBudget *config.GlobalBudget `json:"global_budget,omitempty"`
 }
 
 // Token is an opaque optimistic-concurrency token returned by Load and passed

--- a/scripts/quality-report.sh
+++ b/scripts/quality-report.sh
@@ -116,7 +116,7 @@ display_metric "Linting" "$lint_score" 25 "($lint_issues issues)"
 # 4. Test Coverage (20 points)
 echo -e "${BLUE}🧪 Calculating test coverage...${NC}"
 if go test -coverprofile=coverage.out ./... >/dev/null 2>&1; then
-    coverage=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+    coverage=$(go tool cover -func=coverage.out | grep '^total:' | awk '{print $3}' | sed 's/%//')
     coverage_score=$(echo "scale=1; $coverage * 20 / 100" | bc -l)
     rm -f coverage.out
 else


### PR DESCRIPTION
## Summary

Completes Phase B (and #246). Adds an **org/team-wide budget** that caps *aggregate* spend and volume across all projects, persisted through the same store (local or S3) as project budgets and enforced as a **ceiling on top of any per-project cap**.

```
cargoship cost budget set --global --cost 10000 --volume 5000
cargoship cost budget status --global
```

## Changes
- **`config.go`** — `GlobalBudget` struct (aggregate cost/volume ceiling + alert thresholds); `CostControlConfig.GlobalBudget` pointer.
- **`store.go`** — `LedgerState.GlobalBudget *config.GlobalBudget` (pointer + `omitempty` → pre-PR2 documents round-trip unchanged; absent stays nil).
- **`s3_store.go`** — `global.json` now carries the typed `GlobalBudget` (replacing PR1's forward-compat raw passthrough); Load populates it, Save carries a loaded value through a records-only write so it isn't wiped, and the 412 merge preserves it.
- **`manager.go`** — `NewManager` seeds `config.GlobalBudget` from the store (config file wins); `saveState` persists it.
- **`budget.go`** — `SetGlobalBudget`; **explicit** `checkGlobalBudgetCeiling`/`checkGlobalVolumeCeiling` wired into the existing `checkGlobalBudget`/`checkGlobalVolumeQuota`. Since the per-project checks already fall through to those, **both caps are enforced with global as the ceiling** — the composition decision you chose. `GetGlobalTeamBudgetStatus` reports aggregate spend vs the ceiling.
- **CLI** — `budget set --global` / `budget status --global` (`MaximumNArgs(1)`, validates arg-xor-`--global`).

## Also: fixed a latent tooling bug
`scripts/quality-report.sh` and `.githooks/pre-commit` extracted coverage with `grep total`, which matched the new `totalSpend`/`totalVolumeGB` functions and produced a multi-line value that broke the arithmetic (blocked the first commit attempt). Anchored to `grep '^total:'` so only the summary line matches — this was fragile for any `*total*` symbol.

## Testing
- Global budget round-trip (local + S3 `global.json`), persistence across managers, back-compat (nil stays nil), and **both ceilings enforced**: cost (no project cap) and volume (on top of a *passing* project quota, proving it's a true ceiling).
- `pkg/aws/cost` coverage 73.9% (floor 72). Full pre-commit gate green (A+). Verified via the CLI.

Closes #246 (durable, shareable, team-wide budgets — Phase A #257, Phase B PR1 #258, PR2 here).