### PR TITLE
feat: persist per-upload outcome history — the training corpus (#261)

### DIFF
--- a/cmd/cargoship/cmd/cost.go
+++ b/cmd/cargoship/cmd/cost.go
@@ -499,8 +499,35 @@ Examples:
 	summaryCmd.Flags().String("by-dvc-stage", "", "Aggregate costs for this DVC pipeline stage")
 	summaryCmd.Flags().String("git-commit", "", "List costs tagged with this git commit SHA")
 
+	// #261: inspect the opt-in per-upload outcome history (the training corpus).
+	historyCmd := &cobra.Command{
+		Use:   "history",
+		Short: "Show the recorded per-upload outcome history",
+		Long: `Display the durable per-upload outcome history (metadata only).
+
+This history is opt-in and OFF by default. Enable it with the
+CARGOSHIP_UPLOAD_HISTORY environment variable (1, true, or a file path) or the
+cost_control.upload_history_location config key. Each successful upload then
+appends a metadata-only record — dataset shape, chosen parameters, and measured
+outcomes (compression ratio, throughput, cost). No file content, names, or
+paths are recorded.
+
+Examples:
+  # Show the recorded history
+  cargoship cost history
+
+  # As JSON, most recent first
+  cargoship cost history --json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			limit, _ := cmd.Flags().GetInt("limit")
+			return runCostHistory(cmd, limit, jsonOutput)
+		},
+	}
+	historyCmd.Flags().Int("limit", 20, "Maximum number of records to show (0 = all)")
+
 	// Add subcommands
-	cmd.AddCommand(estimateCmd, uploadCmd, budgetCmd, pricingCmd, reportCmd, projectsCmd, projectCmd, forecastCmd, burnrateCmd, exhaustionCmd, benchmarkCmd, summaryCmd)
+	cmd.AddCommand(estimateCmd, uploadCmd, budgetCmd, pricingCmd, reportCmd, projectsCmd, projectCmd, forecastCmd, burnrateCmd, exhaustionCmd, benchmarkCmd, summaryCmd, historyCmd)
 
 	return cmd
 }
@@ -1633,5 +1660,63 @@ func runComplianceReport(ctx context.Context, region, budgetID, grantNumber, age
 		return nil
 	}
 	fmt.Print(output)
+	return nil
+}
+
+// runCostHistory renders the opt-in per-upload outcome history (#261). When the
+// history is disabled it prints how to enable it rather than erroring, so the
+// command is discoverable.
+func runCostHistory(cmd *cobra.Command, limit int, jsonOutput bool) error {
+	store := cost.NewUploadHistoryStore("")
+	if !store.Enabled() {
+		if jsonOutput {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode([]cost.UploadOutcome{})
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Per-upload outcome history is disabled (opt-in).")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Enable it with CARGOSHIP_UPLOAD_HISTORY=1 (or a file path),")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "or set cost_control.upload_history_location in your config.")
+		return nil
+	}
+
+	records, err := store.LoadOutcomes()
+	if err != nil {
+		return fmt.Errorf("load upload history: %w", err)
+	}
+
+	// Show most recent first; apply the limit after reversing.
+	reversed := make([]*cost.UploadOutcome, len(records))
+	for i, r := range records {
+		reversed[len(records)-1-i] = r
+	}
+	if limit > 0 && len(reversed) > limit {
+		reversed = reversed[:limit]
+	}
+
+	if jsonOutput {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(reversed)
+	}
+
+	if len(reversed) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No upload outcomes recorded yet.")
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "📦 Upload Outcome History (%d record(s), showing %d)\n\n", len(records), len(reversed))
+	for _, r := range reversed {
+		status := "✅"
+		if !r.Success {
+			status = "❌"
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %s  %s\n", status, r.Timestamp.Format("2006-01-02 15:04"), r.UploadID)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   %d files, %.2f GB, %d chunks, %d shards, %s L%d\n",
+			r.FileCount, float64(r.TotalBytes)/(1024*1024*1024), r.ChunkCount, r.ShardCount,
+			r.CompressionType, r.CompressionLevel)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   ratio=%.3f, %.1f MB/s, %v, cost=$%.4f\n\n",
+			r.CompressionRatio, r.ThroughputMBps, r.Duration.Round(time.Second), r.Cost)
+	}
 	return nil
 }

--- a/cmd/cargoship/cmd/cost_test.go
+++ b/cmd/cargoship/cmd/cost_test.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	cargoconfig "github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/aws/cost"
 )
 
 // TestParseSize tests the parseSize helper function
@@ -339,6 +341,7 @@ func TestNewCostCmd_Structure(t *testing.T) {
 		"exhaustion",
 		"benchmark-compare",
 		"summary", // Issue #186: DVC stage / git-commit cost aggregation
+		"history", // Issue #261: per-upload outcome history
 	}
 
 	commands := cmd.Commands()
@@ -565,5 +568,66 @@ func TestExhaustionCmd_Structure(t *testing.T) {
 	}
 	if !strings.Contains(exhaustionCmd.Long, "budget") || !strings.Contains(exhaustionCmd.Long, "exhausted") {
 		t.Error("exhaustion command long description should mention budget exhaustion")
+	}
+}
+
+// TestRunCostHistory_DisabledShowsHint verifies the history command explains how
+// to opt in rather than erroring when the store is disabled.
+func TestRunCostHistory_DisabledShowsHint(t *testing.T) {
+	t.Setenv("CARGOSHIP_UPLOAD_HISTORY", "") // explicitly disabled
+
+	cmd := &cobra.Command{}
+	var out strings.Builder
+	cmd.SetOut(&out)
+
+	if err := runCostHistory(cmd, 20, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "disabled") {
+		t.Errorf("expected an opt-in hint, got: %q", out.String())
+	}
+}
+
+// TestRunCostHistory_JSONEmptyWhenDisabled verifies JSON mode emits an empty
+// array (not an error) when disabled, so scripts can consume it uniformly.
+func TestRunCostHistory_JSONEmptyWhenDisabled(t *testing.T) {
+	t.Setenv("CARGOSHIP_UPLOAD_HISTORY", "")
+
+	cmd := &cobra.Command{}
+	var out strings.Builder
+	cmd.SetOut(&out)
+
+	if err := runCostHistory(cmd, 20, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "[]" {
+		t.Errorf("expected empty JSON array, got: %q", got)
+	}
+}
+
+// TestRunCostHistory_RendersRecords verifies enabled+populated output.
+func TestRunCostHistory_RendersRecords(t *testing.T) {
+	path := t.TempDir() + "/upload_history.json"
+	t.Setenv("CARGOSHIP_UPLOAD_HISTORY", path)
+
+	store := cost.NewUploadHistoryStore("")
+	if err := store.Append(&cost.UploadOutcome{
+		UploadID: "abc123", Timestamp: time.Now(), FileCount: 5,
+		TotalBytes: 1024 * 1024 * 1024, CompressionType: "zstd", CompressionLevel: 3,
+		CompressionRatio: 0.4, ThroughputMBps: 100, Success: true,
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	var out strings.Builder
+	cmd.SetOut(&out)
+
+	if err := runCostHistory(cmd, 20, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "abc123") || !strings.Contains(s, "ratio=0.400") {
+		t.Errorf("expected record details in output, got: %q", s)
 	}
 }

--- a/cmd/cargoship/cmd/upload.go
+++ b/cmd/cargoship/cmd/upload.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/term"
 
 	cargoconfig "github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/aws/cost"
 	"github.com/scttfrdmn/cargoship/pkg/manifest"
 	"github.com/scttfrdmn/cargoship/pkg/observability/metrics"
 	"github.com/scttfrdmn/cargoship/pkg/observability/tracing"
@@ -748,6 +749,11 @@ Examples:
 				)
 			}
 
+			// #261: append a metadata-only outcome record to the opt-in upload
+			// history (the training corpus). Best-effort — the upload already
+			// succeeded, so a telemetry error is a warning, never a failure.
+			recordUploadOutcome(cmd, dvcProject, storageClass, region, compressionLevel, result, pipe.GetManifest())
+
 			// Print newline after progress display (if TUI mode was active)
 			if !quiet && term.IsTerminal(int(os.Stdout.Fd())) {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout())
@@ -950,6 +956,65 @@ func recordUploadCost(ctx context.Context, cmd *cobra.Command, projectID, storag
 		tags,
 	); err != nil {
 		_, _ = fmt.Fprintf(cmd.OutOrStderr(), "⚠️  cost tracking failed: %v\n", err)
+	}
+}
+
+// recordUploadOutcome assembles a metadata-only UploadOutcome from what the
+// completed upload already produced — the pipeline Result and the finalized
+// manifest — and appends it to the opt-in upload history (#261). It is
+// best-effort: the store is a no-op unless the user opted in, and any error is
+// a warning, never a command failure (the upload has already succeeded).
+func recordUploadOutcome(cmd *cobra.Command, projectID, storageClass, region string, compressionLevel int, result *pipeline.Result, m *manifest.Manifest) {
+	store := cost.NewUploadHistoryStore("")
+	if !store.Enabled() || result == nil {
+		return
+	}
+
+	var throughputMBps float64
+	if result.TotalTime > 0 {
+		throughputMBps = float64(result.TotalBytes) / (1024 * 1024) / result.TotalTime.Seconds()
+	}
+
+	outcome := &cost.UploadOutcome{
+		UploadID:         result.UploadID,
+		ProjectID:        projectID,
+		Timestamp:        time.Now(),
+		TotalBytes:       result.TotalBytes,
+		FileCount:        result.TotalFiles,
+		ChunkCount:       result.TotalChunks,
+		CompressionLevel: compressionLevel,
+		StorageClass:     storageClass,
+		Region:           region,
+		Duration:         result.TotalTime,
+		ThroughputMBps:   throughputMBps,
+		ErrorCount:       len(result.Errors),
+		Success:          result.Success,
+	}
+
+	// Prefer the finalized manifest for the measured outcomes and the chosen
+	// parameters; it carries the actual compression ratio, shard count, and the
+	// file list needed for the (metadata-only) type mix.
+	if m != nil {
+		outcome.ShardCount = m.ShardCount
+		outcome.ChunkCount = m.TotalChunks
+		outcome.CompressionType = m.CompressionType
+		if m.CompressionLevel != 0 {
+			outcome.CompressionLevel = m.CompressionLevel
+		}
+		outcome.CompressionRatio = m.CompressionRatio
+		if m.CompressionRatio > 0 {
+			outcome.CompressedBytes = int64(float64(m.TotalBytes) * m.CompressionRatio)
+		}
+		exts := make([]string, 0, len(m.Files))
+		for _, f := range m.Files {
+			exts = append(exts, strings.ToLower(strings.TrimPrefix(filepath.Ext(f.Path), ".")))
+		}
+		outcome.FileTypeMix = cost.FileTypeMixFromExtensions(exts)
+	}
+	// Without a manifest, ShardCount stays 0 (unknown) rather than misreporting.
+
+	if err := store.Append(outcome); err != nil {
+		_, _ = fmt.Fprintf(cmd.OutOrStderr(), "⚠️  upload history not recorded: %v\n", err)
 	}
 }
 

--- a/cmd/cargoship/cmd/upload_test.go
+++ b/cmd/cargoship/cmd/upload_test.go
@@ -3,8 +3,14 @@ package cmd
 import (
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/cost"
+	"github.com/scttfrdmn/cargoship/pkg/manifest"
+	"github.com/scttfrdmn/cargoship/pkg/pipeline"
 )
 
 // TestNewUploadCmd_Structure tests the upload command structure (Issue #95)
@@ -224,4 +230,64 @@ func TestUploadCmd_RequiredArguments(t *testing.T) {
 	// Verify Args is set to ExactArgs(2)
 	// We can't directly test cobra.ExactArgs, but we can verify the command has Args set
 	assert.NotNil(t, cmd.Args, "Args validator should be set")
+}
+
+// TestRecordUploadOutcome_Disabled verifies no history is written when opt-in
+// is off (a nil manifest and disabled store must be a clean no-op).
+func TestRecordUploadOutcome_Disabled(t *testing.T) {
+	t.Setenv("CARGOSHIP_UPLOAD_HISTORY", "")
+
+	cmd := &cobra.Command{}
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	result := &pipeline.Result{Success: true, UploadID: "u1", TotalBytes: 1000, TotalFiles: 2, TotalChunks: 1}
+	recordUploadOutcome(cmd, "", "STANDARD", "us-west-2", 3, result, nil)
+
+	assert.Empty(t, out.String(), "disabled store should produce no output")
+}
+
+// TestRecordUploadOutcome_AssemblesFromManifest verifies the outcome record is
+// assembled from the pipeline result and manifest, including the metadata-only
+// file-type mix and manifest-sourced compression fields.
+func TestRecordUploadOutcome_AssemblesFromManifest(t *testing.T) {
+	path := t.TempDir() + "/upload_history.json"
+	t.Setenv("CARGOSHIP_UPLOAD_HISTORY", path)
+
+	cmd := &cobra.Command{}
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	result := &pipeline.Result{
+		Success: true, UploadID: "up-42", TotalBytes: 2 * 1024 * 1024 * 1024,
+		TotalFiles: 3, TotalChunks: 5, TotalTime: 10 * time.Second,
+	}
+	m := &manifest.Manifest{
+		UploadID: "up-42", ShardCount: 6, TotalChunks: 5, TotalBytes: 2 * 1024 * 1024 * 1024,
+		CompressionType: "zstd", CompressionLevel: 9, CompressionRatio: 0.5,
+		Files: []manifest.FileEntry{
+			{Path: "a/b/file.txt"}, {Path: "c/other.txt"}, {Path: "noext"},
+		},
+	}
+	recordUploadOutcome(cmd, "proj-x", "GLACIER", "us-east-1", 3, result, m)
+
+	store := cost.NewUploadHistoryStore("")
+	got, err := store.LoadOutcomes()
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+
+	o := got[0]
+	assert.Equal(t, "up-42", o.UploadID)
+	assert.Equal(t, "proj-x", o.ProjectID)
+	assert.Equal(t, 6, o.ShardCount, "shard count sourced from manifest")
+	assert.Equal(t, 9, o.CompressionLevel, "level sourced from manifest when set")
+	assert.Equal(t, "zstd", o.CompressionType)
+	assert.InDelta(t, 0.5, o.CompressionRatio, 1e-9)
+	assert.Equal(t, int64(1024*1024*1024), o.CompressedBytes, "ratio * total")
+	assert.Equal(t, "GLACIER", o.StorageClass)
+	assert.Equal(t, map[string]int{"txt": 2, "none": 1}, o.FileTypeMix)
+	assert.Greater(t, o.ThroughputMBps, 0.0)
+	assert.True(t, o.Success)
 }

--- a/docs/gen/cli/cargoship_cost_history.md
+++ b/docs/gen/cli/cargoship_cost_history.md
@@ -1,0 +1,47 @@
+## cargoship cost history
+
+Show the recorded per-upload outcome history
+
+### Synopsis
+
+Display the durable per-upload outcome history (metadata only).
+
+This history is opt-in and OFF by default. Enable it with the
+CARGOSHIP_UPLOAD_HISTORY environment variable (1, true, or a file path) or the
+cost_control.upload_history_location config key. Each successful upload then
+appends a metadata-only record — dataset shape, chosen parameters, and measured
+outcomes (compression ratio, throughput, cost). No file content, names, or
+paths are recorded.
+
+Examples:
+  # Show the recorded history
+  cargoship cost history
+
+  # As JSON, most recent first
+  cargoship cost history --json
+
+```
+cargoship cost history [flags]
+```
+
+### Options
+
+```
+  -h, --help        help for history
+      --limit int   Maximum number of records to show (0 = all) (default 20)
+```
+
+### Options inherited from parent commands
+
+```
+      --context string        Override execution context (local, agent, controller, repl)
+      --json                  Output as JSON
+      --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
+      --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
+      --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
+      --profile               Enable performance profiling. This will generate profile files in a temp directory
+  -r, --region string         AWS region (default "us-west-2")
+  -t, --trace                 Enable trace messages in output
+  -v, --verbose               Enable verbose output
+```
+

--- a/docs/reference/commands/cost.md
+++ b/docs/reference/commands/cost.md
@@ -43,6 +43,8 @@ exposed in two places.
 
 <!-- @include: ../../gen/cli/cargoship_cost_summary.md -->
 
+<!-- @include: ../../gen/cli/cargoship_cost_history.md -->
+
 <!-- @include: ../../gen/cli/cargoship_budget.md -->
 
 <!-- @include: ../../gen/cli/cargoship_budget_status.md -->

--- a/pkg/aws/config/config.go
+++ b/pkg/aws/config/config.go
@@ -112,6 +112,14 @@ type CostControlConfig struct {
 	// Nil means no global budget is set.
 	GlobalBudget *GlobalBudget `yaml:"global_budget,omitempty" json:"global_budget,omitempty"`
 
+	// UploadHistoryLocation opts into a durable, append-only per-upload outcome
+	// history (#261) — the training corpus for future optimization analysis.
+	// Empty (default) means OFF: no telemetry is written. "1"/"true" enables it
+	// at the local default (~/.cargoship/upload_history.json); any other value
+	// is an explicit file path. Overridden by the CARGOSHIP_UPLOAD_HISTORY env
+	// var. Metadata only — no file content, names, or paths are recorded.
+	UploadHistoryLocation string `yaml:"upload_history_location,omitempty" json:"upload_history_location,omitempty"`
+
 	// Enable automatic cost optimization
 	AutoOptimize bool `yaml:"auto_optimize" json:"auto_optimize"`
 

--- a/pkg/aws/cost/upload_history.go
+++ b/pkg/aws/cost/upload_history.go
@@ -1,0 +1,236 @@
+package cost
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// UploadHistoryEnv is the environment override for the per-upload outcome
+// history location (#261). It takes precedence over the config field. Values:
+//
+//	unset / empty  -> disabled (no history written), unless config enables it
+//	"1" or "true"  -> enabled at the default state path
+//	<file path>    -> enabled at that explicit path (used by tests)
+const UploadHistoryEnv = "CARGOSHIP_UPLOAD_HISTORY"
+
+// uploadHistoryStoreVersion is the on-disk schema version.
+const uploadHistoryStoreVersion = 1
+
+// defaultUploadHistoryMax bounds the append-only history (FIFO — oldest records
+// are dropped once the cap is exceeded) so it can't grow without limit.
+const defaultUploadHistoryMax = 10000
+
+// UploadOutcome is a compact, metadata-only record joining one completed
+// upload's inputs (dataset shape and chosen parameters) to its outcomes
+// (actual compression, timing, throughput, reliability, cost). It is the
+// training corpus the Option S analysis (#167) needs: no file content, names,
+// or paths — only aggregates and type counts. (#261)
+type UploadOutcome struct {
+	// Identity
+	UploadID  string    `json:"upload_id"`
+	ProjectID string    `json:"project_id,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+
+	// Inputs — upload characteristics and chosen parameters.
+	TotalBytes       int64          `json:"total_bytes"` // uncompressed source size
+	FileCount        int64          `json:"file_count"`
+	FileTypeMix      map[string]int `json:"file_type_mix,omitempty"` // extension (or detected type) -> count
+	ChunkCount       int            `json:"chunk_count"`
+	ShardCount       int            `json:"shard_count"`
+	CompressionType  string         `json:"compression_type,omitempty"`
+	CompressionLevel int            `json:"compression_level"`
+	StorageClass     string         `json:"storage_class,omitempty"`
+	Region           string         `json:"region,omitempty"`
+
+	// Outcomes — measured results.
+	CompressionRatio float64       `json:"compression_ratio"`
+	CompressedBytes  int64         `json:"compressed_bytes"`
+	Duration         time.Duration `json:"duration_ns"`
+	ThroughputMBps   float64       `json:"throughput_mbps"`
+	RetryCount       int           `json:"retry_count"`
+	ErrorCount       int           `json:"error_count"`
+	Success          bool          `json:"success"`
+
+	// Cost is this upload's recorded USD cost. It joins to the #246 CostRecord
+	// ledger by UploadID (CostRecord.JobID == UploadID); it is populated here
+	// when the caller has it to hand and otherwise left zero (derivable from
+	// the ledger). RetryCount is likewise reserved: the pipeline does not yet
+	// surface a retry counter, so it stays zero until one exists.
+	Cost float64 `json:"cost_usd"`
+}
+
+// uploadHistoryDoc is the persisted on-disk shape of the outcome history.
+type uploadHistoryDoc struct {
+	Version int              `json:"version"`
+	Records []*UploadOutcome `json:"records"`
+}
+
+// UploadHistoryStore is an opt-in, durable, append-only history of per-upload
+// outcomes, reusing the atomic-write + state-dir conventions of the budget
+// store (#246). A zero store (enabled=false) is a no-op, so the common
+// telemetry-off path performs no I/O.
+type UploadHistoryStore struct {
+	enabled bool
+	path    string
+	max     int
+	mu      sync.Mutex
+}
+
+// NewUploadHistoryStore resolves the opt-in state. Precedence, matching the
+// #246 budget-store convention: the CARGOSHIP_UPLOAD_HISTORY env override
+// first, then the provided config location (CostControl.UploadHistoryLocation).
+// This is telemetry — default OFF. A "1"/"true" spec enables the default state
+// path; any other non-empty spec is treated as an explicit file path.
+func NewUploadHistoryStore(configLocation string) *UploadHistoryStore {
+	spec := os.Getenv(UploadHistoryEnv)
+	if spec == "" {
+		spec = configLocation
+	}
+	switch spec {
+	case "":
+		return &UploadHistoryStore{}
+	case "1", "true":
+		path, err := defaultUploadHistoryPath()
+		if err != nil {
+			return &UploadHistoryStore{}
+		}
+		return &UploadHistoryStore{enabled: true, path: path, max: defaultUploadHistoryMax}
+	default:
+		return &UploadHistoryStore{enabled: true, path: spec, max: defaultUploadHistoryMax}
+	}
+}
+
+// Enabled reports whether the history is being persisted.
+func (s *UploadHistoryStore) Enabled() bool { return s != nil && s.enabled }
+
+// defaultUploadHistoryPath mirrors the budget store's state-dir convention:
+// $XDG_DATA_HOME/cargoship, else ~/.cargoship.
+func defaultUploadHistoryPath() (string, error) {
+	base := os.Getenv("XDG_DATA_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("get home dir: %w", err)
+		}
+		base = filepath.Join(home, ".cargoship")
+	} else {
+		base = filepath.Join(base, "cargoship")
+	}
+	return filepath.Join(base, "upload_history.json"), nil
+}
+
+// LoadOutcomes reads the persisted outcome history, oldest-first. A missing
+// file (or a disabled store) returns an empty slice, not an error.
+func (s *UploadHistoryStore) LoadOutcomes() ([]*UploadOutcome, error) {
+	if !s.Enabled() {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.loadLocked()
+}
+
+// loadLocked reads and parses the store. Caller must hold s.mu.
+func (s *UploadHistoryStore) loadLocked() ([]*UploadOutcome, error) {
+	data, err := os.ReadFile(s.path) //nolint:gosec // path is env/config-configured (opt-in) or derived from home/XDG, not attacker input
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read upload history %q: %w", s.path, err)
+	}
+	var doc uploadHistoryDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse upload history %q: %w", s.path, err)
+	}
+	return doc.Records, nil
+}
+
+// Append adds one outcome to the durable history (read-modify-write under an
+// exclusive lock), enforcing the FIFO cap, and writes it back atomically. It is
+// a no-op when the store is disabled. A load error on an existing-but-corrupt
+// store is surfaced; callers on the upload path treat any error as best-effort
+// and must never fail an upload because of it (mirrors persistLedger, #246).
+func (s *UploadHistoryStore) Append(outcome *UploadOutcome) error {
+	if !s.Enabled() || outcome == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	records, err := s.loadLocked()
+	if err != nil {
+		return err
+	}
+	records = append(records, outcome)
+	if s.max > 0 && len(records) > s.max {
+		records = records[len(records)-s.max:] // FIFO: keep the most recent s.max
+	}
+	return s.saveLocked(records)
+}
+
+// saveLocked writes the history atomically (temp file + rename, 0600). Caller
+// must hold s.mu.
+func (s *UploadHistoryStore) saveLocked(records []*UploadOutcome) error {
+	doc := uploadHistoryDoc{Version: uploadHistoryStoreVersion, Records: records}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal upload history: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0700); err != nil {
+		return fmt.Errorf("create upload history dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".upload-history-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp upload history file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp upload history file: %w", err)
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp upload history file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp upload history file: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return fmt.Errorf("rename upload history into place: %w", err)
+	}
+	return nil
+}
+
+// FileTypeMixFromExtensions builds a metadata-only extension -> count histogram
+// from a list of relative paths. Only the lowercased extension (or "none" when
+// absent) is retained — never the file name or path. Kept as a helper so the
+// caller can assemble the mix from a manifest's file list without this package
+// importing pkg/manifest.
+func FileTypeMixFromExtensions(exts []string) map[string]int {
+	if len(exts) == 0 {
+		return nil
+	}
+	mix := make(map[string]int)
+	for _, e := range exts {
+		if e == "" {
+			e = "none"
+		}
+		mix[e]++
+	}
+	return mix
+}
+
+// sortOutcomesByTime returns the records sorted oldest-first. Exposed for the
+// debug view; the store already persists in append (oldest-first) order.
+func sortOutcomesByTime(records []*UploadOutcome) {
+	sort.SliceStable(records, func(i, j int) bool {
+		return records[i].Timestamp.Before(records[j].Timestamp)
+	})
+}

--- a/pkg/aws/cost/upload_history_test.go
+++ b/pkg/aws/cost/upload_history_test.go
@@ -1,0 +1,256 @@
+package cost
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withUploadHistoryEnv points CARGOSHIP_UPLOAD_HISTORY at path for the test.
+func withUploadHistoryEnv(t *testing.T, path string) {
+	t.Helper()
+	prev, had := os.LookupEnv(UploadHistoryEnv)
+	require.NoError(t, os.Setenv(UploadHistoryEnv, path))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(UploadHistoryEnv, prev)
+		} else {
+			_ = os.Unsetenv(UploadHistoryEnv)
+		}
+	})
+}
+
+func sampleOutcome(id string, ts time.Time) *UploadOutcome {
+	return &UploadOutcome{
+		UploadID:         id,
+		ProjectID:        "proj",
+		Timestamp:        ts,
+		TotalBytes:       1024 * 1024 * 1024,
+		FileCount:        42,
+		FileTypeMix:      map[string]int{"txt": 40, "bin": 2},
+		ChunkCount:       8,
+		ShardCount:       4,
+		CompressionType:  "zstd",
+		CompressionLevel: 3,
+		StorageClass:     "STANDARD",
+		Region:           "us-west-2",
+		CompressionRatio: 0.42,
+		CompressedBytes:  450 * 1024 * 1024,
+		Duration:         90 * time.Second,
+		ThroughputMBps:   120.5,
+		Success:          true,
+		Cost:             1.23,
+	}
+}
+
+// TestUploadHistory_DisabledByDefault verifies no store and no I/O when the
+// opt-in is unset.
+func TestUploadHistory_DisabledByDefault(t *testing.T) {
+	prev, had := os.LookupEnv(UploadHistoryEnv)
+	require.NoError(t, os.Unsetenv(UploadHistoryEnv))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(UploadHistoryEnv, prev)
+		}
+	})
+
+	store := NewUploadHistoryStore("")
+	assert.False(t, store.Enabled())
+
+	// Append and Load are no-ops when disabled.
+	require.NoError(t, store.Append(sampleOutcome("u1", time.Now())))
+	got, err := store.LoadOutcomes()
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestUploadHistory_OptInWritesNothingWhenOff is the issue's explicit
+// "opt-in-off writes nothing" criterion: even a default-path store must not
+// create a file when disabled.
+func TestUploadHistory_OptInWritesNothingWhenOff(t *testing.T) {
+	dir := t.TempDir()
+	// Point XDG at a scratch dir so the "default path" can't touch a real home.
+	t.Setenv("XDG_DATA_HOME", dir)
+	prev, had := os.LookupEnv(UploadHistoryEnv)
+	require.NoError(t, os.Unsetenv(UploadHistoryEnv))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(UploadHistoryEnv, prev)
+		}
+	})
+
+	store := NewUploadHistoryStore("") // config also empty => disabled
+	require.NoError(t, store.Append(sampleOutcome("u1", time.Now())))
+
+	_, err := os.Stat(filepath.Join(dir, "cargoship", "upload_history.json"))
+	assert.True(t, os.IsNotExist(err), "no file should be written when opt-in is off")
+}
+
+// TestUploadHistory_RoundTrip verifies an appended outcome round-trips.
+func TestUploadHistory_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "upload_history.json")
+	withUploadHistoryEnv(t, path)
+
+	store := NewUploadHistoryStore("")
+	require.True(t, store.Enabled())
+
+	ts := time.Now().Truncate(time.Second)
+	require.NoError(t, store.Append(sampleOutcome("u1", ts)))
+	require.NoError(t, store.Append(sampleOutcome("u2", ts.Add(time.Minute))))
+
+	// A fresh store (new process) reads the same file.
+	reloaded := NewUploadHistoryStore("")
+	got, err := reloaded.LoadOutcomes()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "u1", got[0].UploadID, "records are oldest-first")
+	assert.Equal(t, "u2", got[1].UploadID)
+	assert.Equal(t, 0.42, got[1].CompressionRatio)
+	assert.Equal(t, map[string]int{"txt": 40, "bin": 2}, got[1].FileTypeMix)
+	assert.Equal(t, 90*time.Second, got[1].Duration)
+}
+
+// TestUploadHistory_ConfigLocation verifies the config field enables the store
+// when the env var is unset.
+func TestUploadHistory_ConfigLocation(t *testing.T) {
+	prev, had := os.LookupEnv(UploadHistoryEnv)
+	require.NoError(t, os.Unsetenv(UploadHistoryEnv))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(UploadHistoryEnv, prev)
+		}
+	})
+	path := filepath.Join(t.TempDir(), "history.json")
+
+	store := NewUploadHistoryStore(path)
+	require.True(t, store.Enabled())
+	require.NoError(t, store.Append(sampleOutcome("c1", time.Now())))
+
+	got, err := store.LoadOutcomes()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "c1", got[0].UploadID)
+}
+
+// TestUploadHistory_EnvOverridesConfig verifies the env var wins over config.
+func TestUploadHistory_EnvOverridesConfig(t *testing.T) {
+	envPath := filepath.Join(t.TempDir(), "env.json")
+	cfgPath := filepath.Join(t.TempDir(), "cfg.json")
+	withUploadHistoryEnv(t, envPath)
+
+	store := NewUploadHistoryStore(cfgPath)
+	require.True(t, store.Enabled())
+	assert.Equal(t, envPath, store.path)
+}
+
+// TestUploadHistory_Cap enforces the FIFO cap, keeping the most recent records.
+func TestUploadHistory_Cap(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "upload_history.json")
+	store := &UploadHistoryStore{enabled: true, path: path, max: 3}
+
+	ts := time.Now()
+	for i := 0; i < 6; i++ {
+		require.NoError(t, store.Append(sampleOutcome(
+			"u"+string(rune('0'+i)), ts.Add(time.Duration(i)*time.Minute))))
+	}
+
+	got, err := store.LoadOutcomes()
+	require.NoError(t, err)
+	require.Len(t, got, 3, "should keep only the most recent 3")
+	assert.Equal(t, "u3", got[0].UploadID)
+	assert.Equal(t, "u5", got[2].UploadID)
+}
+
+// TestUploadHistory_MissingFile confirms a missing store loads as empty.
+func TestUploadHistory_MissingFile(t *testing.T) {
+	store := &UploadHistoryStore{enabled: true, path: filepath.Join(t.TempDir(), "nope.json")}
+	got, err := store.LoadOutcomes()
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestUploadHistory_CorruptFileSurfacedOnLoad confirms a corrupt store yields
+// an error from LoadOutcomes (the upload-path caller treats it best-effort).
+func TestUploadHistory_CorruptFileSurfacedOnLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "upload_history.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0600))
+	store := &UploadHistoryStore{enabled: true, path: path}
+
+	_, err := store.LoadOutcomes()
+	assert.Error(t, err)
+}
+
+// TestUploadHistory_FilePermissions verifies the store is written 0600.
+func TestUploadHistory_FilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "upload_history.json")
+	store := &UploadHistoryStore{enabled: true, path: path, max: defaultUploadHistoryMax}
+	require.NoError(t, store.Append(sampleOutcome("u1", time.Now())))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	// On-disk shape carries the version.
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var doc uploadHistoryDoc
+	require.NoError(t, json.Unmarshal(data, &doc))
+	assert.Equal(t, uploadHistoryStoreVersion, doc.Version)
+	assert.Len(t, doc.Records, 1)
+}
+
+// TestNewUploadHistoryStore_SpecModes covers opt-in spec parsing.
+func TestNewUploadHistoryStore_SpecModes(t *testing.T) {
+	prev, had := os.LookupEnv(UploadHistoryEnv)
+	require.NoError(t, os.Unsetenv(UploadHistoryEnv))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(UploadHistoryEnv, prev)
+		}
+	})
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	tests := []struct {
+		name        string
+		config      string
+		wantEnabled bool
+	}{
+		{name: "empty", config: "", wantEnabled: false},
+		{name: "one", config: "1", wantEnabled: true},
+		{name: "true", config: "true", wantEnabled: true},
+		{name: "path", config: "/tmp/h.json", wantEnabled: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewUploadHistoryStore(tt.config)
+			assert.Equal(t, tt.wantEnabled, store.Enabled())
+			if tt.config == "/tmp/h.json" {
+				assert.Equal(t, tt.config, store.path)
+			}
+		})
+	}
+}
+
+// TestFileTypeMixFromExtensions covers the metadata-only histogram helper.
+func TestFileTypeMixFromExtensions(t *testing.T) {
+	assert.Nil(t, FileTypeMixFromExtensions(nil))
+	got := FileTypeMixFromExtensions([]string{"txt", "txt", "", "go"})
+	assert.Equal(t, map[string]int{"txt": 2, "none": 1, "go": 1}, got)
+}
+
+// TestSortOutcomesByTime covers the debug-view ordering helper.
+func TestSortOutcomesByTime(t *testing.T) {
+	ts := time.Now()
+	recs := []*UploadOutcome{
+		{UploadID: "b", Timestamp: ts.Add(time.Minute)},
+		{UploadID: "a", Timestamp: ts},
+	}
+	sortOutcomesByTime(recs)
+	assert.Equal(t, "a", recs[0].UploadID)
+	assert.Equal(t, "b", recs[1].UploadID)
+}


### PR DESCRIPTION
## Summary

The keystone of the Option S plan (#167). Upload outcomes live in three disconnected places — the durable #246 **cost ledger**, the per-upload **manifest** (a standalone restore artifact, never aggregated), and **ephemeral** Prometheus/in-memory learning scaffolds that reset every process. There was no unified record joining upload *characteristics* to *outcomes*, so nothing could "learn from historical data." This builds that substrate — **capture only, no ML**.

## Changes

- **`cost.UploadOutcome`** — a compact, metadata-only record joining inputs (dataset size, file count, file-type mix, chunk/shard counts, compression algo/level, storage class, region) to outcomes (actual compression ratio, compressed bytes, duration, throughput, error count, success, cost).
- **`UploadHistoryStore`** — opt-in, durable, append-only, FIFO-bounded (10k) local JSON, reusing the #246 atomic-write (temp + rename, 0600) and XDG/`~/.cargoship` conventions. `LoadOutcomes` reads it back.
- **Assembly on completion** — `recordUploadOutcome` builds the record from what already exists (the pipeline `Result` + finalized `manifest.Manifest`) and appends it, hooked next to the existing `RecordCompletedUpload` call in `upload.go`. **Best-effort**: a telemetry error is a warning, never an upload failure.
- **Opt-in, default OFF** (telemetry): `config.CostControl.UploadHistoryLocation` plus the `CARGOSHIP_UPLOAD_HISTORY` env override (env wins), mirroring the #246 budget-store precedence. **Metadata only** — no content, names, or paths (only lowercased extension counts).
- **`cargoship cost history`** — inspect the corpus (table + `--json`); when disabled it prints how to opt in rather than erroring.

## Scope notes

- Optional **S3 backing** (reusing the #246 `s3_store`) is deferred to a follow-up, per the agreed scope — the "Done when" criteria (durable opt-in append-only local store + loader + tests) are met here.
- `Cost` joins to the ledger by `UploadID` (`CostRecord.JobID`); populated when to hand, otherwise derivable. `RetryCount` is reserved until the pipeline surfaces a retry counter.

## Tests

Round-trip, FIFO cap, **opt-in-off-writes-nothing**, config/env precedence, missing/corrupt file, 0600 permissions, outcome assembly from a manifest, and the `cost history` command view (disabled hint, empty JSON, populated render). New store code covered 89–100%.

Part of #167 (Option S); unblocks #140. Closes #261.