### PR TITLE
feat: persist staging compression-ratio learned history (#262)

### DIFF
--- a/pkg/staging/compression_history_store.go
+++ b/pkg/staging/compression_history_store.go
@@ -1,0 +1,162 @@
+package staging
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// compressionHistoryEnv is the opt-in switch (and optional location override)
+// for durable compression-ratio history. This is derived telemetry — only
+// content-type -> ratio aggregates, never file content — so it is off by
+// default, consistent with the rest of the Option S measurement work (#262).
+//
+//	unset / empty  -> persistence disabled (in-memory only, prior behavior)
+//	"1" or "true"  -> enabled at the default state path
+//	<file path>    -> enabled at that explicit path (used by tests)
+const compressionHistoryEnv = "CARGOSHIP_COMPRESSION_HISTORY"
+
+// compressionHistoryDecayWindow is the age past which historical results are
+// discarded on load and down-weighted in GetAverageRatio. Kept as a single
+// source of truth so the on-load pruning and the running average agree.
+const compressionHistoryDecayWindow = 30 * 24 * time.Hour
+
+// compressionHistoryStoreVersion is the on-disk schema version.
+const compressionHistoryStoreVersion = 1
+
+// compressionHistoryDoc is the persisted on-disk shape of a CompressionHistory.
+type compressionHistoryDoc struct {
+	Version int                                       `json:"version"`
+	Results map[string][]*HistoricalCompressionResult `json:"results"`
+}
+
+// compressionHistoryStore locates and persists the learned compression history.
+// A zero store (enabled=false) is a no-op, so an in-memory-only history carries
+// no persistence cost.
+type compressionHistoryStore struct {
+	enabled bool
+	path    string
+}
+
+// newCompressionHistoryStore resolves the opt-in state from the environment.
+// When persistence is disabled it returns a no-op store.
+func newCompressionHistoryStore() compressionHistoryStore {
+	v := os.Getenv(compressionHistoryEnv)
+	switch v {
+	case "":
+		return compressionHistoryStore{}
+	case "1", "true":
+		path, err := defaultCompressionHistoryPath()
+		if err != nil {
+			return compressionHistoryStore{}
+		}
+		return compressionHistoryStore{enabled: true, path: path}
+	default:
+		return compressionHistoryStore{enabled: true, path: v}
+	}
+}
+
+// defaultCompressionHistoryPath mirrors the state-dir convention used by the
+// budget store (pkg/aws/cost/budget_store.go): $XDG_DATA_HOME/cargoship, else
+// ~/.cargoship.
+func defaultCompressionHistoryPath() (string, error) {
+	base := os.Getenv("XDG_DATA_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("get home dir: %w", err)
+		}
+		base = filepath.Join(home, ".cargoship")
+	} else {
+		base = filepath.Join(base, "cargoship")
+	}
+	return filepath.Join(base, "compression_history.json"), nil
+}
+
+// load reads the persisted history, pruning entries older than the decay window
+// and enforcing the per-content-type cap (most recent kept). A missing file is
+// not an error — it returns an empty map. Persistence being disabled likewise
+// yields an empty map with no I/O.
+func (s compressionHistoryStore) load(now time.Time, maxResults int) (map[string][]*HistoricalCompressionResult, error) {
+	if !s.enabled {
+		return map[string][]*HistoricalCompressionResult{}, nil
+	}
+	data, err := os.ReadFile(s.path) //nolint:gosec // path is env-configured (opt-in) or derived from home/XDG, not attacker input
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string][]*HistoricalCompressionResult{}, nil
+		}
+		return nil, fmt.Errorf("read compression history %q: %w", s.path, err)
+	}
+	var doc compressionHistoryDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse compression history %q: %w", s.path, err)
+	}
+	if doc.Results == nil {
+		return map[string][]*HistoricalCompressionResult{}, nil
+	}
+
+	cutoff := now.Add(-compressionHistoryDecayWindow)
+	pruned := make(map[string][]*HistoricalCompressionResult, len(doc.Results))
+	for contentType, results := range doc.Results {
+		kept := make([]*HistoricalCompressionResult, 0, len(results))
+		for _, r := range results {
+			if r == nil || !r.Timestamp.After(cutoff) {
+				continue // drop nil and stale (older than the decay window) entries
+			}
+			kept = append(kept, r)
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		// Oldest-first ordering matches AddResult's append semantics.
+		sort.Slice(kept, func(i, j int) bool {
+			return kept[i].Timestamp.Before(kept[j].Timestamp)
+		})
+		if maxResults > 0 && len(kept) > maxResults {
+			kept = kept[len(kept)-maxResults:] // keep the most recent maxResults
+		}
+		pruned[contentType] = kept
+	}
+	return pruned, nil
+}
+
+// save writes the history atomically (temp file + rename) so a crash mid-write
+// cannot corrupt the store. It is a no-op when persistence is disabled.
+func (s compressionHistoryStore) save(results map[string][]*HistoricalCompressionResult) error {
+	if !s.enabled {
+		return nil
+	}
+	doc := compressionHistoryDoc{Version: compressionHistoryStoreVersion, Results: results}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal compression history: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0700); err != nil {
+		return fmt.Errorf("create compression history dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".compression-history-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp compression history file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp compression history file: %w", err)
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp compression history file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp compression history file: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return fmt.Errorf("rename compression history into place: %w", err)
+	}
+	return nil
+}

--- a/pkg/staging/compression_history_store_test.go
+++ b/pkg/staging/compression_history_store_test.go
@@ -1,0 +1,220 @@
+package staging
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withHistoryStore points CARGOSHIP_COMPRESSION_HISTORY at a scratch file for
+// the duration of a test and restores the prior value afterward.
+func withHistoryStore(t *testing.T, path string) {
+	t.Helper()
+	prev, had := os.LookupEnv(compressionHistoryEnv)
+	require.NoError(t, os.Setenv(compressionHistoryEnv, path))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(compressionHistoryEnv, prev)
+		} else {
+			_ = os.Unsetenv(compressionHistoryEnv)
+		}
+	})
+}
+
+// TestCompressionHistory_Disabled confirms the tracker stays in-memory-only and
+// writes nothing when persistence is not opted into.
+func TestCompressionHistory_Disabled(t *testing.T) {
+	// Ensure the env var is unset for this test.
+	prev, had := os.LookupEnv(compressionHistoryEnv)
+	require.NoError(t, os.Unsetenv(compressionHistoryEnv))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(compressionHistoryEnv, prev)
+		}
+	})
+
+	ch := NewCompressionHistory()
+	assert.False(t, ch.store.enabled, "store should be disabled when env unset")
+
+	ch.AddResult("text", 1000, 0.7)
+	assert.InDelta(t, 0.7, ch.GetAverageRatio("text", 1000), 1e-9)
+}
+
+// TestCompressionHistory_RoundTrip verifies learned history survives a restart:
+// a fresh tracker constructed against the same store recovers prior results.
+func TestCompressionHistory_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "compression_history.json")
+	withHistoryStore(t, path)
+
+	first := NewCompressionHistory()
+	require.True(t, first.store.enabled)
+	first.AddResult("text", 1000, 0.7)
+	first.AddResult("text", 1000, 0.6)
+	first.AddResult("json", 2000, 0.5)
+
+	// File should exist after AddResult flushes.
+	_, err := os.Stat(path)
+	require.NoError(t, err, "history file should be written")
+
+	// A new tracker (simulating a fresh process) loads the persisted history.
+	second := NewCompressionHistory()
+	assert.Len(t, second.GetResultsForContentType("text"), 2)
+	assert.Len(t, second.GetResultsForContentType("json"), 1)
+	// The learned average is recovered (recent-weighted average of 0.7 and 0.6).
+	got := second.GetAverageRatio("text", 1000)
+	assert.Greater(t, got, 0.0)
+	assert.InDelta(t, 0.65, got, 0.05)
+}
+
+// TestCompressionHistory_DecayOnLoad verifies entries older than the decay
+// window are dropped when the store is loaded.
+func TestCompressionHistory_DecayOnLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "compression_history.json")
+
+	now := time.Now()
+	fresh := &HistoricalCompressionResult{ContentType: "text", Size: 1000, Ratio: 0.7, Timestamp: now.Add(-24 * time.Hour)}
+	stale := &HistoricalCompressionResult{ContentType: "text", Size: 1000, Ratio: 0.3, Timestamp: now.Add(-compressionHistoryDecayWindow - 24*time.Hour)}
+	doc := compressionHistoryDoc{
+		Version: compressionHistoryStoreVersion,
+		Results: map[string][]*HistoricalCompressionResult{"text": {stale, fresh}},
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+
+	store := compressionHistoryStore{enabled: true, path: path}
+	loaded, err := store.load(now, 1000)
+	require.NoError(t, err)
+
+	require.Len(t, loaded["text"], 1, "stale entry should be pruned on load")
+	assert.InDelta(t, 0.7, loaded["text"][0].Ratio, 1e-9)
+}
+
+// TestCompressionHistory_CapOnLoad verifies the per-content-type cap keeps only
+// the most recent maxResults entries on load.
+func TestCompressionHistory_CapOnLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "compression_history.json")
+
+	now := time.Now()
+	var results []*HistoricalCompressionResult
+	for i := 0; i < 10; i++ {
+		results = append(results, &HistoricalCompressionResult{
+			ContentType: "text",
+			Size:        1000,
+			Ratio:       float64(i) / 10.0,
+			// Older -> newer as i grows.
+			Timestamp: now.Add(-time.Duration(10-i) * time.Hour),
+		})
+	}
+	doc := compressionHistoryDoc{Version: compressionHistoryStoreVersion, Results: map[string][]*HistoricalCompressionResult{"text": results}}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+
+	store := compressionHistoryStore{enabled: true, path: path}
+	loaded, err := store.load(now, 3)
+	require.NoError(t, err)
+
+	require.Len(t, loaded["text"], 3, "should keep only the most recent 3")
+	// The most recent three have ratios 0.7, 0.8, 0.9 (oldest-first order).
+	assert.InDelta(t, 0.7, loaded["text"][0].Ratio, 1e-9)
+	assert.InDelta(t, 0.9, loaded["text"][2].Ratio, 1e-9)
+}
+
+// TestCompressionHistory_MissingFile confirms a missing store is not an error.
+func TestCompressionHistory_MissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	store := compressionHistoryStore{enabled: true, path: path}
+
+	loaded, err := store.load(time.Now(), 1000)
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+}
+
+// TestCompressionHistory_CorruptFileDoesNotBlockStartup ensures a corrupt store
+// is ignored by the constructor rather than panicking or losing the tracker.
+func TestCompressionHistory_CorruptFileDoesNotBlockStartup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "compression_history.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not valid json"), 0600))
+	withHistoryStore(t, path)
+
+	ch := NewCompressionHistory() // must not panic
+	require.NotNil(t, ch)
+	// Starts cold; still usable and re-persists cleanly.
+	assert.Empty(t, ch.GetResultsForContentType("text"))
+	ch.AddResult("text", 1000, 0.7)
+	assert.Len(t, ch.GetResultsForContentType("text"), 1)
+}
+
+// TestCompressionHistory_SaveConvergence checks that predictions accumulate
+// across simulated runs — the core "improves across restarts" goal.
+func TestCompressionHistory_SaveConvergence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "compression_history.json")
+	withHistoryStore(t, path)
+
+	// Three separate "processes" each learn one result for the same content.
+	for i := 0; i < 3; i++ {
+		ch := NewCompressionHistory()
+		ch.AddResult("logs", 5000, 0.8)
+	}
+
+	final := NewCompressionHistory()
+	assert.Len(t, final.GetResultsForContentType("logs"), 3,
+		"results should accumulate across restarts")
+	assert.InDelta(t, 0.8, final.GetAverageRatio("logs", 5000), 1e-6)
+}
+
+// TestCompressionHistoryStore_FilePermissions verifies the store is written 0600.
+func TestCompressionHistoryStore_FilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "compression_history.json")
+	store := compressionHistoryStore{enabled: true, path: path}
+
+	require.NoError(t, store.save(map[string][]*HistoricalCompressionResult{
+		"text": {{ContentType: "text", Size: 1, Ratio: 0.5, Timestamp: time.Now()}},
+	}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+// TestNewCompressionHistoryStore_EnvModes covers the opt-in switch parsing.
+func TestNewCompressionHistoryStore_EnvModes(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         string
+		unset       bool
+		wantEnabled bool
+	}{
+		{name: "unset", unset: true, wantEnabled: false},
+		{name: "empty", env: "", wantEnabled: false},
+		{name: "one", env: "1", wantEnabled: true},
+		{name: "true", env: "true", wantEnabled: true},
+		{name: "explicit path", env: "/tmp/x.json", wantEnabled: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unset {
+				prev, had := os.LookupEnv(compressionHistoryEnv)
+				require.NoError(t, os.Unsetenv(compressionHistoryEnv))
+				t.Cleanup(func() {
+					if had {
+						_ = os.Setenv(compressionHistoryEnv, prev)
+					}
+				})
+			} else {
+				withHistoryStore(t, tt.env)
+			}
+			store := newCompressionHistoryStore()
+			assert.Equal(t, tt.wantEnabled, store.enabled)
+			if tt.wantEnabled && tt.env != "1" && tt.env != "true" && tt.env != "" {
+				assert.Equal(t, tt.env, store.path)
+			}
+		})
+	}
+}

--- a/pkg/staging/compression_predictor.go
+++ b/pkg/staging/compression_predictor.go
@@ -224,25 +224,40 @@ func (cs *CompressionStats) UpdateWithResult(uncompressedSize, compressedSize in
 	cs.LastUpdated = time.Now()
 }
 
-// CompressionHistory tracks historical compression performance.
+// CompressionHistory tracks historical compression performance. When durable
+// persistence is enabled (opt-in via CARGOSHIP_COMPRESSION_HISTORY, see #262),
+// results survive process restarts so predictions converge across runs;
+// otherwise it behaves exactly as the prior in-memory-only tracker.
 type CompressionHistory struct {
 	results    map[string][]*HistoricalCompressionResult
 	maxResults int
+	store      compressionHistoryStore
 	mu         sync.RWMutex
 }
 
-// NewCompressionHistory creates a new compression history tracker.
+// NewCompressionHistory creates a new compression history tracker. If durable
+// persistence is enabled it loads any previously learned history, dropping
+// entries older than the decay window and honoring the per-content-type cap.
 func NewCompressionHistory() *CompressionHistory {
-	return &CompressionHistory{
+	store := newCompressionHistoryStore()
+	ch := &CompressionHistory{
 		results:    make(map[string][]*HistoricalCompressionResult),
 		maxResults: 1000,
+		store:      store,
 	}
+	// Best-effort load: a corrupt or unreadable store must never block startup.
+	if loaded, err := store.load(time.Now(), ch.maxResults); err == nil && loaded != nil {
+		ch.results = loaded
+	}
+	return ch
 }
 
-// AddResult adds a compression result to the history.
+// AddResult adds a compression result to the history. When persistence is
+// enabled the updated history is flushed to disk best-effort — a save failure
+// is swallowed so it can never fail an upload (mirrors the budget ledger's
+// persistLedger, #246).
 func (ch *CompressionHistory) AddResult(contentType string, size int64, ratio float64) {
 	ch.mu.Lock()
-	defer ch.mu.Unlock()
 
 	result := &HistoricalCompressionResult{
 		ContentType: contentType,
@@ -261,6 +276,25 @@ func (ch *CompressionHistory) AddResult(contentType string, size int64, ratio fl
 	if len(ch.results[contentType]) > ch.maxResults {
 		ch.results[contentType] = ch.results[contentType][1:]
 	}
+
+	// Snapshot under lock; persist outside it.
+	snapshot := ch.snapshotLocked()
+	ch.mu.Unlock()
+
+	_ = ch.store.save(snapshot)
+}
+
+// snapshotLocked returns a deep-enough copy of the results map for persistence.
+// The per-type slices are copied (the pointer elements are treated as
+// immutable once appended). Caller must hold ch.mu.
+func (ch *CompressionHistory) snapshotLocked() map[string][]*HistoricalCompressionResult {
+	out := make(map[string][]*HistoricalCompressionResult, len(ch.results))
+	for k, v := range ch.results {
+		cp := make([]*HistoricalCompressionResult, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+	return out
 }
 
 // GetAverageRatio gets the average compression ratio for similar content.
@@ -294,13 +328,13 @@ func (ch *CompressionHistory) GetAverageRatio(contentType string, size int64) fl
 	now := time.Now()
 
 	for _, result := range similarResults {
-		// Weight decreases with age (max 30 days)
+		// Weight decreases with age (down to a floor past the decay window)
 		age := now.Sub(result.Timestamp)
 		var weight float64
-		if age > time.Hour*24*30 {
+		if age > compressionHistoryDecayWindow {
 			weight = 0.1
 		} else {
-			weight = 1.0 - float64(age)/(float64(time.Hour*24*30))
+			weight = 1.0 - float64(age)/float64(compressionHistoryDecayWindow)
 		}
 
 		weightedSum += result.Ratio * weight
@@ -331,10 +365,10 @@ func (ch *CompressionHistory) GetResultsForContentType(contentType string) []*Hi
 
 // HistoricalCompressionResult represents a historical compression result.
 type HistoricalCompressionResult struct {
-	ContentType string
-	Size        int64
-	Ratio       float64
-	Timestamp   time.Time
+	ContentType string    `json:"content_type"`
+	Size        int64     `json:"size"`
+	Ratio       float64   `json:"ratio"`
+	Timestamp   time.Time `json:"timestamp"`
 }
 
 // abs64 returns the absolute value of a 64-bit integer.


### PR DESCRIPTION
## Summary

The staging `CompressionRatioPredictor` already has a genuine online learner — `LearnFromResult` feeds a `CompressionHistory` that keeps up to 1000 results per content-type with a 30-day time-decayed weighted average. But that history lived in an in-memory map with no persistence, so **every process started cold** and never improved across runs. This makes it durable.

## Changes

- **`compressionHistoryStore`** — a small durable JSON file keyed by content-type, using the atomic-write (temp + rename, 0600) and XDG/`~/.cargoship` conventions from `pkg/aws/cost/budget_store.go`.
- **Load on construction** (`NewCompressionHistory`), best-effort — a corrupt or unreadable store never blocks startup. On load it prunes entries older than the decay window and enforces the per-content-type cap (most recent kept).
- **Save after `AddResult`**, best-effort — a save error is swallowed so it can never fail an upload (mirrors the budget ledger's `persistLedger`, #246). Snapshot taken under lock, written outside it.
- **Opt-in** via `CARGOSHIP_COMPRESSION_HISTORY` (off by default). This is derived telemetry — only content-type → ratio aggregates, never file content — consistent with the rest of Option S. `1`/`true` uses the default state path; any other value is treated as an explicit file path.
- Factored the 30-day decay window into a shared constant so on-load pruning and the running-average weighting agree.

## Scope

Not wired onto the default upload path — the predictor only runs under the opt-in staging/adaptive transporter today (`pkg/pipeline/transporter_factory.go`), left as-is per the issue. The separate `pkg/aws/s3` predictor of the same name is an independent type and is untouched.

## Tests

Round-trip across a simulated restart, decay-on-load, cap-on-load, missing file, corrupt-file-doesn't-block-startup, cross-run convergence, 0600 permissions, and env-mode parsing. New code covered 88–100% (`save`'s uncovered lines are OS-error branches, as in the budget store). `pkg/staging` coverage 82.8%.

- `gofmt`/`go vet`/`staticcheck`/`golangci-lint` clean; pre-commit gates passed.

Part of #167 (Option S). Closes #262.