### PR TITLE
feat: verify --deep + chunk-level checksum capture (#271 part 1)

### DIFF
--- a/cmd/cargoship/cmd/verify.go
+++ b/cmd/cargoship/cmd/verify.go
@@ -24,6 +24,7 @@ func NewVerifyCmd() *cobra.Command {
 		region   string
 		quick    bool
 		verbose  bool
+		deep     bool
 	)
 
 	cmd := &cobra.Command{
@@ -189,7 +190,18 @@ Exit Codes:
 					fmt.Println()
 				}
 
+				// Deep verification (#271): re-download stored objects and
+				// recompute checksums to confirm the DATA matches the manifest,
+				// not just that the manifest is internally consistent.
+				if deep {
+					if err := runDeepVerify(ctx, s3Client, m, verbose); err != nil {
+						os.Exit(1)
+					}
+					return nil
+				}
+
 				fmt.Printf("✅ All %s files verified successfully\n", humanize.Comma(m.TotalFiles))
+				fmt.Printf("   💡 Run with --deep to re-download and checksum the stored data\n")
 				return nil
 			}
 
@@ -243,6 +255,57 @@ Exit Codes:
 	cmd.Flags().StringVarP(&region, "region", "r", "us-west-2", "AWS region")
 	cmd.Flags().BoolVar(&quick, "quick", false, "Quick validation (metadata only, fast)")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed error and warning information")
+	cmd.Flags().BoolVar(&deep, "deep", false, "Deep verification: re-download stored objects and recompute checksums against the manifest (data-level integrity)")
 
 	return cmd
+}
+
+// runDeepVerify re-downloads each chunk object, recomputes its checksum, and
+// compares it to the manifest. It prints a per-chunk report and returns an
+// error if any chunk is corrupted, missing, or unverifiable (#271).
+func runDeepVerify(ctx context.Context, s3Client manifest.S3Downloader, m *manifest.Manifest, verbose bool) error {
+	fmt.Printf("🔬 Deep verification: re-downloading and checksumming stored data...\n")
+	if m.ChecksumAlgorithm == "" {
+		fmt.Printf("⚠️  This manifest predates checksum capture (no algorithm recorded).\n")
+		fmt.Printf("    Deep verify cannot confirm data integrity for it.\n\n")
+	} else {
+		fmt.Printf("   Algorithm: %s | Chunks: %d\n\n", m.ChecksumAlgorithm, len(m.Chunks))
+	}
+
+	verifier := manifest.NewDeepVerifier(m, s3Client)
+	result, err := verifier.VerifyChunks(ctx)
+	if err != nil {
+		fmt.Printf("❌ Deep verification aborted: %v\n", err)
+		return err
+	}
+
+	if verbose || !result.Passed() {
+		for _, c := range result.Chunks {
+			switch c.Status {
+			case manifest.ChunkVerifyOK:
+				if verbose {
+					fmt.Printf("   ✓ chunk %d (%s)\n", c.ChunkID, c.S3Key)
+				}
+			case manifest.ChunkVerifyMismatch:
+				fmt.Printf("   ✗ chunk %d CORRUPTED: expected %s, got %s\n", c.ChunkID, c.Expected, c.Actual)
+			case manifest.ChunkVerifyMissing:
+				fmt.Printf("   ✗ chunk %d MISSING: %s (%s)\n", c.ChunkID, c.S3Key, c.Err)
+			case manifest.ChunkVerifyUnverifiable:
+				fmt.Printf("   ⚠ chunk %d UNVERIFIABLE: no checksum recorded\n", c.ChunkID)
+			}
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("📊 Deep Verify: %d OK, %d corrupted, %d missing, %d unverifiable (of %d chunks)\n",
+		result.OK, result.Mismatched, result.Missing, result.Unverifiable, result.TotalChunks)
+
+	if result.Passed() {
+		fmt.Printf("✅ Deep verification PASS — all %d chunk objects match the manifest\n", result.TotalChunks)
+		return nil
+	}
+
+	fmt.Printf("❌ Deep verification FAIL\n")
+	return fmt.Errorf("deep verification failed: %d corrupted, %d missing, %d unverifiable",
+		result.Mismatched, result.Missing, result.Unverifiable)
 }

--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -1,0 +1,193 @@
+package manifest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// ChunkVerifyStatus is the outcome of deep-verifying a single chunk object.
+type ChunkVerifyStatus string
+
+const (
+	// ChunkVerifyOK means the recomputed hash matched the manifest.
+	ChunkVerifyOK ChunkVerifyStatus = "ok"
+	// ChunkVerifyMismatch means the stored bytes hashed to a different value —
+	// the object was corrupted or replaced.
+	ChunkVerifyMismatch ChunkVerifyStatus = "mismatch"
+	// ChunkVerifyMissing means the object could not be fetched from S3.
+	ChunkVerifyMissing ChunkVerifyStatus = "missing"
+	// ChunkVerifyUnverifiable means the manifest recorded no checksum for this
+	// chunk, so its integrity cannot be confirmed.
+	ChunkVerifyUnverifiable ChunkVerifyStatus = "unverifiable"
+)
+
+// ChunkVerifyResult is the per-chunk outcome of a deep verification.
+type ChunkVerifyResult struct {
+	ChunkID  int               `json:"chunk_id"`
+	S3Key    string            `json:"s3_key"`
+	Status   ChunkVerifyStatus `json:"status"`
+	Expected string            `json:"expected,omitempty"`
+	Actual   string            `json:"actual,omitempty"`
+	SizeGot  int64             `json:"size_got,omitempty"`
+	Err      string            `json:"error,omitempty"`
+}
+
+// DeepVerifyResult aggregates the outcome of a data-level verification.
+type DeepVerifyResult struct {
+	Algorithm    string              `json:"algorithm"`
+	TotalChunks  int                 `json:"total_chunks"`
+	OK           int                 `json:"ok"`
+	Mismatched   int                 `json:"mismatched"`
+	Missing      int                 `json:"missing"`
+	Unverifiable int                 `json:"unverifiable"`
+	Chunks       []ChunkVerifyResult `json:"chunks"`
+}
+
+// Passed reports whether the deep verification is a clean pass: every chunk
+// verified OK, with no mismatches, missing objects, or unverifiable chunks.
+// Unverifiable counts as a failure in deep mode — the whole point is to confirm
+// data, and a manifest without checksums can't.
+func (r *DeepVerifyResult) Passed() bool {
+	return r.Mismatched == 0 && r.Missing == 0 && r.Unverifiable == 0 && r.TotalChunks > 0
+}
+
+// DeepVerifier performs data-level integrity verification by re-downloading the
+// stored chunk objects and recomputing their checksums against the manifest
+// (#271). It is the mechanism behind CargoShip's integrity guarantee: it proves
+// the bytes in S3 still match what was recorded at upload time, not merely that
+// the manifest is internally consistent.
+type DeepVerifier struct {
+	manifest *Manifest
+	s3Client S3Downloader
+}
+
+// NewDeepVerifier creates a deep verifier for a manifest.
+func NewDeepVerifier(m *Manifest, s3Client S3Downloader) *DeepVerifier {
+	return &DeepVerifier{manifest: m, s3Client: s3Client}
+}
+
+// VerifyChunks re-downloads every chunk object, recomputes its SHA-256, and
+// compares it to ChunkEntry.Checksum. It streams each object through the hasher
+// (no full-object buffering) so memory stays bounded regardless of chunk size.
+// A chunk whose object is missing or whose hash differs is recorded; the walk
+// continues so the report covers every chunk rather than stopping at the first
+// failure.
+func (dv *DeepVerifier) VerifyChunks(ctx context.Context) (*DeepVerifyResult, error) {
+	// A manifest with no recorded ChecksumAlgorithm predates checksum capture;
+	// every chunk will report unverifiable (handled per-chunk in verifyChunk)
+	// rather than silently passing.
+
+	// Verify in a stable chunk-ID order for deterministic reports.
+	chunks := make([]ChunkEntry, len(dv.manifest.Chunks))
+	copy(chunks, dv.manifest.Chunks)
+	sort.Slice(chunks, func(i, j int) bool { return chunks[i].ID < chunks[j].ID })
+
+	result := &DeepVerifyResult{Algorithm: dv.manifest.ChecksumAlgorithm, TotalChunks: len(chunks)}
+
+	for i := range chunks {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		cr := dv.verifyChunk(ctx, &chunks[i])
+		switch cr.Status {
+		case ChunkVerifyOK:
+			result.OK++
+		case ChunkVerifyMismatch:
+			result.Mismatched++
+		case ChunkVerifyMissing:
+			result.Missing++
+		case ChunkVerifyUnverifiable:
+			result.Unverifiable++
+		}
+		result.Chunks = append(result.Chunks, cr)
+	}
+
+	return result, nil
+}
+
+// ResolveObjectKey normalizes a ChunkEntry.S3Key into the S3 object key to
+// fetch. S3Key can take one of three shapes depending on the upload path:
+//   - a full URL (some SDK upload managers return result.Location as a URL that
+//     the uploader stores verbatim, e.g. "http://host/bucket/prefix/.../chunk");
+//   - a bucket-qualified path ("bucket/prefix/.../chunk");
+//   - a key relative to the manifest Prefix (".../chunk"), the uploader default.
+//
+// All three normalize to the object key within the bucket, prepending prefix
+// only when the key doesn't already contain it. Exported so callers that need
+// the real object location (e.g. tests, tooling) resolve it identically.
+func ResolveObjectKey(prefix, bucket, s3Key string) string {
+	key := s3Key
+
+	// Strip a scheme://host/ prefix if S3Key was stored as a full URL.
+	if i := strings.Index(key, "://"); i >= 0 {
+		rest := key[i+3:]
+		if slash := strings.Index(rest, "/"); slash >= 0 {
+			key = rest[slash+1:] // drop host, keep path
+		} else {
+			key = ""
+		}
+	}
+
+	// Strip a leading "bucket/" if present.
+	if bucket != "" {
+		key = strings.TrimPrefix(key, bucket+"/")
+	}
+
+	// Prepend the manifest Prefix unless it's already there (or empty).
+	if prefix != "" && !strings.HasPrefix(key, prefix+"/") {
+		key = prefix + "/" + key
+	}
+	return key
+}
+
+// objectKey resolves a chunk key against this manifest's prefix/bucket.
+func (dv *DeepVerifier) objectKey(chunkKey string) string {
+	return ResolveObjectKey(dv.manifest.Prefix, dv.manifest.Bucket, chunkKey)
+}
+
+// verifyChunk fetches and hashes a single chunk object.
+func (dv *DeepVerifier) verifyChunk(ctx context.Context, chunk *ChunkEntry) ChunkVerifyResult {
+	cr := ChunkVerifyResult{ChunkID: chunk.ID, S3Key: chunk.S3Key, Expected: chunk.Checksum}
+
+	// No recorded checksum (or no algorithm) => can't verify.
+	if chunk.Checksum == "" || dv.manifest.ChecksumAlgorithm == "" {
+		cr.Status = ChunkVerifyUnverifiable
+		return cr
+	}
+
+	output, err := dv.s3Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(dv.manifest.Bucket),
+		Key:    aws.String(dv.objectKey(chunk.S3Key)),
+	})
+	if err != nil {
+		cr.Status = ChunkVerifyMissing
+		cr.Err = err.Error()
+		return cr
+	}
+	defer func() { _ = output.Body.Close() }()
+
+	hasher := sha256.New()
+	n, err := io.Copy(hasher, output.Body)
+	if err != nil {
+		cr.Status = ChunkVerifyMissing
+		cr.Err = fmt.Sprintf("read object: %v", err)
+		return cr
+	}
+	cr.SizeGot = n
+	cr.Actual = hex.EncodeToString(hasher.Sum(nil))
+
+	if cr.Actual == chunk.Checksum {
+		cr.Status = ChunkVerifyOK
+	} else {
+		cr.Status = ChunkVerifyMismatch
+	}
+	return cr
+}

--- a/pkg/manifest/deep_verify_test.go
+++ b/pkg/manifest/deep_verify_test.go
@@ -1,0 +1,209 @@
+package manifest
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDownloader serves object bytes from an in-memory map and can simulate
+// missing objects. It implements manifest.S3Downloader.
+type fakeDownloader struct {
+	objects map[string][]byte
+}
+
+func (f *fakeDownloader) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	key := *in.Key
+	data, ok := f.objects[key]
+	if !ok {
+		return nil, fmt.Errorf("NoSuchKey: %s", key)
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data))}, nil
+}
+
+func sha256hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// manifestWith builds a minimal manifest with the given chunks and algorithm.
+func manifestWith(algo string, chunks []ChunkEntry) *Manifest {
+	return &Manifest{
+		Version:           ManifestVersion,
+		Bucket:            "test-bucket",
+		ChecksumAlgorithm: algo,
+		Chunks:            chunks,
+	}
+}
+
+// TestDeepVerify_AllOK verifies a clean pass when every object matches.
+func TestDeepVerify_AllOK(t *testing.T) {
+	c0 := []byte("chunk-zero-contents")
+	c1 := []byte("chunk-one-different-contents")
+	dl := &fakeDownloader{objects: map[string][]byte{
+		"uploads/u/shard-0/chunk-0.tar.zst": c0,
+		"uploads/u/shard-0/chunk-1.tar.zst": c1,
+	}}
+	m := manifestWith(ChecksumAlgorithmSHA256, []ChunkEntry{
+		{ID: 0, S3Key: "uploads/u/shard-0/chunk-0.tar.zst", Checksum: sha256hex(c0)},
+		{ID: 1, S3Key: "uploads/u/shard-0/chunk-1.tar.zst", Checksum: sha256hex(c1)},
+	})
+
+	res, err := NewDeepVerifier(m, dl).VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.True(t, res.Passed())
+	assert.Equal(t, 2, res.OK)
+	assert.Equal(t, 0, res.Mismatched)
+	assert.Equal(t, int64(len(c0)), res.Chunks[0].SizeGot)
+}
+
+// TestDeepVerify_DetectsCorruption is the trust-defining test: a stored object
+// whose bytes were altered must be flagged as a mismatch and fail the verify.
+func TestDeepVerify_DetectsCorruption(t *testing.T) {
+	original := []byte("the original archive bytes")
+	corrupted := []byte("the CORRUPTED archive bytes")
+	dl := &fakeDownloader{objects: map[string][]byte{
+		"uploads/u/shard-0/chunk-0.tar.zst": corrupted, // stored bytes differ
+	}}
+	m := manifestWith(ChecksumAlgorithmSHA256, []ChunkEntry{
+		{ID: 0, S3Key: "uploads/u/shard-0/chunk-0.tar.zst", Checksum: sha256hex(original)},
+	})
+
+	res, err := NewDeepVerifier(m, dl).VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.False(t, res.Passed(), "corruption must fail verification")
+	assert.Equal(t, 1, res.Mismatched)
+	assert.Equal(t, ChunkVerifyMismatch, res.Chunks[0].Status)
+	assert.Equal(t, sha256hex(original), res.Chunks[0].Expected)
+	assert.Equal(t, sha256hex(corrupted), res.Chunks[0].Actual)
+}
+
+// TestDeepVerify_MissingObject flags an object that isn't in S3.
+func TestDeepVerify_MissingObject(t *testing.T) {
+	dl := &fakeDownloader{objects: map[string][]byte{}} // nothing stored
+	m := manifestWith(ChecksumAlgorithmSHA256, []ChunkEntry{
+		{ID: 0, S3Key: "uploads/u/shard-0/chunk-0.tar.zst", Checksum: sha256hex([]byte("x"))},
+	})
+
+	res, err := NewDeepVerifier(m, dl).VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.False(t, res.Passed())
+	assert.Equal(t, 1, res.Missing)
+	assert.Equal(t, ChunkVerifyMissing, res.Chunks[0].Status)
+	assert.Contains(t, res.Chunks[0].Err, "NoSuchKey")
+}
+
+// TestDeepVerify_UnverifiableNoChecksum fails when a chunk has no recorded
+// checksum even though the algorithm is set.
+func TestDeepVerify_UnverifiableNoChecksum(t *testing.T) {
+	c0 := []byte("data")
+	dl := &fakeDownloader{objects: map[string][]byte{"k0": c0}}
+	m := manifestWith(ChecksumAlgorithmSHA256, []ChunkEntry{
+		{ID: 0, S3Key: "k0", Checksum: ""}, // no checksum recorded
+	})
+
+	res, err := NewDeepVerifier(m, dl).VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.False(t, res.Passed(), "unverifiable must fail in deep mode")
+	assert.Equal(t, 1, res.Unverifiable)
+	assert.Equal(t, ChunkVerifyUnverifiable, res.Chunks[0].Status)
+}
+
+// TestDeepVerify_PreCaptureManifest fails cleanly when the manifest predates
+// checksum capture (no algorithm) — every chunk is unverifiable, not a false pass.
+func TestDeepVerify_PreCaptureManifest(t *testing.T) {
+	dl := &fakeDownloader{objects: map[string][]byte{"k0": []byte("x")}}
+	m := manifestWith("", []ChunkEntry{
+		{ID: 0, S3Key: "k0", Checksum: "deadbeef"}, // checksum present but no algorithm
+	})
+
+	res, err := NewDeepVerifier(m, dl).VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.False(t, res.Passed())
+	assert.Equal(t, 1, res.Unverifiable)
+}
+
+// TestDeepVerify_MixedContinuesPastFailure verifies the walk reports every chunk
+// rather than stopping at the first failure.
+func TestDeepVerify_MixedContinuesPastFailure(t *testing.T) {
+	good := []byte("good")
+	dl := &fakeDownloader{objects: map[string][]byte{
+		"k0": good,
+		"k1": []byte("corrupted"),
+		// k2 missing
+	}}
+	m := manifestWith(ChecksumAlgorithmSHA256, []ChunkEntry{
+		{ID: 0, S3Key: "k0", Checksum: sha256hex(good)},
+		{ID: 1, S3Key: "k1", Checksum: sha256hex([]byte("expected"))},
+		{ID: 2, S3Key: "k2", Checksum: sha256hex([]byte("z"))},
+	})
+
+	res, err := NewDeepVerifier(m, dl).VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.TotalChunks)
+	assert.Equal(t, 1, res.OK)
+	assert.Equal(t, 1, res.Mismatched)
+	assert.Equal(t, 1, res.Missing)
+	assert.Len(t, res.Chunks, 3, "reports all chunks")
+}
+
+// TestResolveObjectKey covers the three S3Key shapes deep verify must handle.
+func TestResolveObjectKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		prefix, bucket string
+		s3Key          string
+		want           string
+	}{
+		{"relative key with prefix", "myprefix", "b", "uploads/u/shard-0/chunk-0.tar.zst", "myprefix/uploads/u/shard-0/chunk-0.tar.zst"},
+		{"relative key no prefix", "", "b", "uploads/u/shard-0/chunk-0.tar.zst", "uploads/u/shard-0/chunk-0.tar.zst"},
+		{"already prefixed", "myprefix", "b", "myprefix/uploads/u/chunk-0", "myprefix/uploads/u/chunk-0"},
+		{"bucket-qualified", "myprefix", "b", "b/myprefix/uploads/u/chunk-0", "myprefix/uploads/u/chunk-0"},
+		{"full URL", "myprefix", "cargoship-test", "http://127.0.0.1:9000/cargoship-test/myprefix/uploads/u/chunk-0", "myprefix/uploads/u/chunk-0"},
+		{"https URL no prefix", "", "b", "https://s3.amazonaws.com/b/uploads/u/chunk-0", "uploads/u/chunk-0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ResolveObjectKey(tt.prefix, tt.bucket, tt.s3Key))
+		})
+	}
+}
+
+// TestDeepVerify_ResolvesURLKeys verifies the verifier fetches the right object
+// when S3Key was stored as a full URL (as some upload managers return).
+func TestDeepVerify_ResolvesURLKeys(t *testing.T) {
+	c0 := []byte("archive-contents")
+	dl := &fakeDownloader{objects: map[string][]byte{
+		"pfx/uploads/u/shard-0/chunk-0.tar.zst": c0, // stored under the resolved key
+	}}
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "bkt", Prefix: "pfx",
+		ChecksumAlgorithm: ChecksumAlgorithmSHA256,
+		Chunks: []ChunkEntry{{
+			ID:       0,
+			S3Key:    "http://host:9000/bkt/pfx/uploads/u/shard-0/chunk-0.tar.zst",
+			Checksum: sha256hex(c0),
+		}},
+	}
+	res, err := NewDeepVerifier(m, dl).VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.True(t, res.Passed(), "should resolve the URL key and verify OK")
+}
+
+// TestDeepVerify_EmptyManifestNotPass ensures a manifest with zero chunks is not
+// reported as a pass (nothing was actually verified).
+func TestDeepVerify_EmptyManifestNotPass(t *testing.T) {
+	m := manifestWith(ChecksumAlgorithmSHA256, nil)
+	res, err := NewDeepVerifier(m, &fakeDownloader{}).VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.False(t, res.Passed())
+	assert.Equal(t, 0, res.TotalChunks)
+}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -21,6 +21,11 @@ const (
 	// ManifestVersion is the current manifest format version
 	ManifestVersion = "2.0"
 
+	// ChecksumAlgorithmSHA256 is the hash algorithm recorded in
+	// Manifest.ChecksumAlgorithm for chunk (and per-file) checksums. It matches
+	// the SHA-256 (hex) used by the deduplication index. (#271)
+	ChecksumAlgorithmSHA256 = "sha256"
+
 	// ManifestVersionV1 is the legacy v1.0 manifest format version (backward-compat read-only)
 	ManifestVersionV1 = "1.0"
 
@@ -50,17 +55,18 @@ func NewBuilder(uploadID, sourcePath, bucket, prefix, region string) (*Builder, 
 
 	return &Builder{
 		manifest: &Manifest{
-			Version:    ManifestVersion,
-			UploadID:   uploadID,
-			CreatedAt:  time.Now(),
-			SourcePath: sourcePath,
-			Hostname:   hostname,
-			Bucket:     bucket,
-			Prefix:     prefix,
-			Region:     region,
-			Files:      make([]FileEntry, 0),
-			Chunks:     make([]ChunkEntry, 0),
-			Shards:     make([]ShardEntry, 0),
+			Version:           ManifestVersion,
+			UploadID:          uploadID,
+			CreatedAt:         time.Now(),
+			SourcePath:        sourcePath,
+			Hostname:          hostname,
+			Bucket:            bucket,
+			Prefix:            prefix,
+			Region:            region,
+			ChecksumAlgorithm: ChecksumAlgorithmSHA256,
+			Files:             make([]FileEntry, 0),
+			Chunks:            make([]ChunkEntry, 0),
+			Shards:            make([]ShardEntry, 0),
 		},
 		hostname: hostname,
 	}, nil
@@ -75,29 +81,30 @@ func NewBuilderFromExisting(existing *Manifest) (*Builder, error) {
 
 	// Clone the existing manifest to avoid modifying the original
 	cloned := &Manifest{
-		Version:          existing.Version,
-		UploadID:         existing.UploadID,
-		CreatedAt:        existing.CreatedAt,
-		CompletedAt:      existing.CompletedAt,
-		SourcePath:       existing.SourcePath,
-		Hostname:         hostname, // Use current hostname for resumed portion
-		Bucket:           existing.Bucket,
-		Prefix:           existing.Prefix,
-		Region:           existing.Region,
-		TotalFiles:       existing.TotalFiles,
-		TotalBytes:       existing.TotalBytes,
-		TotalChunks:      existing.TotalChunks,
-		ShardCount:       existing.ShardCount,
-		CompressionType:  existing.CompressionType,
-		CompressionLevel: existing.CompressionLevel,
-		CompressionRatio: existing.CompressionRatio,
-		Files:            append([]FileEntry(nil), existing.Files...),
-		Chunks:           append([]ChunkEntry(nil), existing.Chunks...),
-		Shards:           append([]ShardEntry(nil), existing.Shards...),
-		VersionInfo:      existing.VersionInfo,
-		GitMetadata:      existing.GitMetadata,
-		DVCCompatibility: existing.DVCCompatibility,
-		DVCPipeline:      existing.DVCPipeline,
+		Version:           existing.Version,
+		UploadID:          existing.UploadID,
+		CreatedAt:         existing.CreatedAt,
+		CompletedAt:       existing.CompletedAt,
+		SourcePath:        existing.SourcePath,
+		Hostname:          hostname, // Use current hostname for resumed portion
+		Bucket:            existing.Bucket,
+		Prefix:            existing.Prefix,
+		Region:            existing.Region,
+		TotalFiles:        existing.TotalFiles,
+		TotalBytes:        existing.TotalBytes,
+		TotalChunks:       existing.TotalChunks,
+		ShardCount:        existing.ShardCount,
+		CompressionType:   existing.CompressionType,
+		CompressionLevel:  existing.CompressionLevel,
+		CompressionRatio:  existing.CompressionRatio,
+		ChecksumAlgorithm: existing.ChecksumAlgorithm,
+		Files:             append([]FileEntry(nil), existing.Files...),
+		Chunks:            append([]ChunkEntry(nil), existing.Chunks...),
+		Shards:            append([]ShardEntry(nil), existing.Shards...),
+		VersionInfo:       existing.VersionInfo,
+		GitMetadata:       existing.GitMetadata,
+		DVCCompatibility:  existing.DVCCompatibility,
+		DVCPipeline:       existing.DVCPipeline,
 	}
 
 	return &Builder{

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -39,6 +39,11 @@ type Manifest struct {
 	CompressionLevel int     `json:"compression_level"` // Compression level used
 	CompressionRatio float64 `json:"compression_ratio"` // Actual compression ratio achieved
 
+	// ChecksumAlgorithm names the hash used for chunk (and per-file) checksums,
+	// e.g. "sha256" (#271). Empty on manifests written before checksum capture
+	// existed; verify --deep treats those as unverifiable rather than assuming.
+	ChecksumAlgorithm string `json:"checksum_algorithm,omitempty"`
+
 	// Encryption (Issue #163)
 	Encryption *EncryptionMetadata `json:"encryption,omitempty"` // Encryption configuration if enabled
 

--- a/pkg/pipeline/checksum_reader.go
+++ b/pkg/pipeline/checksum_reader.go
@@ -1,0 +1,49 @@
+package pipeline
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"io"
+)
+
+// hashingReadCloser wraps an io.ReadCloser and computes a running hash of every
+// byte read through it. The digest is only valid once the underlying stream has
+// been fully consumed (i.e. after the upload finishes reading it). It adds no
+// buffering and a single hash.Write per Read, so it is safe on the streaming
+// upload hot path.
+type hashingReadCloser struct {
+	rc     io.ReadCloser
+	hasher hash.Hash
+}
+
+// newHashingReadCloser wraps rc so that reads feed a SHA-256 hasher. Passing a
+// nil rc returns nil so callers can wrap unconditionally.
+func newHashingReadCloser(rc io.ReadCloser) *hashingReadCloser {
+	if rc == nil {
+		return nil
+	}
+	return &hashingReadCloser{rc: rc, hasher: sha256.New()}
+}
+
+// Read reads from the underlying stream and updates the hash with the bytes
+// returned. A hash.Hash never errors on Write, so the read result is passed
+// through unchanged.
+func (h *hashingReadCloser) Read(p []byte) (int, error) {
+	n, err := h.rc.Read(p)
+	if n > 0 {
+		_, _ = h.hasher.Write(p[:n])
+	}
+	return n, err
+}
+
+// Close closes the underlying stream.
+func (h *hashingReadCloser) Close() error {
+	return h.rc.Close()
+}
+
+// Sum returns the hex-encoded digest of everything read so far. Call it only
+// after the stream is fully consumed; a partial read yields a partial digest.
+func (h *hashingReadCloser) Sum() string {
+	return hex.EncodeToString(h.hasher.Sum(nil))
+}

--- a/pkg/pipeline/checksum_reader_test.go
+++ b/pkg/pipeline/checksum_reader_test.go
@@ -1,0 +1,57 @@
+package pipeline
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashingReadCloser_HashesStreamedBytes(t *testing.T) {
+	data := bytes.Repeat([]byte("cargoship-archive-bytes"), 1000)
+	want := sha256.Sum256(data)
+
+	h := newHashingReadCloser(io.NopCloser(bytes.NewReader(data)))
+	require.NotNil(t, h)
+
+	// Read in small chunks to exercise the running hash across many Reads.
+	got, err := io.CopyBuffer(io.Discard, h, make([]byte, 64))
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(data)), got)
+	assert.NoError(t, h.Close())
+
+	assert.Equal(t, hex.EncodeToString(want[:]), h.Sum())
+}
+
+func TestHashingReadCloser_NilPassthrough(t *testing.T) {
+	assert.Nil(t, newHashingReadCloser(nil))
+}
+
+func TestHashingReadCloser_EmptyStream(t *testing.T) {
+	h := newHashingReadCloser(io.NopCloser(bytes.NewReader(nil)))
+	_, err := io.Copy(io.Discard, h)
+	require.NoError(t, err)
+	// SHA-256 of the empty input.
+	empty := sha256.Sum256(nil)
+	assert.Equal(t, hex.EncodeToString(empty[:]), h.Sum())
+}
+
+// TestJob_ArchiveChecksum verifies the Job accessor returns "" without a hasher
+// and the digest once one is attached and consumed.
+func TestJob_ArchiveChecksum(t *testing.T) {
+	j := &Job{}
+	assert.Equal(t, "", j.ArchiveChecksum(), "no hasher => empty")
+
+	data := []byte("hello world")
+	j.archiveHasher = newHashingReadCloser(io.NopCloser(bytes.NewReader(data)))
+	j.Archive = j.archiveHasher
+	_, err := io.Copy(io.Discard, j.Archive)
+	require.NoError(t, err)
+
+	want := sha256.Sum256(data)
+	assert.Equal(t, hex.EncodeToString(want[:]), j.ArchiveChecksum())
+}

--- a/pkg/pipeline/manifest_integration_test.go
+++ b/pkg/pipeline/manifest_integration_test.go
@@ -3,6 +3,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -138,6 +139,40 @@ func TestManifestIntegration_Generation(t *testing.T) {
 		assert.Greater(t, chunk.UncompressedSize, int64(0), "Chunk %d should have uncompressed size", i)
 		assert.Greater(t, chunk.CompressedSize, int64(0), "Chunk %d should have compressed size", i)
 	}
+
+	// #271: chunk-level checksum capture. The manifest must record the
+	// algorithm, and every chunk must carry a checksum populated during upload.
+	assert.Equal(t, manifest.ChecksumAlgorithmSHA256, m.ChecksumAlgorithm,
+		"manifest should record the checksum algorithm")
+	for i, chunk := range m.Chunks {
+		assert.NotEmpty(t, chunk.Checksum, "Chunk %d should have a checksum captured on upload", i)
+		assert.Len(t, chunk.Checksum, 64, "Chunk %d checksum should be a hex SHA-256", i)
+	}
+
+	// #271: deep verify should PASS against the freshly-uploaded objects —
+	// re-download each chunk, recompute SHA-256, compare to the manifest.
+	deepRes, err := manifest.NewDeepVerifier(m, s3Client).VerifyChunks(ctx)
+	require.NoError(t, err)
+	assert.True(t, deepRes.Passed(),
+		"deep verify should pass on fresh upload: %d OK, %d mismatched, %d missing, %d unverifiable",
+		deepRes.OK, deepRes.Mismatched, deepRes.Missing, deepRes.Unverifiable)
+	assert.Equal(t, len(m.Chunks), deepRes.OK, "every chunk should verify OK")
+
+	// #271: corruption is detected. Overwrite one chunk object with garbage and
+	// confirm deep verify now FAILS with a mismatch on that chunk. Derive the
+	// object key the same way deep verify does (S3Key may be a full URL).
+	corruptKey := manifest.ResolveObjectKey(m.Prefix, bucket, m.Chunks[0].S3Key)
+	_, err = s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(corruptKey),
+		Body:   bytes.NewReader([]byte("this is not the original archive")),
+	})
+	require.NoError(t, err, "should be able to overwrite chunk object for corruption test")
+
+	corruptRes, err := manifest.NewDeepVerifier(m, s3Client).VerifyChunks(ctx)
+	require.NoError(t, err)
+	assert.False(t, corruptRes.Passed(), "deep verify must fail after a chunk is corrupted")
+	assert.GreaterOrEqual(t, corruptRes.Mismatched, 1, "the corrupted chunk should be flagged as a mismatch")
 
 	// Verify shard statistics
 	totalFilesInShards := int64(0)

--- a/pkg/pipeline/s3_multiprefix_uploader.go
+++ b/pkg/pipeline/s3_multiprefix_uploader.go
@@ -383,7 +383,7 @@ func (s *S3MultiPrefixUploaderStage) processJob(ctx context.Context, job *Job, p
 			// Update file entries with S3 key and shard ID
 			builder.UpdateFileS3Keys(job.Chunk.ID, shardID, job.S3Key)
 
-			// Add chunk entry
+			// Add chunk entry (#271: record the SHA-256 of the uploaded archive)
 			builder.AddChunk(manifest.ChunkEntry{
 				ID:               job.Chunk.ID,
 				ShardID:          shardID,
@@ -394,6 +394,7 @@ func (s *S3MultiPrefixUploaderStage) processJob(ctx context.Context, job *Job, p
 				CompressedSize:   atomic.LoadInt64(&job.ArchiveSize),
 				CreatedAt:        job.StartTime,
 				UploadedAt:       job.EndTime,
+				Checksum:         job.ArchiveChecksum(),
 			})
 
 			// Update shard stats
@@ -440,6 +441,15 @@ func (s *S3MultiPrefixUploaderStage) uploadToS3(ctx context.Context, job *Job) e
 	s3Key := job.S3Key
 	if s.config.Prefix != "" {
 		s3Key = s.config.Prefix + "/" + job.S3Key
+	}
+
+	// #271: wrap the archive stream so we hash the exact bytes uploaded to S3.
+	// Both upload paths (transporter, manager) read job.Archive, so wrapping
+	// here covers both. The digest is finalized once the stream is consumed and
+	// is read into ChunkEntry.Checksum after a successful upload.
+	if job.Archive != nil && job.archiveHasher == nil {
+		job.archiveHasher = newHashingReadCloser(job.Archive)
+		job.Archive = job.archiveHasher
 	}
 
 	// Prepare metadata

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -37,6 +37,20 @@ type Job struct {
 	pipeReader *BufferedPipeReader // Reader side of pipe (for pool cleanup)
 	pipeWriter *BufferedPipeWriter // Writer side of pipe (for pool cleanup)
 	pipePool   *BufferedPipePool   // Pool to return pipe to after upload
+
+	// #271: SHA-256 of the compressed archive stream, computed as the uploader
+	// reads job.Archive. Valid only after the upload has consumed the stream;
+	// read via ArchiveChecksum(). Nil when checksum capture isn't wired.
+	archiveHasher *hashingReadCloser
+}
+
+// ArchiveChecksum returns the hex SHA-256 of the uploaded archive stream, or ""
+// if no checksum was captured for this job. Call only after upload completes.
+func (j *Job) ArchiveChecksum() string {
+	if j.archiveHasher == nil {
+		return ""
+	}
+	return j.archiveHasher.Sum()
 }
 
 // Stage represents a pipeline stage


### PR DESCRIPTION
First of two PRs for #271 (chunk level; per-file is part 2). Foundation for the trust epic #270.

## Problem

`cargoship verify` only checked that the **manifest was internally consistent** and *counted* checksums (`validate.go:353` "always passes") — a manifest pointing at a corrupted or missing S3 object still reported ✅ PASS. Worse, on a normal upload **no per-object checksums were recorded at all** (only duplicate files under opt-in dedup got one, `scanner.go:700`). So there was nothing to verify against.

## Capture (upload path)

- **`hashingReadCloser`** (`checksum_reader.go`): a TeeReader that hashes the exact archive bytes streamed to S3, inserted once in the multiprefix uploader's `uploadToS3` so it covers **both** the transporter and manager upload paths — no extra read, bounded memory, safe on the hot path.
- The SHA-256 is written to `ChunkEntry.Checksum` after a successful upload, and **`Manifest.ChecksumAlgorithm`** (`"sha256"`, matching the dedup index) records how to recompute. Both `omitempty` for back-compat.

## Verify (consume path)

- **`manifest.DeepVerifier`** re-downloads every chunk object, recomputes SHA-256, compares to the manifest. Streams through the hasher (no buffering); continues past failures so the report covers every chunk. Missing objects and — in deep mode — chunks with no recorded checksum are **failures, not warnings**: a manifest that can't be verified doesn't silently pass.
- **`ResolveObjectKey`** normalizes `ChunkEntry.S3Key` (relative, bucket-qualified, or a full URL as some upload managers return) to the real object key.
- **`cargoship verify --deep`** runs it and exits non-zero on any corrupted/missing/unverifiable chunk. Plain `verify` is unchanged (fast metadata) and now hints at `--deep`.

## Tests

`DeepVerifier` unit tests (OK / corruption / missing / unverifiable / pre-capture manifest / mixed-continues-past-failure / URL-key resolution), a `ResolveObjectKey` table test, `hashingReadCloser` tests, and the trust-defining **end-to-end emulator integration test**: upload → assert every chunk carries a checksum → deep-verify PASS → corrupt a chunk object → deep-verify FAIL.

## Scope

Per-file checksums (end-to-end source→restore identity) are **part 2** of #271. This part gives `verify --deep` real data-level integrity for the stored chunk objects (catches S3-side corruption). Parent: #270.