### PR TITLE
feat: staging performance trend & anomaly analysis over the outcome corpus (#140)

### DIFF
--- a/pkg/aws/s3/adaptive_staging.go
+++ b/pkg/aws/s3/adaptive_staging.go
@@ -92,14 +92,17 @@ type ProgressTracker struct {
 
 // PerformanceAnalyzer analyzes upload performance patterns.
 type PerformanceAnalyzer struct {
-	// Analysis algorithms
-	// trendAnalyzer       *TrendAnalyzer // TODO: Add trend analysis
-	// patternDetector     *PatternDetector // TODO: Add pattern detection
-	// anomalyDetector     *AnomalyDetector // TODO: Add anomaly detection
-	// predictionModel     *PerformancePredictionModel // TODO: Add prediction model
+	// Analysis algorithms (#140). The trend/anomaly layer is fed by the
+	// persisted upload-outcome corpus (#261) via IngestOutcomes. The ML
+	// predictionModel and the streaming patternDetector remain deferred to
+	// Option L / #137.
+	trendAnalyzer   *TrendAnalyzer
+	anomalyDetector *AnomalyDetector
+	// patternDetector *PatternDetector             // deferred (Option L / #137)
+	// predictionModel *PerformancePredictionModel  // deferred (Option L / #137)
 
 	// Performance characteristics
-	// baselineMetrics     *BaselineMetrics // TODO: Add baseline metrics
+	baselineMetrics    *BaselineMetrics
 	currentPerformance *PerformanceMetrics
 	performanceTrends  map[string]*TrendData
 
@@ -899,6 +902,9 @@ func NewProgressTracker() *ProgressTracker {
 
 func NewPerformanceAnalyzer() *PerformanceAnalyzer {
 	return &PerformanceAnalyzer{
+		trendAnalyzer:      NewTrendAnalyzer(),
+		anomalyDetector:    NewAnomalyDetector(),
+		baselineMetrics:    NewBaselineMetrics(),
 		performanceTrends:  make(map[string]*TrendData),
 		adaptationTriggers: make([]AdaptationTrigger, 0),
 		triggerThresholds:  make(map[string]float64),
@@ -1137,11 +1143,12 @@ func (ra *ResourceAllocator) SetMaxConcurrentChunks(count int) {
 }
 
 // Placeholder types for completeness
-type TrendAnalyzer struct{}
 type PatternDetector struct{}
-type AnomalyDetector struct{}
 type PerformancePredictionModel struct{}
-type BaselineMetrics struct{}
-type TrendData struct{}
 type AdaptationTrigger struct{}
 type StagingPriorityQueue struct{}
+
+// TrendAnalyzer, AnomalyDetector, BaselineMetrics, and TrendData are implemented
+// in staging_trends.go (#140): they turn the persisted per-upload outcome corpus
+// (#261) into per-metric trends and anomaly flags. The ML predictionModel field
+// remains deferred to Option L / #137.

--- a/pkg/aws/s3/staging_trends.go
+++ b/pkg/aws/s3/staging_trends.go
@@ -1,0 +1,339 @@
+package s3
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/cost"
+)
+
+// This file implements the trend + anomaly layer of the staging
+// PerformanceAnalyzer (#140). It turns the persisted per-upload outcome corpus
+// (#261) into per-metric trends and anomaly flags that adaptation logic can
+// consult. It is pure analysis over recorded history — it observes, it does not
+// change any optimization decision, and the ML prediction model remains
+// deferred to Option L / #137.
+
+// TrendQuality classifies whether a metric's recent movement is good or bad for
+// upload performance (distinct from coordinator.go's raw TrendDirection, which
+// only records increasing/decreasing without a notion of "better").
+type TrendQuality string
+
+const (
+	TrendImproving TrendQuality = "improving"
+	TrendDegrading TrendQuality = "degrading"
+	TrendFlat      TrendQuality = "stable"
+)
+
+// TrendData is the computed trend for a single named metric over the analyzed
+// window. Slope is in metric-units per sample (oldest→newest).
+type TrendData struct {
+	Metric      string       `json:"metric"`
+	Direction   TrendQuality `json:"direction"`
+	Slope       float64      `json:"slope"`
+	RecentMean  float64      `json:"recent_mean"`
+	SampleCount int          `json:"sample_count"`
+	UpdatedAt   time.Time    `json:"updated_at"`
+}
+
+// baselineStat is the rolling mean/stddev of one metric, the reference an
+// anomaly is measured against.
+type baselineStat struct {
+	Mean   float64
+	StdDev float64
+	Count  int
+}
+
+// BaselineMetrics holds per-metric baselines derived from the corpus.
+type BaselineMetrics struct {
+	stats map[string]baselineStat
+}
+
+// NewBaselineMetrics returns an empty baseline set.
+func NewBaselineMetrics() *BaselineMetrics {
+	return &BaselineMetrics{stats: make(map[string]baselineStat)}
+}
+
+// TrendAnalyzer computes least-squares slope over an ordered metric series.
+type TrendAnalyzer struct {
+	// stableThreshold is the fraction of the series mean below which an
+	// absolute slope is treated as "stable" (no meaningful trend).
+	stableThreshold float64
+}
+
+// NewTrendAnalyzer returns a trend analyzer with sensible defaults.
+func NewTrendAnalyzer() *TrendAnalyzer {
+	return &TrendAnalyzer{stableThreshold: 0.01}
+}
+
+// higherIsBetter reports whether a rising value of the metric is an improvement.
+// Throughput rising is good; latency or duration rising is bad. Compression
+// ratio here is compressed/original, so a falling ratio (smaller output) is the
+// improvement.
+func higherIsBetter(metric string) bool {
+	switch metric {
+	case "throughput_mbps":
+		return true
+	default:
+		// latency_ms, duration_s, compression_ratio, error_rate: lower is better.
+		return false
+	}
+}
+
+// Analyze computes a TrendData for the given metric over an oldest-first series.
+// Fewer than two points yields a stable trend (nothing to slope over).
+func (ta *TrendAnalyzer) Analyze(metric string, series []float64, now time.Time) *TrendData {
+	n := len(series)
+	td := &TrendData{Metric: metric, Direction: TrendFlat, SampleCount: n, UpdatedAt: now}
+	if n == 0 {
+		return td
+	}
+
+	// Recent mean over the trailing quarter (min 1) of the series.
+	recentN := n / 4
+	if recentN < 1 {
+		recentN = 1
+	}
+	var recentSum float64
+	for _, v := range series[n-recentN:] {
+		recentSum += v
+	}
+	td.RecentMean = recentSum / float64(recentN)
+
+	if n < 2 {
+		return td
+	}
+
+	// Least-squares slope of value vs index.
+	fn := float64(n)
+	var sumX, sumY, sumXY, sumX2 float64
+	for i, y := range series {
+		x := float64(i)
+		sumX += x
+		sumY += y
+		sumXY += x * y
+		sumX2 += x * x
+	}
+	denom := fn*sumX2 - sumX*sumX
+	if denom == 0 {
+		return td
+	}
+	td.Slope = (fn*sumXY - sumX*sumY) / denom
+
+	mean := sumY / fn
+	// Treat near-flat slopes (relative to the mean magnitude) as stable.
+	if mean == 0 || math.Abs(td.Slope) < ta.stableThreshold*math.Abs(mean) {
+		td.Direction = TrendFlat
+		return td
+	}
+	rising := td.Slope > 0
+	if rising == higherIsBetter(metric) {
+		td.Direction = TrendImproving
+	} else {
+		td.Direction = TrendDegrading
+	}
+	return td
+}
+
+// Anomaly flags a single observation that deviates from a metric's baseline.
+type Anomaly struct {
+	Metric   string    `json:"metric"`
+	Value    float64   `json:"value"`
+	Baseline float64   `json:"baseline"`
+	ZScore   float64   `json:"z_score"`
+	At       time.Time `json:"at"`
+}
+
+// AnomalyDetector flags observations beyond a z-score threshold from baseline.
+type AnomalyDetector struct {
+	// zThreshold is the |z-score| beyond which a value is anomalous.
+	zThreshold float64
+}
+
+// NewAnomalyDetector returns a detector with a 3-sigma default threshold.
+func NewAnomalyDetector() *AnomalyDetector {
+	return &AnomalyDetector{zThreshold: 3.0}
+}
+
+// Check reports whether value is anomalous relative to the baseline. A baseline
+// with fewer than 2 samples or zero variance can't be judged (returns false).
+func (ad *AnomalyDetector) Check(metric string, value float64, base baselineStat, now time.Time) (*Anomaly, bool) {
+	if base.Count < 2 || base.StdDev == 0 {
+		return nil, false
+	}
+	z := (value - base.Mean) / base.StdDev
+	if math.Abs(z) < ad.zThreshold {
+		return nil, false
+	}
+	return &Anomaly{Metric: metric, Value: value, Baseline: base.Mean, ZScore: z, At: now}, true
+}
+
+// metricSeries extracts the four analyzed metrics from an oldest-first slice of
+// successful outcomes. Failed uploads are skipped for throughput/compression
+// (their measurements are not representative) but counted for error rate.
+func metricSeries(outcomes []*cost.UploadOutcome) map[string][]float64 {
+	series := map[string][]float64{
+		"throughput_mbps":   {},
+		"compression_ratio": {},
+		"duration_s":        {},
+	}
+	for _, o := range outcomes {
+		if o == nil {
+			continue
+		}
+		if o.Success {
+			if o.ThroughputMBps > 0 {
+				series["throughput_mbps"] = append(series["throughput_mbps"], o.ThroughputMBps)
+			}
+			if o.CompressionRatio > 0 {
+				series["compression_ratio"] = append(series["compression_ratio"], o.CompressionRatio)
+			}
+			if o.Duration > 0 {
+				series["duration_s"] = append(series["duration_s"], o.Duration.Seconds())
+			}
+		}
+	}
+	return series
+}
+
+// computeBaseline returns the mean/stddev of a series.
+func computeBaseline(series []float64) baselineStat {
+	n := len(series)
+	if n == 0 {
+		return baselineStat{}
+	}
+	var sum float64
+	for _, v := range series {
+		sum += v
+	}
+	mean := sum / float64(n)
+	var ss float64
+	for _, v := range series {
+		d := v - mean
+		ss += d * d
+	}
+	return baselineStat{Mean: mean, StdDev: math.Sqrt(ss / float64(n)), Count: n}
+}
+
+// IngestOutcomes rebuilds the analyzer's trends and baselines from a corpus of
+// per-upload outcomes (#261). Outcomes are sorted oldest-first so the trend
+// slope points forward in time. It replaces (not merges) prior trend state, so
+// repeated calls with a growing corpus are idempotent. Returns the anomalies
+// found in the most recent successful upload relative to the historical
+// baseline (empty if there's too little history).
+func (pa *PerformanceAnalyzer) IngestOutcomes(outcomes []*cost.UploadOutcome) []*Anomaly {
+	now := time.Now()
+
+	// Defensive copy + stable sort oldest-first.
+	sorted := make([]*cost.UploadOutcome, 0, len(outcomes))
+	for _, o := range outcomes {
+		if o != nil {
+			sorted = append(sorted, o)
+		}
+	}
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Timestamp.Before(sorted[j].Timestamp)
+	})
+
+	series := metricSeries(sorted)
+
+	pa.mu.Lock()
+	defer pa.mu.Unlock()
+
+	pa.performanceTrends = make(map[string]*TrendData, len(series))
+	if pa.baselineMetrics == nil {
+		pa.baselineMetrics = NewBaselineMetrics()
+	}
+	pa.baselineMetrics.stats = make(map[string]baselineStat, len(series))
+
+	for metric, values := range series {
+		pa.performanceTrends[metric] = pa.trendAnalyzer.Analyze(metric, values, now)
+		pa.baselineMetrics.stats[metric] = computeBaseline(values)
+	}
+
+	// Reflect the latest throughput into currentPerformance so existing
+	// consumers (AnalyzeCurrentPerformance) see corpus-derived numbers.
+	if tp := series["throughput_mbps"]; len(tp) > 0 {
+		latest := tp[len(tp)-1]
+		if pa.currentPerformance == nil {
+			pa.currentPerformance = &PerformanceMetrics{TargetThroughput: 100.0, Reliability: 0.95}
+		}
+		pa.currentPerformance.ThroughputMBps = latest
+	}
+
+	// Anomaly check on the most recent successful upload. The reference
+	// baseline is built from PRIOR history only (excluding the last upload) —
+	// including a genuine outlier in its own baseline inflates the stddev and
+	// masks it. This needs at least a few points of prior history to be
+	// meaningful (AnomalyDetector.Check requires count >= 2).
+	var anomalies []*Anomaly
+	if len(sorted) > 0 {
+		last := sorted[len(sorted)-1]
+		if last.Success {
+			priorSeries := metricSeries(sorted[:len(sorted)-1])
+			latest := map[string]float64{
+				"throughput_mbps":   last.ThroughputMBps,
+				"compression_ratio": last.CompressionRatio,
+			}
+			if last.Duration > 0 {
+				latest["duration_s"] = last.Duration.Seconds()
+			}
+			for metric, v := range latest {
+				if v == 0 {
+					continue
+				}
+				priorBase := computeBaseline(priorSeries[metric])
+				if a, found := pa.anomalyDetector.Check(metric, v, priorBase, now); found {
+					anomalies = append(anomalies, a)
+				}
+			}
+		}
+	}
+	return anomalies
+}
+
+// PrimeFromHistory loads the persisted upload-outcome corpus (#261) and rebuilds
+// the performance analyzer's trends and baselines from it, returning any
+// anomalies detected in the most recent upload. It is a no-op returning nil when
+// the history store is disabled (the opt-in default), so callers can invoke it
+// unconditionally at startup. Reads only — it never changes staging behavior.
+func (as *AdaptiveStaging) PrimeFromHistory() ([]*Anomaly, error) {
+	store := cost.NewUploadHistoryStore("")
+	if !store.Enabled() {
+		return nil, nil
+	}
+	outcomes, err := store.LoadOutcomes()
+	if err != nil {
+		return nil, err
+	}
+	if len(outcomes) == 0 {
+		return nil, nil
+	}
+	return as.performanceAnalyzer.IngestOutcomes(outcomes), nil
+}
+
+// GetPerformanceTrends returns a copy of the analyzer's current per-metric
+// trends, for status reporting.
+func (as *AdaptiveStaging) GetPerformanceTrends() map[string]*TrendData {
+	return as.performanceAnalyzer.GetTrends()
+}
+
+// GetTrend returns the computed trend for a metric, if analyzed.
+func (pa *PerformanceAnalyzer) GetTrend(metric string) (*TrendData, bool) {
+	pa.mu.RLock()
+	defer pa.mu.RUnlock()
+	td, ok := pa.performanceTrends[metric]
+	return td, ok
+}
+
+// GetTrends returns a copy of all computed trends.
+func (pa *PerformanceAnalyzer) GetTrends() map[string]*TrendData {
+	pa.mu.RLock()
+	defer pa.mu.RUnlock()
+	out := make(map[string]*TrendData, len(pa.performanceTrends))
+	for k, v := range pa.performanceTrends {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/aws/s3/staging_trends_test.go
+++ b/pkg/aws/s3/staging_trends_test.go
@@ -1,0 +1,267 @@
+package s3
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/cost"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func outcome(ts time.Time, thr, ratio float64, durSec int, success bool) *cost.UploadOutcome {
+	return &cost.UploadOutcome{
+		UploadID:         "u",
+		Timestamp:        ts,
+		ThroughputMBps:   thr,
+		CompressionRatio: ratio,
+		Duration:         time.Duration(durSec) * time.Second,
+		Success:          success,
+	}
+}
+
+// TestTrendAnalyzer_RisingThroughputImproves verifies a rising throughput series
+// is classified as improving (higher is better).
+func TestTrendAnalyzer_RisingThroughputImproves(t *testing.T) {
+	ta := NewTrendAnalyzer()
+	td := ta.Analyze("throughput_mbps", []float64{50, 60, 70, 80, 90}, time.Now())
+
+	assert.Equal(t, TrendImproving, td.Direction)
+	assert.Greater(t, td.Slope, 0.0)
+	assert.Equal(t, 5, td.SampleCount)
+	assert.InDelta(t, 90, td.RecentMean, 0.001, "recent mean = trailing quarter (last point)")
+}
+
+// TestTrendAnalyzer_RisingRatioDegrades verifies that for compression ratio
+// (lower is better), a rising series is degrading.
+func TestTrendAnalyzer_RisingRatioDegrades(t *testing.T) {
+	ta := NewTrendAnalyzer()
+	td := ta.Analyze("compression_ratio", []float64{0.3, 0.4, 0.5, 0.6}, time.Now())
+
+	assert.Equal(t, TrendDegrading, td.Direction)
+	assert.Greater(t, td.Slope, 0.0)
+}
+
+// TestTrendAnalyzer_FallingDurationImproves verifies falling duration (lower is
+// better) is improving.
+func TestTrendAnalyzer_FallingDurationImproves(t *testing.T) {
+	ta := NewTrendAnalyzer()
+	td := ta.Analyze("duration_s", []float64{100, 80, 60, 40}, time.Now())
+
+	assert.Equal(t, TrendImproving, td.Direction)
+	assert.Less(t, td.Slope, 0.0)
+}
+
+// TestTrendAnalyzer_FlatIsStable verifies a flat series is stable.
+func TestTrendAnalyzer_FlatIsStable(t *testing.T) {
+	ta := NewTrendAnalyzer()
+	td := ta.Analyze("throughput_mbps", []float64{50, 50, 50, 50}, time.Now())
+
+	assert.Equal(t, TrendFlat, td.Direction)
+	assert.InDelta(t, 0.0, td.Slope, 1e-9)
+}
+
+// TestTrendAnalyzer_EdgeCases covers empty and single-point series.
+func TestTrendAnalyzer_EdgeCases(t *testing.T) {
+	ta := NewTrendAnalyzer()
+
+	empty := ta.Analyze("throughput_mbps", nil, time.Now())
+	assert.Equal(t, TrendFlat, empty.Direction)
+	assert.Equal(t, 0, empty.SampleCount)
+
+	single := ta.Analyze("throughput_mbps", []float64{42}, time.Now())
+	assert.Equal(t, TrendFlat, single.Direction)
+	assert.Equal(t, 1, single.SampleCount)
+	assert.InDelta(t, 42, single.RecentMean, 1e-9)
+}
+
+// TestAnomalyDetector_FlagsOutlier verifies a 3-sigma outlier is flagged.
+func TestAnomalyDetector_FlagsOutlier(t *testing.T) {
+	ad := NewAnomalyDetector()
+	base := computeBaseline([]float64{100, 101, 99, 100, 100, 101, 99})
+
+	// Way outside baseline.
+	a, found := ad.Check("throughput_mbps", 10, base, time.Now())
+	require.True(t, found)
+	assert.Equal(t, "throughput_mbps", a.Metric)
+	assert.Less(t, a.ZScore, -3.0)
+
+	// Within baseline.
+	_, found = ad.Check("throughput_mbps", 100.5, base, time.Now())
+	assert.False(t, found)
+}
+
+// TestAnomalyDetector_InsufficientBaseline verifies too-small or zero-variance
+// baselines are not judged.
+func TestAnomalyDetector_InsufficientBaseline(t *testing.T) {
+	ad := NewAnomalyDetector()
+
+	_, found := ad.Check("m", 100, baselineStat{Mean: 50, StdDev: 10, Count: 1}, time.Now())
+	assert.False(t, found, "count < 2 can't be judged")
+
+	_, found = ad.Check("m", 100, baselineStat{Mean: 50, StdDev: 0, Count: 5}, time.Now())
+	assert.False(t, found, "zero variance can't be judged")
+}
+
+// TestComputeBaseline verifies mean/stddev.
+func TestComputeBaseline(t *testing.T) {
+	b := computeBaseline([]float64{2, 4, 4, 4, 5, 5, 7, 9})
+	assert.InDelta(t, 5.0, b.Mean, 1e-9)
+	assert.InDelta(t, 2.0, b.StdDev, 1e-9) // population stddev
+	assert.Equal(t, 8, b.Count)
+
+	assert.Equal(t, 0, computeBaseline(nil).Count)
+}
+
+// TestIngestOutcomes_BuildsTrends verifies the analyzer builds forward-in-time
+// trends from an unordered corpus and reflects the latest throughput.
+func TestIngestOutcomes_BuildsTrends(t *testing.T) {
+	pa := NewPerformanceAnalyzer()
+	base := time.Now().Add(-10 * time.Hour)
+
+	// Deliberately out of order; throughput rising over time.
+	outcomes := []*cost.UploadOutcome{
+		outcome(base.Add(3*time.Hour), 80, 0.5, 40, true),
+		outcome(base.Add(1*time.Hour), 60, 0.5, 60, true),
+		outcome(base.Add(4*time.Hour), 90, 0.5, 30, true),
+		outcome(base.Add(2*time.Hour), 70, 0.5, 50, true),
+	}
+	anomalies := pa.IngestOutcomes(outcomes)
+
+	tp, ok := pa.GetTrend("throughput_mbps")
+	require.True(t, ok)
+	assert.Equal(t, TrendImproving, tp.Direction, "sorted oldest-first, throughput rises")
+	assert.Equal(t, 4, tp.SampleCount)
+
+	dur, ok := pa.GetTrend("duration_s")
+	require.True(t, ok)
+	assert.Equal(t, TrendImproving, dur.Direction, "duration falling over time is good")
+
+	// Latest throughput (90) reflected into currentPerformance.
+	assert.InDelta(t, 90, pa.AnalyzeCurrentPerformance().ThroughputMBps, 1e-9)
+
+	// A steady series produces no anomalies.
+	assert.Empty(t, anomalies)
+}
+
+// TestIngestOutcomes_DetectsAnomaly verifies a wildly different final upload is
+// flagged as anomalous.
+func TestIngestOutcomes_DetectsAnomaly(t *testing.T) {
+	pa := NewPerformanceAnalyzer()
+	base := time.Now().Add(-10 * time.Hour)
+
+	// Prior history clusters near 100 MB/s with small, realistic variance.
+	priorThroughputs := []float64{98, 101, 99, 102, 100, 97, 103, 100}
+	var outcomes []*cost.UploadOutcome
+	for i, thr := range priorThroughputs {
+		outcomes = append(outcomes, outcome(base.Add(time.Duration(i)*time.Hour), thr, 0.5, 50, true))
+	}
+	// Final upload: throughput collapses far outside the baseline.
+	outcomes = append(outcomes, outcome(base.Add(9*time.Hour), 5, 0.5, 50, true))
+
+	anomalies := pa.IngestOutcomes(outcomes)
+	require.NotEmpty(t, anomalies)
+	found := false
+	for _, a := range anomalies {
+		if a.Metric == "throughput_mbps" {
+			found = true
+			assert.Less(t, a.ZScore, 0.0)
+		}
+	}
+	assert.True(t, found, "collapsed throughput should be flagged")
+}
+
+// TestIngestOutcomes_SkipsFailedAndZero verifies failed uploads and zero-valued
+// metrics are excluded from the series.
+func TestIngestOutcomes_SkipsFailedAndZero(t *testing.T) {
+	pa := NewPerformanceAnalyzer()
+	base := time.Now().Add(-5 * time.Hour)
+
+	outcomes := []*cost.UploadOutcome{
+		outcome(base.Add(1*time.Hour), 60, 0.5, 60, true),
+		outcome(base.Add(2*time.Hour), 999, 0.5, 60, false), // failed: excluded
+		outcome(base.Add(3*time.Hour), 0, 0.5, 60, true),    // zero throughput: excluded
+		outcome(base.Add(4*time.Hour), 80, 0.5, 60, true),
+	}
+	pa.IngestOutcomes(outcomes)
+
+	tp, ok := pa.GetTrend("throughput_mbps")
+	require.True(t, ok)
+	assert.Equal(t, 2, tp.SampleCount, "only the two valid successful throughputs")
+}
+
+// TestIngestOutcomes_Idempotent verifies re-ingesting replaces (not accumulates)
+// trend state.
+func TestIngestOutcomes_Idempotent(t *testing.T) {
+	pa := NewPerformanceAnalyzer()
+	base := time.Now().Add(-5 * time.Hour)
+	outcomes := []*cost.UploadOutcome{
+		outcome(base.Add(1*time.Hour), 60, 0.5, 60, true),
+		outcome(base.Add(2*time.Hour), 80, 0.5, 60, true),
+	}
+	pa.IngestOutcomes(outcomes)
+	pa.IngestOutcomes(outcomes)
+
+	tp, ok := pa.GetTrend("throughput_mbps")
+	require.True(t, ok)
+	assert.Equal(t, 2, tp.SampleCount, "state replaced, not doubled")
+}
+
+// TestPrimeFromHistory_DisabledIsNoop verifies priming does nothing when the
+// history store is disabled (default).
+func TestPrimeFromHistory_DisabledIsNoop(t *testing.T) {
+	t.Setenv("CARGOSHIP_UPLOAD_HISTORY", "")
+	as := NewAdaptiveStaging(context.Background())
+
+	anomalies, err := as.PrimeFromHistory()
+	require.NoError(t, err)
+	assert.Nil(t, anomalies)
+	assert.Empty(t, as.GetPerformanceTrends())
+}
+
+// TestPrimeFromHistory_LoadsCorpus verifies priming ingests a persisted corpus
+// end-to-end through the #261 store.
+func TestPrimeFromHistory_LoadsCorpus(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "upload_history.json")
+	t.Setenv("CARGOSHIP_UPLOAD_HISTORY", path)
+
+	store := cost.NewUploadHistoryStore("")
+	require.True(t, store.Enabled())
+	base := time.Now().Add(-4 * time.Hour)
+	for i := 0; i < 4; i++ {
+		require.NoError(t, store.Append(outcome(
+			base.Add(time.Duration(i)*time.Hour), float64(50+i*10), 0.5, 60, true)))
+	}
+
+	as := NewAdaptiveStaging(context.Background())
+	_, err := as.PrimeFromHistory()
+	require.NoError(t, err)
+
+	trends := as.GetPerformanceTrends()
+	require.Contains(t, trends, "throughput_mbps")
+	assert.Equal(t, TrendImproving, trends["throughput_mbps"].Direction)
+	assert.Equal(t, 4, trends["throughput_mbps"].SampleCount)
+}
+
+// TestPrimeFromHistory_LoadErrorSurfaced verifies a corrupt store surfaces an
+// error rather than panicking.
+func TestPrimeFromHistory_LoadErrorSurfaced(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "upload_history.json")
+	require.NoError(t, os.WriteFile(path, []byte("{corrupt"), 0600))
+	t.Setenv("CARGOSHIP_UPLOAD_HISTORY", path)
+
+	as := NewAdaptiveStaging(context.Background())
+	_, err := as.PrimeFromHistory()
+	assert.Error(t, err)
+}
+
+// TestHigherIsBetter documents the metric polarity map.
+func TestHigherIsBetter(t *testing.T) {
+	assert.True(t, higherIsBetter("throughput_mbps"))
+	assert.False(t, higherIsBetter("compression_ratio"))
+	assert.False(t, higherIsBetter("duration_s"))
+	assert.False(t, higherIsBetter("unknown_metric"))
+}


### PR DESCRIPTION
## Summary

`pkg/aws/s3/adaptive_staging.go`'s `PerformanceAnalyzer` had commented-out `trendAnalyzer` / `anomalyDetector` / `baselineMetrics` fields with no implementation. Per the Option S scoping comment on #140, this implements that **trend + anomaly layer** as the natural consumer of the persisted per-upload outcome corpus (#261). The ML `predictionModel` and streaming `patternDetector` stay **deferred to Option L / #137**.

Read-only analysis — it observes recorded history and changes no optimization decision.

## Changes (`staging_trends.go`)

- **`TrendAnalyzer`** — least-squares slope over an ordered metric series, classified `improving`/`degrading`/`stable` with per-metric polarity (throughput higher-is-better; compression ratio & duration lower-is-better).
- **`AnomalyDetector`** — z-score flag (3σ default) against a baseline; refuses to judge with <2 samples or zero variance.
- **`BaselineMetrics`** — per-metric mean/stddev.
- **`PerformanceAnalyzer.IngestOutcomes`** — rebuilds trends + baselines from a corpus (sorted oldest-first, idempotent replace), skips failed/zero samples, reflects latest throughput into `currentPerformance`, and returns anomalies in the most recent upload judged against **prior** history (so a genuine outlier isn't masked by its own inflated baseline).
- **`AdaptiveStaging.PrimeFromHistory`** — loads the opt-in #261 store and ingests it; a no-op when telemetry is disabled (the default).

Renamed the new quality enum to `TrendQuality` to avoid colliding with `coordinator.go`'s existing int `TrendDirection`.

## Tests

Trend polarity per metric, flat/edge cases, anomaly flagging + insufficient/zero-variance baselines, corpus ingest (ordering, skip, idempotency, anomaly-vs-prior-history), and end-to-end priming through the #261 store (disabled no-op, populated, corrupt-surfaces-error). New code covered 89–100%; `golangci-lint` clean.

Part of #167 (Option S). Closes #140.