### PR TITLE
feat: implement exponential & moving-average cost forecasts (#263)

### DIFF
--- a/pkg/aws/cost/forecasting.go
+++ b/pkg/aws/cost/forecasting.go
@@ -281,14 +281,26 @@ func (fe *ForecastEngine) GenerateForecast(projectID string, model ForecastModel
 	}
 }
 
-// generateLinearForecast uses linear regression for forecasting
-func (fe *ForecastEngine) generateLinearForecast(projectID string, forecastDays int) (*CostForecast, error) {
+// dailyPoint is one calendar day of the cost series: the cost incurred that
+// day and the running cumulative total through that day.
+type dailyPoint struct {
+	day        string
+	dayCost    float64
+	cumulative float64
+}
+
+// forecastHistoricalDays is the look-back window all forecast models train on.
+const forecastHistoricalDays = 90
+
+// buildDailySeries aggregates the reporter's raw cost records into an ordered,
+// de-duplicated per-day series (oldest first) for the given project over the
+// look-back window. It acquires the reporter read lock itself, so callers must
+// not already hold it.
+func (fe *ForecastEngine) buildDailySeries(projectID string) ([]dailyPoint, error) {
 	fe.reporter.mu.RLock()
 	defer fe.reporter.mu.RUnlock()
 
-	// Get historical data (last 90 days or all available)
-	historicalDays := 90
-	cutoffDate := time.Now().Add(-time.Duration(historicalDays) * 24 * time.Hour)
+	cutoffDate := time.Now().Add(-time.Duration(forecastHistoricalDays) * 24 * time.Hour)
 	var records []CostRecord
 	for _, r := range fe.reporter.costs {
 		if r.Timestamp.After(cutoffDate) {
@@ -297,44 +309,117 @@ func (fe *ForecastEngine) generateLinearForecast(projectID string, forecastDays 
 			}
 		}
 	}
-
 	if len(records) == 0 {
 		return nil, fmt.Errorf("no historical cost records found")
 	}
 
-	// Sort by timestamp
 	sort.Slice(records, func(i, j int) bool {
 		return records[i].Timestamp.Before(records[j].Timestamp)
 	})
 
-	// Calculate cumulative daily costs
 	dailyCosts := make(map[string]float64)
+	var order []string
+	seen := make(map[string]bool)
 	for _, r := range records {
 		day := r.Timestamp.Format("2006-01-02")
+		if !seen[day] {
+			seen[day] = true
+			order = append(order, day)
+		}
 		dailyCosts[day] += r.Cost
 	}
 
-	// Convert to sorted cumulative costs
-	type dayCost struct {
-		day            string
-		cumulativeCost float64
-	}
-	var costs []dayCost
+	points := make([]dailyPoint, 0, len(order))
 	cumulative := 0.0
-	for _, r := range records {
-		day := r.Timestamp.Format("2006-01-02")
-		// Check if we already processed this day
-		found := false
-		for _, dc := range costs {
-			if dc.day == day {
-				found = true
-				break
-			}
-		}
-		if !found {
-			cumulative += dailyCosts[day]
-			costs = append(costs, dayCost{day: day, cumulativeCost: cumulative})
-		}
+	for _, day := range order {
+		cumulative += dailyCosts[day]
+		points = append(points, dailyPoint{day: day, dayCost: dailyCosts[day], cumulative: cumulative})
+	}
+	return points, nil
+}
+
+// fitMetrics returns the R², MAE and RMSE of a fitted series against actuals.
+func fitMetrics(actual, fitted []float64) (r2, mae, rmse float64) {
+	n := len(actual)
+	if n == 0 {
+		return 0, 0, 0
+	}
+	mean := 0.0
+	for _, a := range actual {
+		mean += a
+	}
+	mean /= float64(n)
+
+	var ssTotal, ssResidual, sumAbs, sumSq float64
+	for i := range actual {
+		res := actual[i] - fitted[i]
+		diff := actual[i] - mean
+		ssTotal += diff * diff
+		ssResidual += res * res
+		sumAbs += math.Abs(res)
+		sumSq += res * res
+	}
+	if ssTotal > 0 {
+		r2 = 1 - ssResidual/ssTotal
+	}
+	mae = sumAbs / float64(n)
+	rmse = math.Sqrt(sumSq / float64(n))
+	return r2, mae, rmse
+}
+
+// setKeyPredictions copies the daily cumulative forecasts into the named
+// time-point fields (7/14/30/60/90 days) that are within the horizon.
+func setKeyPredictions(f *CostForecast) {
+	if f.ForecastDays >= 7 {
+		f.Predicted7Days = f.DailyForecasts[7]
+	}
+	if f.ForecastDays >= 14 {
+		f.Predicted14Days = f.DailyForecasts[14]
+	}
+	if f.ForecastDays >= 30 {
+		f.Predicted30Days = f.DailyForecasts[30]
+	}
+	if f.ForecastDays >= 60 {
+		f.Predicted60Days = f.DailyForecasts[60]
+	}
+	if f.ForecastDays >= 90 {
+		f.Predicted90Days = f.DailyForecasts[90]
+	}
+}
+
+// growingConfidence builds a 95% interval whose width grows with the square
+// root of the forecast horizon (random-walk style), from an in-sample residual
+// standard error.
+func growingConfidence(prediction, stdError float64, horizon int) *ConfidenceInterval {
+	const z = 1.96
+	margin := z * stdError * math.Sqrt(float64(horizon))
+	return &ConfidenceInterval{
+		ConfidenceLevel: 95,
+		Prediction:      prediction,
+		LowerBound:      math.Max(0, prediction-margin),
+		UpperBound:      prediction + margin,
+	}
+}
+
+// setGrowingConfidence populates the 7/30/90-day confidence intervals from a
+// single residual standard error, widening with the horizon.
+func setGrowingConfidence(f *CostForecast, stdError float64) {
+	if f.ForecastDays >= 7 {
+		f.Confidence7Days = growingConfidence(f.Predicted7Days, stdError, 7)
+	}
+	if f.ForecastDays >= 30 {
+		f.Confidence30Days = growingConfidence(f.Predicted30Days, stdError, 30)
+	}
+	if f.ForecastDays >= 90 {
+		f.Confidence90Days = growingConfidence(f.Predicted90Days, stdError, 90)
+	}
+}
+
+// generateLinearForecast uses linear regression for forecasting
+func (fe *ForecastEngine) generateLinearForecast(projectID string, forecastDays int) (*CostForecast, error) {
+	costs, err := fe.buildDailySeries(projectID)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(costs) < 2 {
@@ -350,7 +435,7 @@ func (fe *ForecastEngine) generateLinearForecast(projectID string, forecastDays 
 	sumX2 := 0.0
 	for i, c := range costs {
 		x := float64(i)
-		y := c.cumulativeCost
+		y := c.cumulative
 		sumX += x
 		sumY += y
 		sumXY += x * y
@@ -365,7 +450,7 @@ func (fe *ForecastEngine) generateLinearForecast(projectID string, forecastDays 
 		Model:          ForecastModelLinear,
 		GeneratedAt:    time.Now(),
 		ForecastDays:   forecastDays,
-		BaseCost:       costs[len(costs)-1].cumulativeCost,
+		BaseCost:       costs[len(costs)-1].cumulative,
 		BaseDate:       time.Now(),
 		HistoricalDays: len(costs),
 		DailyForecasts: make(map[int]float64),
@@ -400,7 +485,7 @@ func (fe *ForecastEngine) generateLinearForecast(projectID string, forecastDays 
 	sumSquaredResiduals := 0.0
 	for i, c := range costs {
 		predicted := intercept + slope*float64(i)
-		residual := c.cumulativeCost - predicted
+		residual := c.cumulative - predicted
 		sumSquaredResiduals += residual * residual
 	}
 	stdError := math.Sqrt(sumSquaredResiduals / (n - 2))
@@ -441,8 +526,8 @@ func (fe *ForecastEngine) generateLinearForecast(projectID string, forecastDays 
 	ssResidual := 0.0
 	for i, c := range costs {
 		predicted := intercept + slope*float64(i)
-		diff1 := c.cumulativeCost - meanY
-		diff2 := c.cumulativeCost - predicted
+		diff1 := c.cumulative - meanY
+		diff2 := c.cumulative - predicted
 		ssTotal += diff1 * diff1
 		ssResidual += diff2 * diff2
 	}
@@ -456,7 +541,7 @@ func (fe *ForecastEngine) generateLinearForecast(projectID string, forecastDays 
 	sumSquaredError := 0.0
 	for i, c := range costs {
 		predicted := intercept + slope*float64(i)
-		error := math.Abs(c.cumulativeCost - predicted)
+		error := math.Abs(c.cumulative - predicted)
 		sumAbsError += error
 		sumSquaredError += error * error
 	}
@@ -466,27 +551,146 @@ func (fe *ForecastEngine) generateLinearForecast(projectID string, forecastDays 
 	return forecast, nil
 }
 
-// generateExponentialForecast uses exponential smoothing
+// Holt's double exponential smoothing parameters.
+const (
+	holtAlpha = 0.3 // level smoothing factor
+	holtBeta  = 0.1 // trend smoothing factor
+)
+
+// generateExponentialForecast forecasts with Holt's double exponential smoothing
+// (level + trend) over the per-day cost series. Unlike linear regression, it
+// weights recent observations more heavily, so it tracks changes in the recent
+// burn rate rather than fitting the whole history equally.
 func (fe *ForecastEngine) generateExponentialForecast(projectID string, forecastDays int) (*CostForecast, error) {
-	// TODO: Implement exponential smoothing (alpha = 0.3 for level, beta = 0.1 for trend)
-	// For now, fall back to linear forecast
-	forecast, err := fe.generateLinearForecast(projectID, forecastDays)
+	costs, err := fe.buildDailySeries(projectID)
 	if err != nil {
 		return nil, err
 	}
-	forecast.Model = ForecastModelExponential
+	if len(costs) < 2 {
+		return nil, fmt.Errorf("insufficient historical data for forecasting (need at least 2 days)")
+	}
+
+	// Initialize level to the first observation and trend to the first delta.
+	level := costs[0].dayCost
+	trend := costs[1].dayCost - costs[0].dayCost
+
+	// One-step-ahead in-sample fit for accuracy metrics (on daily cost).
+	actual := make([]float64, 0, len(costs)-1)
+	fitted := make([]float64, 0, len(costs)-1)
+	for i := 1; i < len(costs); i++ {
+		forecastOne := level + trend // one-step-ahead prediction for day i
+		actual = append(actual, costs[i].dayCost)
+		fitted = append(fitted, forecastOne)
+
+		prevLevel := level
+		level = holtAlpha*costs[i].dayCost + (1-holtAlpha)*(level+trend)
+		trend = holtBeta*(level-prevLevel) + (1-holtBeta)*trend
+	}
+
+	base := costs[len(costs)-1].cumulative
+	forecast := &CostForecast{
+		Model:          ForecastModelExponential,
+		GeneratedAt:    time.Now(),
+		ForecastDays:   forecastDays,
+		BaseCost:       base,
+		BaseDate:       time.Now(),
+		HistoricalDays: len(costs),
+		DailyForecasts: make(map[int]float64),
+	}
+
+	// Project forward: daily cost h steps out is level + h*trend (clamped at 0),
+	// accumulated onto the current cumulative total.
+	cumulative := base
+	for day := 1; day <= forecastDays; day++ {
+		dayCost := math.Max(0, level+trend*float64(day))
+		cumulative += dayCost
+		forecast.DailyForecasts[day] = cumulative
+	}
+
+	setKeyPredictions(forecast)
+	r2, mae, rmse := fitMetrics(actual, fitted)
+	forecast.R2Score = r2
+	forecast.ModelAccuracy = math.Max(0, r2)
+	forecast.MeanAbsoluteError = mae
+	forecast.RootMeanSquaredError = rmse
+	setGrowingConfidence(forecast, rmse)
+
 	return forecast, nil
 }
 
-// generateMovingAverageForecast uses weighted moving average
+// maWindow is the trailing window (days) for the weighted moving average.
+const maWindow = 7
+
+// generateMovingAverageForecast forecasts with an exponentially-weighted moving
+// average over the trailing 7-day daily-cost window. It projects the most
+// recent smoothed burn rate flat into the future, so — unlike the trend-bearing
+// linear and exponential models — its daily cost is constant and it reacts
+// quickly to the latest days while ignoring older history.
 func (fe *ForecastEngine) generateMovingAverageForecast(projectID string, forecastDays int) (*CostForecast, error) {
-	// TODO: Implement weighted moving average (window = 7 days, exponential weights)
-	// For now, fall back to linear forecast
-	forecast, err := fe.generateLinearForecast(projectID, forecastDays)
+	costs, err := fe.buildDailySeries(projectID)
 	if err != nil {
 		return nil, err
 	}
-	forecast.Model = ForecastModelMovingAverage
+	if len(costs) < 2 {
+		return nil, fmt.Errorf("insufficient historical data for forecasting (need at least 2 days)")
+	}
+
+	// weightedMA returns the exponentially-weighted average of the daily costs
+	// in costs[:end] over the trailing maWindow, most-recent weighted highest.
+	weightedMA := func(end int) float64 {
+		start := end - maWindow
+		if start < 0 {
+			start = 0
+		}
+		var weightedSum, weightTotal float64
+		for i := start; i < end; i++ {
+			// Exponential weights: most recent day (i == end-1) gets weight 1,
+			// each older day is discounted by another factor of 0.7.
+			w := math.Pow(0.7, float64(end-1-i))
+			weightedSum += w * costs[i].dayCost
+			weightTotal += w
+		}
+		if weightTotal == 0 {
+			return 0
+		}
+		return weightedSum / weightTotal
+	}
+
+	// One-step-ahead in-sample fit for accuracy metrics.
+	actual := make([]float64, 0, len(costs)-1)
+	fitted := make([]float64, 0, len(costs)-1)
+	for i := 1; i < len(costs); i++ {
+		actual = append(actual, costs[i].dayCost)
+		fitted = append(fitted, weightedMA(i))
+	}
+
+	base := costs[len(costs)-1].cumulative
+	projected := math.Max(0, weightedMA(len(costs))) // flat projected daily cost
+
+	forecast := &CostForecast{
+		Model:          ForecastModelMovingAverage,
+		GeneratedAt:    time.Now(),
+		ForecastDays:   forecastDays,
+		BaseCost:       base,
+		BaseDate:       time.Now(),
+		HistoricalDays: len(costs),
+		DailyForecasts: make(map[int]float64),
+	}
+
+	cumulative := base
+	for day := 1; day <= forecastDays; day++ {
+		cumulative += projected
+		forecast.DailyForecasts[day] = cumulative
+	}
+
+	setKeyPredictions(forecast)
+	r2, mae, rmse := fitMetrics(actual, fitted)
+	forecast.R2Score = r2
+	forecast.ModelAccuracy = math.Max(0, r2)
+	forecast.MeanAbsoluteError = mae
+	forecast.RootMeanSquaredError = rmse
+	setGrowingConfidence(forecast, rmse)
+
 	return forecast, nil
 }
 
@@ -526,32 +730,30 @@ func (fe *ForecastEngine) generateEnsembleForecast(projectID string, forecastDay
 	}
 
 	// Set specific time point predictions
-	if forecastDays >= 7 {
-		ensemble.Predicted7Days = ensemble.DailyForecasts[7]
-	}
-	if forecastDays >= 14 {
-		ensemble.Predicted14Days = ensemble.DailyForecasts[14]
-	}
-	if forecastDays >= 30 {
-		ensemble.Predicted30Days = ensemble.DailyForecasts[30]
-	}
-	if forecastDays >= 60 {
-		ensemble.Predicted60Days = ensemble.DailyForecasts[60]
-	}
-	if forecastDays >= 90 {
-		ensemble.Predicted90Days = ensemble.DailyForecasts[90]
-	}
+	setKeyPredictions(ensemble)
 
-	// Use linear forecast's confidence intervals as baseline
-	ensemble.Confidence7Days = linearForecast.Confidence7Days
-	ensemble.Confidence30Days = linearForecast.Confidence30Days
-	ensemble.Confidence90Days = linearForecast.Confidence90Days
+	// Blend accuracy metrics with the same weights, falling back to the
+	// linear component's weight when a component is unavailable.
+	blend := func(pick func(*CostForecast) float64) float64 {
+		total := w1
+		val := w1 * pick(linearForecast)
+		if exponentialForecast != nil {
+			val += w2 * pick(exponentialForecast)
+			total += w2
+		}
+		if movingAvgForecast != nil {
+			val += w3 * pick(movingAvgForecast)
+			total += w3
+		}
+		return val / total
+	}
+	ensemble.ModelAccuracy = blend(func(f *CostForecast) float64 { return f.ModelAccuracy })
+	ensemble.MeanAbsoluteError = blend(func(f *CostForecast) float64 { return f.MeanAbsoluteError })
+	ensemble.RootMeanSquaredError = blend(func(f *CostForecast) float64 { return f.RootMeanSquaredError })
+	ensemble.R2Score = blend(func(f *CostForecast) float64 { return f.R2Score })
 
-	// Average model accuracy metrics
-	ensemble.ModelAccuracy = linearForecast.ModelAccuracy
-	ensemble.MeanAbsoluteError = linearForecast.MeanAbsoluteError
-	ensemble.RootMeanSquaredError = linearForecast.RootMeanSquaredError
-	ensemble.R2Score = linearForecast.R2Score
+	// Derive confidence intervals from the blended RMSE, widening with horizon.
+	setGrowingConfidence(ensemble, ensemble.RootMeanSquaredError)
 
 	return ensemble, nil
 }

--- a/pkg/aws/cost/forecasting_test.go
+++ b/pkg/aws/cost/forecasting_test.go
@@ -385,6 +385,162 @@ func TestConfidenceIntervals(t *testing.T) {
 	assert.Greater(t, width99, width95, "99% CI should be wider than 95%")
 }
 
+// TestGenerateForecast_ModelsAreDistinct verifies the exponential and
+// moving-average models are no longer linear relabeled (#263): on a series
+// where the recent burn rate differs from the long-run average they must
+// produce materially different forecasts.
+func TestGenerateForecast_ModelsAreDistinct(t *testing.T) {
+	reporter := createTestReporterWithHistoricalData(t, 30, 10.0, "increasing")
+	engine := NewForecastEngine(reporter)
+
+	linear, err := engine.GenerateForecast("test-project", ForecastModelLinear, 90)
+	require.NoError(t, err)
+	exp, err := engine.GenerateForecast("test-project", ForecastModelExponential, 90)
+	require.NoError(t, err)
+	ma, err := engine.GenerateForecast("test-project", ForecastModelMovingAverage, 90)
+	require.NoError(t, err)
+
+	assert.Equal(t, ForecastModelExponential, exp.Model)
+	assert.Equal(t, ForecastModelMovingAverage, ma.Model)
+
+	// Each model must diverge from linear at the 90-day horizon.
+	assert.Greater(t, math.Abs(linear.Predicted90Days-exp.Predicted90Days), 1.0,
+		"exponential should differ from linear")
+	assert.Greater(t, math.Abs(linear.Predicted90Days-ma.Predicted90Days), 1.0,
+		"moving average should differ from linear")
+	// And from each other.
+	assert.Greater(t, math.Abs(exp.Predicted90Days-ma.Predicted90Days), 1.0,
+		"exponential and moving average should differ from each other")
+
+	t.Logf("90d forecasts: linear=%.2f exponential=%.2f moving_avg=%.2f",
+		linear.Predicted90Days, exp.Predicted90Days, ma.Predicted90Days)
+}
+
+// TestGenerateForecast_Exponential checks Holt's smoothing characteristics.
+func TestGenerateForecast_Exponential(t *testing.T) {
+	tests := []struct {
+		name  string
+		trend string
+	}{
+		{"increasing", "increasing"},
+		{"decreasing", "decreasing"},
+		{"stable", "stable"},
+		{"volatile", "volatile"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reporter := createTestReporterWithHistoricalData(t, 30, 10.0, tt.trend)
+			engine := NewForecastEngine(reporter)
+
+			f, err := engine.GenerateForecast("test-project", ForecastModelExponential, 90)
+			require.NoError(t, err)
+			require.NotNil(t, f)
+
+			assert.Equal(t, ForecastModelExponential, f.Model)
+			assert.Len(t, f.DailyForecasts, 90)
+			assert.Equal(t, 30, f.HistoricalDays)
+
+			// Cumulative forecast is monotonically non-decreasing (daily cost is
+			// clamped at >= 0).
+			for day := 1; day < 90; day++ {
+				assert.GreaterOrEqual(t, f.DailyForecasts[day+1], f.DailyForecasts[day],
+					"cumulative forecast should be non-decreasing")
+			}
+
+			// For a rising series, forecast should exceed the base cost.
+			if tt.trend == "increasing" {
+				assert.Greater(t, f.Predicted90Days, f.BaseCost,
+					"increasing trend should forecast growth")
+			}
+
+			// Confidence intervals present; when the in-sample fit has non-zero
+			// residuals the interval widens with the horizon.
+			require.NotNil(t, f.Confidence7Days)
+			require.NotNil(t, f.Confidence90Days)
+			w7 := f.Confidence7Days.UpperBound - f.Confidence7Days.LowerBound
+			w90 := f.Confidence90Days.UpperBound - f.Confidence90Days.LowerBound
+			if w7 > 0 {
+				assert.Greater(t, w90, w7, "90-day CI should be wider than 7-day")
+			}
+
+			t.Logf("%s exponential: base=%.2f 90d=%.2f R²=%.2f MAE=%.2f",
+				tt.name, f.BaseCost, f.Predicted90Days, f.R2Score, f.MeanAbsoluteError)
+		})
+	}
+}
+
+// TestGenerateForecast_MovingAverage checks the flat-projection characteristic:
+// because the weighted MA projects a constant daily cost, its cumulative
+// forecast grows linearly with a constant per-day increment.
+func TestGenerateForecast_MovingAverage(t *testing.T) {
+	reporter := createTestReporterWithHistoricalData(t, 30, 10.0, "increasing")
+	engine := NewForecastEngine(reporter)
+
+	f, err := engine.GenerateForecast("test-project", ForecastModelMovingAverage, 90)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	assert.Equal(t, ForecastModelMovingAverage, f.Model)
+	assert.Len(t, f.DailyForecasts, 90)
+
+	// Constant daily increment => equal successive differences.
+	inc1 := f.DailyForecasts[2] - f.DailyForecasts[1]
+	inc2 := f.DailyForecasts[3] - f.DailyForecasts[2]
+	assert.InDelta(t, inc1, inc2, 1e-6, "moving average projects a constant daily cost")
+	assert.Greater(t, inc1, 0.0, "daily increment should be positive for non-zero costs")
+
+	// The projected daily cost reflects the recent window, so on a rising
+	// series it exceeds the earliest daily costs.
+	assert.Greater(t, f.Predicted90Days, f.BaseCost)
+
+	t.Logf("moving average: base=%.2f 90d=%.2f daily_inc=%.2f", f.BaseCost, f.Predicted90Days, inc1)
+}
+
+// TestGenerateForecast_EnsembleBlends verifies the ensemble is a genuine blend
+// of three distinct components, not linear relabeled.
+func TestGenerateForecast_EnsembleBlends(t *testing.T) {
+	reporter := createTestReporterWithHistoricalData(t, 30, 10.0, "increasing")
+	engine := NewForecastEngine(reporter)
+
+	linear, err := engine.GenerateForecast("test-project", ForecastModelLinear, 90)
+	require.NoError(t, err)
+	exp, err := engine.GenerateForecast("test-project", ForecastModelExponential, 90)
+	require.NoError(t, err)
+	ma, err := engine.GenerateForecast("test-project", ForecastModelMovingAverage, 90)
+	require.NoError(t, err)
+	ens, err := engine.GenerateForecast("test-project", ForecastModelEnsemble, 90)
+	require.NoError(t, err)
+
+	assert.Equal(t, ForecastModelEnsemble, ens.Model)
+
+	// The blended 90-day prediction must equal the 0.5/0.3/0.2 weighting.
+	want := 0.5*linear.Predicted90Days + 0.3*exp.Predicted90Days + 0.2*ma.Predicted90Days
+	assert.InDelta(t, want, ens.Predicted90Days, 1e-6, "ensemble should be the weighted blend")
+
+	// And be distinct from a plain linear forecast.
+	assert.Greater(t, math.Abs(linear.Predicted90Days-ens.Predicted90Days), 1.0,
+		"ensemble should differ from linear once components differ")
+
+	require.NotNil(t, ens.Confidence90Days)
+
+	t.Logf("ensemble 90d=%.2f (linear=%.2f exp=%.2f ma=%.2f)",
+		ens.Predicted90Days, linear.Predicted90Days, exp.Predicted90Days, ma.Predicted90Days)
+}
+
+// TestGenerateForecast_ModelsInsufficientData ensures the new models surface the
+// same insufficient-data error as linear rather than panicking.
+func TestGenerateForecast_ModelsInsufficientData(t *testing.T) {
+	reporter := createTestReporterWithHistoricalData(t, 1, 10.0, "stable")
+	engine := NewForecastEngine(reporter)
+
+	for _, m := range []ForecastModel{ForecastModelExponential, ForecastModelMovingAverage, ForecastModelEnsemble} {
+		f, err := engine.GenerateForecast("test-project", m, 30)
+		assert.Error(t, err, "model %s should error on insufficient data", m)
+		assert.Nil(t, f)
+		assert.Contains(t, err.Error(), "insufficient historical data")
+	}
+}
+
 // BenchmarkAnalyzeBurnRate benchmarks burn rate analysis
 func BenchmarkAnalyzeBurnRate(b *testing.B) {
 	reporter := createTestReporterWithHistoricalData(&testing.T{}, 90, 10.0, "increasing")


### PR DESCRIPTION
## Summary

`cargoship cost forecast` advertised 4 models but only **linear** was real. `exponential` and `moving_average` were TODO stubs that fell back to `generateLinearForecast` and merely relabeled `forecast.Model` — which also made the `ensemble` (0.5/0.3/0.2 blend) a linear forecast in disguise. This finishes the three already-declared statistical models over the persisted #246 cost ledger.

## Changes

- **Exponential** → Holt's double exponential smoothing (`alpha=0.3` level, `beta=0.1` trend) over the per-day cost series. Weights recent days more heavily and carries a trend, so it tracks changes in the recent burn rate rather than fitting the whole history equally.
- **Moving average** → exponentially-weighted 7-day trailing window, projected flat forward (constant daily cost). Reacts to the latest days and ignores older history — a genuinely different shape from the trend-bearing models.
- **Refactor** → extracted a shared `buildDailySeries` + `fitMetrics`/`setKeyPredictions`/confidence helpers; `generateLinearForecast` now reuses them (behavior preserved — existing linear/burn-rate tests unchanged).
- **Ensemble** → now blends three genuinely distinct components for both the daily forecasts *and* the accuracy metrics (R²/MAE/RMSE/CI), instead of copying linear's.

## Tests

Table-driven tests on synthetic cost series (increasing/decreasing/stable/volatile) assert each model's characteristic behavior and that all three models — and the ensemble — are materially distinct from linear, not relabeled. `pkg/aws/cost` coverage 75.1%; new functions 94–98%.

- `gofmt`/`go vet`/`staticcheck` clean
- Pre-commit gates passed (quality A+, 91.4)

Part of #167 (Option S). Closes #263.