### PR TITLE
fix(ci): regenerate CLI docs for #246 budget flags; fuzz by count not time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,8 +114,14 @@ jobs:
       # Runs each fuzz target for a short burst to catch new crashers beyond the
       # committed seed corpus (which the -short jobs already execute as unit
       # tests). -fuzz runs one target per package invocation, so iterate. Kept
-      # brief (20s each) to stay on the PR critical path; the corpus grows over
-      # time via developers running longer local sessions. (#238 Phase 4)
+      # brief to stay on the PR critical path; the corpus grows over time via
+      # developers running longer local sessions. (#238 Phase 4)
+      #
+      # Budget is an execution COUNT, not a wall-clock duration: a duration
+      # -fuzztime lets the fuzzing coordinator race its own deadline on a
+      # contended runner and fail with a spurious "context deadline exceeded"
+      # (not a real crasher). A count has no time-based context, so that flake
+      # cannot occur while still exercising ~500k inputs per target.
       - name: Fuzz manifest + chunking targets
         run: |
           set -euo pipefail
@@ -123,7 +129,7 @@ jobs:
             local pkg="$1"; shift
             for target in "$@"; do
               echo "::group::$pkg $target"
-              go test "$pkg" -run '^$' -fuzz "^${target}$" -fuzztime 20s
+              go test "$pkg" -run '^$' -fuzz "^${target}$" -fuzztime 500000x
               echo "::endgroup::"
             done
           }

--- a/docs/gen/cli/cargoship_budget.md
+++ b/docs/gen/cli/cargoship_budget.md
@@ -44,7 +44,8 @@ cargoship budget [flags]
 ### Options
 
 ```
-  -h, --help   help for budget
+  -h, --help           help for budget
+      --store string   Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
 ```
 
 ### Options inherited from parent commands

--- a/docs/gen/cli/cargoship_budget_list.md
+++ b/docs/gen/cli/cargoship_budget_list.md
@@ -39,6 +39,7 @@ cargoship budget list [flags]
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
       --profile               Enable performance profiling. This will generate profile files in a temp directory
+      --store string          Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
   -t, --trace                 Enable trace messages in output
   -v, --verbose               Enable verbose output
 ```

--- a/docs/gen/cli/cargoship_budget_remove.md
+++ b/docs/gen/cli/cargoship_budget_remove.md
@@ -31,6 +31,7 @@ cargoship budget remove <project-id> [flags]
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
       --profile               Enable performance profiling. This will generate profile files in a temp directory
+      --store string          Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
   -t, --trace                 Enable trace messages in output
   -v, --verbose               Enable verbose output
 ```

--- a/docs/gen/cli/cargoship_budget_set.md
+++ b/docs/gen/cli/cargoship_budget_set.md
@@ -29,6 +29,9 @@ Examples:
   # Set unlimited
   cargoship budget set project1 --cost 0 --volume 0
 
+  # Set the org/team-wide budget ceiling (across all projects)
+  cargoship budget set --global --cost 10000 --volume 5000
+
 
 ```
 cargoship budget set <project-id> [flags]
@@ -39,6 +42,7 @@ cargoship budget set <project-id> [flags]
 ```
       --cost float           Maximum cost budget in USD (0 = unlimited)
       --cost-alert float     Cost alert threshold (0.0-1.0, default 0.8) (default 0.8)
+      --global               Set the org/team-wide budget ceiling (across all projects) instead of a per-project budget
   -h, --help                 help for set
       --volume float         Maximum volume quota in GB (0 = unlimited)
       --volume-alert float   Volume alert threshold (0.0-1.0, default 0.75) (default 0.75)
@@ -52,6 +56,7 @@ cargoship budget set <project-id> [flags]
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
       --profile               Enable performance profiling. This will generate profile files in a temp directory
+      --store string          Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
   -t, --trace                 Enable trace messages in output
   -v, --verbose               Enable verbose output
 ```

--- a/docs/gen/cli/cargoship_budget_status.md
+++ b/docs/gen/cli/cargoship_budget_status.md
@@ -22,6 +22,9 @@ Examples:
   # Status as JSON
   cargoship budget status project1 --json
 
+  # Show the org/team-wide budget status
+  cargoship budget status --global
+
 
 ```
 cargoship budget status <project-id> [flags]
@@ -30,8 +33,9 @@ cargoship budget status <project-id> [flags]
 ### Options
 
 ```
-  -h, --help   help for status
-      --json   Output as JSON
+      --global   Show the org/team-wide budget status instead of a project's
+  -h, --help     help for status
+      --json     Output as JSON
 ```
 
 ### Options inherited from parent commands
@@ -42,6 +46,7 @@ cargoship budget status <project-id> [flags]
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
       --profile               Enable performance profiling. This will generate profile files in a temp directory
+      --store string          Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
   -t, --trace                 Enable trace messages in output
   -v, --verbose               Enable verbose output
 ```

--- a/docs/gen/cli/cargoship_cost_budget.md
+++ b/docs/gen/cli/cargoship_cost_budget.md
@@ -44,7 +44,8 @@ cargoship cost budget [flags]
 ### Options
 
 ```
-  -h, --help   help for budget
+  -h, --help           help for budget
+      --store string   Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
 ```
 
 ### Options inherited from parent commands

--- a/docs/gen/cli/cargoship_cost_budget_list.md
+++ b/docs/gen/cli/cargoship_cost_budget_list.md
@@ -40,6 +40,7 @@ cargoship cost budget list [flags]
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
       --profile               Enable performance profiling. This will generate profile files in a temp directory
   -r, --region string         AWS region (default "us-west-2")
+      --store string          Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
   -t, --trace                 Enable trace messages in output
   -v, --verbose               Enable verbose output
 ```

--- a/docs/gen/cli/cargoship_cost_budget_remove.md
+++ b/docs/gen/cli/cargoship_cost_budget_remove.md
@@ -33,6 +33,7 @@ cargoship cost budget remove <project-id> [flags]
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
       --profile               Enable performance profiling. This will generate profile files in a temp directory
   -r, --region string         AWS region (default "us-west-2")
+      --store string          Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
   -t, --trace                 Enable trace messages in output
   -v, --verbose               Enable verbose output
 ```

--- a/docs/gen/cli/cargoship_cost_budget_set.md
+++ b/docs/gen/cli/cargoship_cost_budget_set.md
@@ -29,6 +29,9 @@ Examples:
   # Set unlimited
   cargoship budget set project1 --cost 0 --volume 0
 
+  # Set the org/team-wide budget ceiling (across all projects)
+  cargoship budget set --global --cost 10000 --volume 5000
+
 
 ```
 cargoship cost budget set <project-id> [flags]
@@ -39,6 +42,7 @@ cargoship cost budget set <project-id> [flags]
 ```
       --cost float           Maximum cost budget in USD (0 = unlimited)
       --cost-alert float     Cost alert threshold (0.0-1.0, default 0.8) (default 0.8)
+      --global               Set the org/team-wide budget ceiling (across all projects) instead of a per-project budget
   -h, --help                 help for set
       --volume float         Maximum volume quota in GB (0 = unlimited)
       --volume-alert float   Volume alert threshold (0.0-1.0, default 0.75) (default 0.75)
@@ -54,6 +58,7 @@ cargoship cost budget set <project-id> [flags]
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
       --profile               Enable performance profiling. This will generate profile files in a temp directory
   -r, --region string         AWS region (default "us-west-2")
+      --store string          Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
   -t, --trace                 Enable trace messages in output
   -v, --verbose               Enable verbose output
 ```

--- a/docs/gen/cli/cargoship_cost_budget_status.md
+++ b/docs/gen/cli/cargoship_cost_budget_status.md
@@ -22,6 +22,9 @@ Examples:
   # Status as JSON
   cargoship budget status project1 --json
 
+  # Show the org/team-wide budget status
+  cargoship budget status --global
+
 
 ```
 cargoship cost budget status <project-id> [flags]
@@ -30,8 +33,9 @@ cargoship cost budget status <project-id> [flags]
 ### Options
 
 ```
-  -h, --help   help for status
-      --json   Output as JSON
+      --global   Show the org/team-wide budget status instead of a project's
+  -h, --help     help for status
+      --json     Output as JSON
 ```
 
 ### Options inherited from parent commands
@@ -43,6 +47,7 @@ cargoship cost budget status <project-id> [flags]
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
       --profile               Enable performance profiling. This will generate profile files in a temp directory
   -r, --region string         AWS region (default "us-west-2")
+      --store string          Budget store location: local (default) or s3://bucket/prefix for a shared, durable store
   -t, --trace                 Enable trace messages in output
   -v, --verbose               Enable verbose output
 ```


### PR DESCRIPTION
Fixes two unrelated failures currently red on `main`.

## 1. Deploy Documentation — CLI reference drift (deterministic)

The #246 budget flags (`--global`, `--store` on `budget set`/`budget status` and the `cost budget` aliases) were merged without regenerating `docs/gen/cli/`, so the "Check CLI reference is in sync" gate fails. Ran `docs/scripts/gen-cli.sh`; the diff is exactly those new flags — no other churn.

## 2. Fuzz (short burst) — spurious timeout (flake, 2/15 runs)

The fuzz lane intermittently failed with `context deadline exceeded` at ~20.10s. That's the Go fuzzing coordinator racing its own wall-clock `-fuzztime 20s` deadline on a contended runner — **not** a discovered crasher (`FuzzParseS3URL`'s reconstruction is mathematically exact; 11M+ execs pass locally).

Switched `-fuzztime` from a duration (`20s`) to an execution **count** (`500000x`). A count has no time-based context, so the deadline flake cannot occur, while each target still exercises ~500k inputs (~3s wall).

No product code changed.