### PR TITLE
feat: per-file checksums + file-level verify --deep; fix chunk truncation (#271 part 2, fixes #275)

### DIFF
--- a/cmd/cargoship/cmd/upload.go
+++ b/cmd/cargoship/cmd/upload.go
@@ -584,6 +584,9 @@ Examples:
 				PartialManifestSaveInterval: 30 * time.Second,
 				SourcePath:                  absPath,
 
+				// #271: per-file content checksums (on by default; --no-file-checksums opts out)
+				FileChecksums: func() bool { v, _ := cmd.Flags().GetBool("no-file-checksums"); return !v }(),
+
 				// Cleanup on failure
 				CleanupOnFailure: true,
 
@@ -832,6 +835,7 @@ Examples:
 
 	// Issue #108: Deduplication flag
 	cmd.Flags().Bool("enable-dedup", false, "Enable cross-shard file deduplication (10-30% space savings for redundant datasets)")
+	cmd.Flags().Bool("no-file-checksums", false, "Disable per-file content checksums (faster uploads, but 'verify --deep' can't confirm per-file integrity)")
 
 	// Issue #119: Resume configuration
 	cmd.Flags().BoolVar(&forceRestart, "force-restart", false, "Ignore saved state and start fresh upload (bypasses resume detection)")

--- a/cmd/cargoship/cmd/verify.go
+++ b/cmd/cargoship/cmd/verify.go
@@ -300,12 +300,52 @@ func runDeepVerify(ctx context.Context, s3Client manifest.S3Downloader, m *manif
 	fmt.Printf("📊 Deep Verify: %d OK, %d corrupted, %d missing, %d unverifiable (of %d chunks)\n",
 		result.OK, result.Mismatched, result.Missing, result.Unverifiable, result.TotalChunks)
 
-	if result.Passed() {
-		fmt.Printf("✅ Deep verification PASS — all %d chunk objects match the manifest\n", result.TotalChunks)
+	chunksPassed := result.Passed()
+	if chunksPassed {
+		fmt.Printf("✅ Chunk objects PASS — all %d chunk objects match the manifest\n", result.TotalChunks)
+	} else {
+		fmt.Printf("❌ Chunk verification FAIL\n")
+	}
+
+	// File-level verification: extract each file and confirm its content hash.
+	// Proves end-to-end source->restore identity, not just object integrity.
+	fmt.Printf("\n🔬 Verifying per-file content checksums...\n")
+	fileRes, ferr := verifier.VerifyFiles(ctx)
+	if ferr != nil {
+		fmt.Printf("❌ File verification aborted: %v\n", ferr)
+		return ferr
+	}
+
+	if verbose || !fileRes.Passed() {
+		for _, f := range fileRes.Files {
+			switch f.Status {
+			case manifest.ChunkVerifyMismatch:
+				fmt.Printf("   ✗ %s CORRUPTED: expected %s, got %s\n", f.Path, f.Expected, f.Actual)
+			case manifest.ChunkVerifyMissing:
+				fmt.Printf("   ✗ %s MISSING from its chunk\n", f.Path)
+			case manifest.ChunkVerifyUnverifiable:
+				fmt.Printf("   ⚠ %s UNVERIFIABLE: no checksum recorded\n", f.Path)
+			case manifest.ChunkVerifyOK:
+				if verbose {
+					fmt.Printf("   ✓ %s\n", f.Path)
+				}
+			}
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("📊 File Verify: %d OK, %d corrupted, %d missing, %d unverifiable (of %d files)\n",
+		fileRes.OK, fileRes.Mismatched, fileRes.Missing, fileRes.Unverifiable, fileRes.TotalFiles)
+
+	filesPassed := fileRes.Passed()
+	if chunksPassed && filesPassed {
+		fmt.Printf("✅ Deep verification PASS — %d chunks and %d files match the manifest\n",
+			result.TotalChunks, fileRes.TotalFiles)
 		return nil
 	}
 
 	fmt.Printf("❌ Deep verification FAIL\n")
-	return fmt.Errorf("deep verification failed: %d corrupted, %d missing, %d unverifiable",
-		result.Mismatched, result.Missing, result.Unverifiable)
+	return fmt.Errorf("deep verification failed: chunks(%d corrupted, %d missing, %d unverifiable) files(%d corrupted, %d missing, %d unverifiable)",
+		result.Mismatched, result.Missing, result.Unverifiable,
+		fileRes.Mismatched, fileRes.Missing, fileRes.Unverifiable)
 }

--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -400,9 +400,18 @@ func (dv *DeepVerifier) verifyChunkFiles(ctx context.Context, chunk *ChunkEntry,
 		}
 		seen[k] = true
 
+		// Hash exactly the file's declared size via CopyN. The bound guards
+		// against a decompression bomb (a malicious manifest/chunk can't stream
+		// unbounded data through us) and surfaces a truncated entry as a
+		// mismatch. tar.Reader already caps reads at the entry boundary.
 		hasher := sha256.New()
-		if _, err := io.Copy(hasher, tr); err != nil {
-			return nil, fmt.Errorf("hash file %q: %w", hdr.Name, err)
+		if _, err := io.CopyN(hasher, tr, hdr.Size); err != nil {
+			// Short entry (fewer bytes than declared) — record a mismatch and
+			// keep going so the report still covers the remaining files.
+			results = append(results, FileVerifyResult{
+				Path: path, ChunkID: chunk.ID, Expected: exp, Status: ChunkVerifyMismatch,
+			})
+			continue
 		}
 		actual := hex.EncodeToString(hasher.Sum(nil))
 

--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -1,6 +1,9 @@
 package manifest
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -11,6 +14,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/klauspost/compress/zstd"
 )
 
 // ChunkVerifyStatus is the outcome of deep-verifying a single chunk object.
@@ -190,4 +194,228 @@ func (dv *DeepVerifier) verifyChunk(ctx context.Context, chunk *ChunkEntry) Chun
 		cr.Status = ChunkVerifyMismatch
 	}
 	return cr
+}
+
+// fileKey identifies a file (or split-file part) for checksum lookup.
+type fileKey struct {
+	path string
+	part int
+}
+
+// FileVerifyResult is the per-file outcome of file-level deep verification.
+type FileVerifyResult struct {
+	Path     string            `json:"path"`
+	ChunkID  int               `json:"chunk_id"`
+	Status   ChunkVerifyStatus `json:"status"` // reuses ok/mismatch/missing/unverifiable
+	Expected string            `json:"expected,omitempty"`
+	Actual   string            `json:"actual,omitempty"`
+}
+
+// FileVerifyResult aggregate.
+type FilesVerifyResult struct {
+	Algorithm    string             `json:"algorithm"`
+	TotalFiles   int                `json:"total_files"`
+	OK           int                `json:"ok"`
+	Mismatched   int                `json:"mismatched"`
+	Missing      int                `json:"missing"`
+	Unverifiable int                `json:"unverifiable"`
+	Files        []FileVerifyResult `json:"files"`
+}
+
+// Passed reports a clean file-level pass: every file hashed and matched.
+func (r *FilesVerifyResult) Passed() bool {
+	return r.Mismatched == 0 && r.Missing == 0 && r.Unverifiable == 0 && r.TotalFiles > 0
+}
+
+// tarNameToFileKey maps a tar entry name back to the key used in the manifest's
+// FileEntry checksum lookup. Split-file parts are stored under "path.partN" in
+// the tar (see archiver), which correspond to FileEntry{Path, PartIndex}. Whole
+// files use the plain path.
+func tarNameToFileKey(tarName string) (path string, partIndex int, isPart bool) {
+	if i := strings.LastIndex(tarName, ".part"); i >= 0 {
+		var p int
+		if _, err := fmt.Sscanf(tarName[i+len(".part"):], "%d", &p); err == nil {
+			return tarName[:i], p, true
+		}
+	}
+	return tarName, 0, false
+}
+
+// VerifyFiles re-downloads each chunk, extracts every file, recomputes its
+// content SHA-256, and compares to FileEntry.Checksum (#271). This is the
+// end-to-end source->restore integrity check: it proves each restored file's
+// bytes match what was recorded at upload, not merely that the chunk object is
+// intact. Files whose FileEntry carries no checksum are reported unverifiable.
+func (dv *DeepVerifier) VerifyFiles(ctx context.Context) (*FilesVerifyResult, error) {
+	result := &FilesVerifyResult{Algorithm: dv.manifest.ChecksumAlgorithm}
+
+	// Index expected checksums by (path, partIndex).
+	expected := make(map[fileKey]string)
+	for _, f := range dv.manifest.Files {
+		if f.IsDuplicate {
+			continue // deduplicated files aren't stored in a chunk of their own
+		}
+		expected[fileKey{f.Path, f.PartIndex}] = f.Checksum
+		result.TotalFiles++
+	}
+
+	// Group files by chunk so we download each chunk object once.
+	byChunk := make(map[int]bool)
+	for _, f := range dv.manifest.Files {
+		if !f.IsDuplicate {
+			byChunk[f.ChunkID] = true
+		}
+	}
+	chunkIDs := make([]int, 0, len(byChunk))
+	for id := range byChunk {
+		chunkIDs = append(chunkIDs, id)
+	}
+	sort.Ints(chunkIDs)
+
+	seen := make(map[fileKey]bool)
+
+	for _, chunkID := range chunkIDs {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		chunk := dv.chunkByID(chunkID)
+		if chunk == nil {
+			continue
+		}
+		fileResults, err := dv.verifyChunkFiles(ctx, chunk, expected, seen)
+		if err != nil {
+			// Chunk object unreadable: every file in it is missing.
+			for _, f := range dv.manifest.Files {
+				if f.ChunkID == chunkID && !f.IsDuplicate {
+					result.Files = append(result.Files, FileVerifyResult{
+						Path: f.Path, ChunkID: chunkID, Status: ChunkVerifyMissing,
+					})
+					result.Missing++
+				}
+			}
+			continue
+		}
+		for _, fr := range fileResults {
+			switch fr.Status {
+			case ChunkVerifyOK:
+				result.OK++
+			case ChunkVerifyMismatch:
+				result.Mismatched++
+			case ChunkVerifyUnverifiable:
+				result.Unverifiable++
+			}
+			result.Files = append(result.Files, fr)
+		}
+	}
+
+	// Any expected file we never saw in its chunk's tar is missing.
+	for _, f := range dv.manifest.Files {
+		if f.IsDuplicate {
+			continue
+		}
+		k := fileKey{f.Path, f.PartIndex}
+		if !seen[k] {
+			result.Files = append(result.Files, FileVerifyResult{
+				Path: f.Path, ChunkID: f.ChunkID, Status: ChunkVerifyMissing,
+			})
+			result.Missing++
+		}
+	}
+
+	return result, nil
+}
+
+// chunkByID returns the chunk with the given ID, or nil.
+func (dv *DeepVerifier) chunkByID(id int) *ChunkEntry {
+	for i := range dv.manifest.Chunks {
+		if dv.manifest.Chunks[i].ID == id {
+			return &dv.manifest.Chunks[i]
+		}
+	}
+	return nil
+}
+
+// verifyChunkFiles downloads one chunk, walks its tar, and hashes each file
+// entry, comparing to the expected checksums. It marks seen keys so the caller
+// can detect files that never appeared.
+func (dv *DeepVerifier) verifyChunkFiles(ctx context.Context, chunk *ChunkEntry, expected map[fileKey]string, seen map[fileKey]bool) ([]FileVerifyResult, error) {
+	output, err := dv.s3Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(dv.manifest.Bucket),
+		Key:    aws.String(dv.objectKey(chunk.S3Key)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get chunk object: %w", err)
+	}
+	// Buffer the compressed object before decompressing. The tar/zstd readers
+	// need the complete stream; reading directly from the S3 body can surface a
+	// premature "unexpected EOF" on some endpoints. Chunk objects are bounded
+	// (target sizes are tens of MB), so this stays memory-safe.
+	objectBytes, err := io.ReadAll(output.Body)
+	_ = output.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("read chunk object: %w", err)
+	}
+	body := bytes.NewReader(objectBytes)
+
+	var decompressed io.Reader
+	switch dv.manifest.CompressionType {
+	case "zstd", "":
+		dec, err := zstd.NewReader(body)
+		if err != nil {
+			return nil, fmt.Errorf("zstd reader: %w", err)
+		}
+		defer dec.Close()
+		decompressed = dec
+	case "gzip", "gz":
+		gz, err := gzip.NewReader(body)
+		if err != nil {
+			return nil, fmt.Errorf("gzip reader: %w", err)
+		}
+		defer func() { _ = gz.Close() }()
+		decompressed = gz
+	case "none":
+		decompressed = body
+	default:
+		return nil, fmt.Errorf("unsupported compression type: %s", dv.manifest.CompressionType)
+	}
+
+	var results []FileVerifyResult
+	tr := tar.NewReader(decompressed)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("tar read: %w", err)
+		}
+		if hdr.Name == ".padding" {
+			continue // synthetic padding entry, not a real file
+		}
+		path, part, _ := tarNameToFileKey(hdr.Name)
+		k := fileKey{path, part}
+		exp, isExpected := expected[k]
+		if !isExpected {
+			continue // not a manifest file we track (shouldn't happen)
+		}
+		seen[k] = true
+
+		hasher := sha256.New()
+		if _, err := io.Copy(hasher, tr); err != nil {
+			return nil, fmt.Errorf("hash file %q: %w", hdr.Name, err)
+		}
+		actual := hex.EncodeToString(hasher.Sum(nil))
+
+		fr := FileVerifyResult{Path: path, ChunkID: chunk.ID, Expected: exp, Actual: actual}
+		switch {
+		case exp == "" || dv.manifest.ChecksumAlgorithm == "":
+			fr.Status = ChunkVerifyUnverifiable
+		case actual == exp:
+			fr.Status = ChunkVerifyOK
+		default:
+			fr.Status = ChunkVerifyMismatch
+		}
+		results = append(results, fr)
+	}
+	return results, nil
 }

--- a/pkg/manifest/deep_verify_test.go
+++ b/pkg/manifest/deep_verify_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -10,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -206,4 +208,145 @@ func TestDeepVerify_EmptyManifestNotPass(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, res.Passed())
 	assert.Equal(t, 0, res.TotalChunks)
+}
+
+// makeTarZst builds a zstd-compressed tar containing the given name->content
+// entries, for file-level deep-verify tests.
+func makeTarZst(t *testing.T, entries map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	require.NoError(t, err)
+	tw := tar.NewWriter(zw)
+	for name, content := range entries {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0644, Size: int64(len(content))}))
+		_, err := tw.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+// TestVerifyFiles_AllOK verifies per-file checksums match after extraction.
+func TestVerifyFiles_AllOK(t *testing.T) {
+	fileA := []byte("contents of file a")
+	fileB := []byte("contents of file b, longer")
+	chunk := makeTarZst(t, map[string][]byte{"a.txt": fileA, "b.txt": fileB})
+
+	dl := &fakeDownloader{objects: map[string][]byte{"pfx/chunk-0": chunk}}
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "bkt", Prefix: "pfx",
+		CompressionType: "zstd", ChecksumAlgorithm: ChecksumAlgorithmSHA256,
+		Chunks: []ChunkEntry{{ID: 0, S3Key: "chunk-0"}},
+		Files: []FileEntry{
+			{Path: "a.txt", ChunkID: 0, Checksum: sha256hex(fileA)},
+			{Path: "b.txt", ChunkID: 0, Checksum: sha256hex(fileB)},
+		},
+	}
+
+	res, err := NewDeepVerifier(m, dl).VerifyFiles(context.Background())
+	require.NoError(t, err)
+	assert.True(t, res.Passed(), "%+v", res)
+	assert.Equal(t, 2, res.OK)
+	assert.Equal(t, 2, res.TotalFiles)
+}
+
+// TestVerifyFiles_DetectsCorruptedFile flags a file whose content changed even
+// if the surrounding chunk is otherwise readable.
+func TestVerifyFiles_DetectsCorruptedFile(t *testing.T) {
+	good := []byte("the real content")
+	tampered := []byte("the tampered content!!")
+	// Chunk actually stores the tampered bytes; manifest records the good hash.
+	chunk := makeTarZst(t, map[string][]byte{"a.txt": tampered})
+
+	dl := &fakeDownloader{objects: map[string][]byte{"pfx/chunk-0": chunk}}
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "bkt", Prefix: "pfx",
+		CompressionType: "zstd", ChecksumAlgorithm: ChecksumAlgorithmSHA256,
+		Chunks: []ChunkEntry{{ID: 0, S3Key: "chunk-0"}},
+		Files:  []FileEntry{{Path: "a.txt", ChunkID: 0, Checksum: sha256hex(good)}},
+	}
+
+	res, err := NewDeepVerifier(m, dl).VerifyFiles(context.Background())
+	require.NoError(t, err)
+	assert.False(t, res.Passed())
+	assert.Equal(t, 1, res.Mismatched)
+	assert.Equal(t, ChunkVerifyMismatch, res.Files[0].Status)
+}
+
+// TestVerifyFiles_MissingFromChunk flags a manifest file absent from the tar.
+func TestVerifyFiles_MissingFromChunk(t *testing.T) {
+	fileA := []byte("only a is present")
+	chunk := makeTarZst(t, map[string][]byte{"a.txt": fileA})
+
+	dl := &fakeDownloader{objects: map[string][]byte{"pfx/chunk-0": chunk}}
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "bkt", Prefix: "pfx",
+		CompressionType: "zstd", ChecksumAlgorithm: ChecksumAlgorithmSHA256,
+		Chunks: []ChunkEntry{{ID: 0, S3Key: "chunk-0"}},
+		Files: []FileEntry{
+			{Path: "a.txt", ChunkID: 0, Checksum: sha256hex(fileA)},
+			{Path: "b.txt", ChunkID: 0, Checksum: sha256hex([]byte("missing"))},
+		},
+	}
+
+	res, err := NewDeepVerifier(m, dl).VerifyFiles(context.Background())
+	require.NoError(t, err)
+	assert.False(t, res.Passed())
+	assert.Equal(t, 1, res.OK)
+	assert.Equal(t, 1, res.Missing)
+}
+
+// TestVerifyFiles_Unverifiable flags a file with no recorded checksum.
+func TestVerifyFiles_Unverifiable(t *testing.T) {
+	fileA := []byte("content")
+	chunk := makeTarZst(t, map[string][]byte{"a.txt": fileA})
+
+	dl := &fakeDownloader{objects: map[string][]byte{"pfx/chunk-0": chunk}}
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "bkt", Prefix: "pfx",
+		CompressionType: "zstd", ChecksumAlgorithm: ChecksumAlgorithmSHA256,
+		Chunks: []ChunkEntry{{ID: 0, S3Key: "chunk-0"}},
+		Files:  []FileEntry{{Path: "a.txt", ChunkID: 0, Checksum: ""}}, // no checksum
+	}
+
+	res, err := NewDeepVerifier(m, dl).VerifyFiles(context.Background())
+	require.NoError(t, err)
+	assert.False(t, res.Passed())
+	assert.Equal(t, 1, res.Unverifiable)
+}
+
+// TestVerifyFiles_SkipsDuplicates verifies deduplicated files aren't counted
+// (they don't have their own stored bytes).
+func TestVerifyFiles_SkipsDuplicates(t *testing.T) {
+	fileA := []byte("original")
+	chunk := makeTarZst(t, map[string][]byte{"a.txt": fileA})
+	dl := &fakeDownloader{objects: map[string][]byte{"pfx/chunk-0": chunk}}
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "bkt", Prefix: "pfx",
+		CompressionType: "zstd", ChecksumAlgorithm: ChecksumAlgorithmSHA256,
+		Chunks: []ChunkEntry{{ID: 0, S3Key: "chunk-0"}},
+		Files: []FileEntry{
+			{Path: "a.txt", ChunkID: 0, Checksum: sha256hex(fileA)},
+			{Path: "dup.txt", ChunkID: 0, IsDuplicate: true, Checksum: sha256hex(fileA)},
+		},
+	}
+	res, err := NewDeepVerifier(m, dl).VerifyFiles(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.TotalFiles, "duplicate excluded")
+	assert.True(t, res.Passed())
+}
+
+// TestTarNameToFileKey covers whole-file and split-part name parsing.
+func TestTarNameToFileKey(t *testing.T) {
+	p, part, isPart := tarNameToFileKey("dir/file.bin")
+	assert.Equal(t, "dir/file.bin", p)
+	assert.Equal(t, 0, part)
+	assert.False(t, isPart)
+
+	p, part, isPart = tarNameToFileKey("dir/big.bin.part3")
+	assert.Equal(t, "dir/big.bin", p)
+	assert.Equal(t, 3, part)
+	assert.True(t, isPart)
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -261,6 +261,33 @@ func (b *Builder) UpdateFileS3Keys(chunkID int, shardID int, s3Key string) {
 	}
 }
 
+// SetFileChecksums records per-file content hashes into the matching FileEntry
+// records for the given chunk (#271). Keys are FileEntry.Path, or "path#part"
+// for split-file parts; a whole-file key sets Checksum on every entry with that
+// path in the chunk, while a "path#part" key sets it on the matching part.
+// Files not present in the map are left unchanged (e.g. checksums disabled).
+func (b *Builder) SetFileChecksums(chunkID int, checksums map[string]string) {
+	if len(checksums) == 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for i := range b.manifest.Files {
+		f := &b.manifest.Files[i]
+		if f.ChunkID != chunkID {
+			continue
+		}
+		key := f.Path
+		if f.TotalParts > 1 {
+			key = fmt.Sprintf("%s#%d", f.Path, f.PartIndex)
+		}
+		if sum, ok := checksums[key]; ok {
+			f.Checksum = sum
+		}
+	}
+}
+
 // UpdateFileS3KeyByPath updates the S3Key, ShardID, and ChunkID for the single
 // FileEntry whose SourcePath matches path. Used by direct upload mode where each
 // file has its own S3 key (unlike chunk-based mode where all files in a chunk

--- a/pkg/pipeline/archiver.go
+++ b/pkg/pipeline/archiver.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"archive/tar"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -479,16 +481,6 @@ func (s *ArchiverStage) Process(ctx context.Context, job *Job) error {
 
 	// Archive creation goroutine
 	go func() {
-		defer func() {
-			_ = pw.Close()
-			// Issue #105: Return encoder to correct pool after work is done
-			if encoder != nil && encoderPool != nil {
-				// Close encoder to flush data, then return to pool
-				_ = encoder.Close()
-				encoderPool.Put(encoder)
-			}
-		}()
-
 		var tw *tar.Writer
 
 		if useCompression {
@@ -506,14 +498,32 @@ func (s *ArchiverStage) Process(ctx context.Context, job *Job) error {
 			atomic.AddInt64(&s.compressionTimeSaved, estimatedTimeSaved)
 		}
 
-		// Close tar writer to flush all data
+		// Close in the correct order so the FULL stream is flushed before the
+		// reader (uploader) sees EOF (#275). Defers run LIFO, so this registers
+		// the close chain that must run bottom-up: (1) flush the tar into the
+		// encoder, (2) flush/close the encoder into the pipe, (3) close the
+		// pipe. Closing pw before the encoder flushes its final zstd frame
+		// truncates the last file — the bug this ordering fixes.
+		defer func() {
+			_ = pw.Close() // (3) runs last: reader gets EOF only after all data
+		}()
+		if useCompression {
+			defer func() {
+				// (2) flush the encoder's final frame into pw, then return it.
+				_ = encoder.Close()
+				if encoderPool != nil {
+					encoderPool.Put(encoder)
+				}
+			}()
+		}
+		// (1) runs first: flush all tar data into the encoder/pipe.
 		defer func() {
 			_ = tw.Close()
 		}()
 
 		// Add all files to archive with parallel I/O optimization
 		var totalSize int64
-		if err := s.addFilesWithParallelIO(tw, job.Chunk.Files, &totalSize); err != nil {
+		if err := s.addFilesWithParallelIO(tw, job, job.Chunk.Files, &totalSize); err != nil {
 			_ = pw.CloseWithError(err)
 			return
 		}
@@ -706,11 +716,11 @@ type fileData struct {
 // addFilesWithParallelIO adds files to archive with parallel I/O optimization
 // Files are read in parallel by a worker pool, but written to tar sequentially
 // to maintain tar format integrity. This provides 4-8x speedup for I/O bound workloads.
-func (s *ArchiverStage) addFilesWithParallelIO(tw *tar.Writer, files []chunking.File, totalSize *int64) error {
+func (s *ArchiverStage) addFilesWithParallelIO(tw *tar.Writer, job *Job, files []chunking.File, totalSize *int64) error {
 	// For very small file counts, parallel I/O overhead isn't worth it
 	if len(files) < 3 {
 		for _, file := range files {
-			if err := s.addFileToArchiveWithMetadata(tw, file); err != nil {
+			if err := s.addFileToArchiveWithMetadata(tw, job, file); err != nil {
 				return err
 			}
 			*totalSize += file.Size
@@ -850,7 +860,7 @@ func (s *ArchiverStage) addFilesWithParallelIO(tw *tar.Writer, files []chunking.
 		}
 
 		// Write to tar sequentially (fast, data already in memory)
-		if err := s.addFileToArchiveFromMemoryWithMetadata(tw, fd.File, fd.Info, fd.Data); err != nil {
+		if err := s.addFileToArchiveFromMemoryWithMetadata(tw, job, fd.File, fd.Info, fd.Data); err != nil {
 			close(fileChan)
 			return err
 		}
@@ -878,7 +888,7 @@ func (s *ArchiverStage) addFilesWithParallelIO(tw *tar.Writer, files []chunking.
 
 // addFileToArchiveWithMetadata adds a file to archive with full metadata support (Phase 5)
 // Supports partial file reads with offset/length for split files
-func (s *ArchiverStage) addFileToArchiveWithMetadata(tw *tar.Writer, file chunking.File) error {
+func (s *ArchiverStage) addFileToArchiveWithMetadata(tw *tar.Writer, job *Job, file chunking.File) error {
 	// Open file
 	f, err := os.Open(file.Path)
 	if err != nil {
@@ -937,16 +947,47 @@ func (s *ArchiverStage) addFileToArchiveWithMetadata(tw *tar.Writer, file chunki
 		return fmt.Errorf("failed to write tar header: %w", err)
 	}
 
-	// Copy file content with length limit (platform-specific zero-copy)
-	if err := s.copyFileToArchive(tw, f, length); err != nil {
-		return fmt.Errorf("failed to write file content: %w", err)
+	// Copy file content with length limit. When per-file checksums are enabled
+	// (#271) we hash the content as it's copied. This routes through a
+	// TeeReader, which bypasses the platform zero-copy (splice/sendfile) path —
+	// an accepted trade for the integrity guarantee, and this small-chunk
+	// (<3 files) branch is not the throughput-critical path (that's the
+	// in-memory parallel path). With checksums off, the fast path is unchanged.
+	if job != nil && s.config.FileChecksums {
+		hasher := sha256.New()
+		if err := s.copyFileToArchivePlain(tw, io.TeeReader(io.LimitReader(f, length), hasher)); err != nil {
+			return fmt.Errorf("failed to write file content: %w", err)
+		}
+		job.SetFileChecksum(fileChecksumKey(file), hex.EncodeToString(hasher.Sum(nil)))
+	} else {
+		if err := s.copyFileToArchive(tw, f, length); err != nil {
+			return fmt.Errorf("failed to write file content: %w", err)
+		}
 	}
 
 	return nil
 }
 
+// copyFileToArchivePlain copies from an arbitrary reader (e.g. a TeeReader used
+// for checksumming) to the tar writer. Unlike copyFileToArchive it can't use
+// the platform zero-copy path because the source isn't a plain *os.File.
+func (s *ArchiverStage) copyFileToArchivePlain(tw *tar.Writer, r io.Reader) error {
+	_, err := io.Copy(tw, r)
+	return err
+}
+
+// fileChecksumKey returns the map key under which a file's (or split part's)
+// content hash is recorded on the job. Whole files key by path; split-file
+// parts key by "path#partIndex" so each part's hash is distinct (#271).
+func fileChecksumKey(file chunking.File) string {
+	if file.TotalParts > 1 {
+		return fmt.Sprintf("%s#%d", file.Path, file.PartIndex)
+	}
+	return file.Path
+}
+
 // addFileToArchiveFromMemoryWithMetadata adds a file to tar from in-memory data with metadata (Phase 5)
-func (s *ArchiverStage) addFileToArchiveFromMemoryWithMetadata(tw *tar.Writer, file chunking.File, info os.FileInfo, data []byte) error {
+func (s *ArchiverStage) addFileToArchiveFromMemoryWithMetadata(tw *tar.Writer, job *Job, file chunking.File, info os.FileInfo, data []byte) error {
 	// Create tar header
 	header, err := tar.FileInfoHeader(info, "")
 	if err != nil {
@@ -980,6 +1021,13 @@ func (s *ArchiverStage) addFileToArchiveFromMemoryWithMetadata(tw *tar.Writer, f
 	// Write data from memory
 	if _, err := tw.Write(data); err != nil {
 		return fmt.Errorf("failed to write file content: %w", err)
+	}
+
+	// #271: the file content is already in memory here, so hashing is a single
+	// extra pass with no additional I/O.
+	if job != nil && s.config.FileChecksums {
+		sum := sha256.Sum256(data)
+		job.SetFileChecksum(fileChecksumKey(file), hex.EncodeToString(sum[:]))
 	}
 
 	return nil

--- a/pkg/pipeline/archiver_test.go
+++ b/pkg/pipeline/archiver_test.go
@@ -1,10 +1,15 @@
 package pipeline
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/scttfrdmn/cargoship/pkg/chunking"
 	"github.com/scttfrdmn/cargoship/pkg/compression"
 	"github.com/stretchr/testify/assert"
@@ -542,4 +547,74 @@ func TestArchiverStage_Worker(t *testing.T) {
 		err = stage.Stop()
 		assert.NoError(t, err)
 	})
+}
+
+// TestArchiverStage_Process_NoTruncation is the #275 regression test: it drives
+// a real chunk of multiple files (including highly-compressible content, which
+// exposed the lost-final-flush bug) through Process and asserts every file
+// decodes back to its full declared length with a clean tar EOF. Before the
+// defer-ordering fix, the last file's zstd tail was dropped (short by a block).
+func TestArchiverStage_Process_NoTruncation(t *testing.T) {
+	// Create highly-compressible test files (constant bytes) — the case that
+	// compressed small enough to reveal the truncated final frame.
+	dir := t.TempDir()
+	const nFiles = 5
+	const fileSize = 512 * 1024 // 512KB each
+	var files []chunking.File
+	want := make(map[string]int64)
+	for i := 0; i < nFiles; i++ {
+		content := make([]byte, fileSize)
+		for j := range content {
+			content[j] = byte(i)
+		}
+		path := fmt.Sprintf("%s/file%d.dat", dir, i)
+		require.NoError(t, os.WriteFile(path, content, 0644))
+		files = append(files, chunking.File{Path: path, Size: fileSize})
+		want[path] = fileSize
+	}
+
+	config := &ArchiverConfig{Workers: 2, CompressionType: "zstd"}
+	input := make(chan *Job, 1)
+	output := make(chan *Job, 1)
+	stage, err := NewArchiverStage(config, input, output)
+	require.NoError(t, err)
+	defer func() { _ = stage.Stop() }()
+
+	job := &Job{ID: 0, Chunk: chunking.Chunk{ID: 0, Files: files, TotalSize: nFiles * fileSize}}
+	require.NoError(t, stage.Process(context.Background(), job))
+
+	out := <-output
+	require.NotNil(t, out.Archive)
+
+	// Read the full archive stream, decompress, and confirm every file entry
+	// reads back to its declared size with a clean EOF (no truncation).
+	raw, err := io.ReadAll(out.Archive)
+	require.NoError(t, err)
+	_ = out.Archive.Close()
+
+	dec, err := zstd.NewReader(bytes.NewReader(raw))
+	require.NoError(t, err)
+	defer dec.Close()
+	tr := tar.NewReader(dec)
+
+	got := make(map[string]int64)
+	for {
+		hdr, terr := tr.Next()
+		if terr == io.EOF {
+			break
+		}
+		require.NoError(t, terr, "tar stream must not be truncated")
+		if hdr.Name == ".padding" {
+			continue
+		}
+		n, cerr := io.Copy(io.Discard, tr)
+		require.NoError(t, cerr, "file %q content must not be truncated", hdr.Name)
+		require.Equal(t, hdr.Size, n, "file %q read %d of %d declared bytes", hdr.Name, n, hdr.Size)
+		got[hdr.Name] = n
+	}
+
+	require.Len(t, got, nFiles, "all files must be present in the archive")
+	for path, size := range want {
+		assert.Equal(t, size, got[path], "file %q should be full length", path)
+	}
 }

--- a/pkg/pipeline/manifest_integration_test.go
+++ b/pkg/pipeline/manifest_integration_test.go
@@ -77,6 +77,7 @@ func TestManifestIntegration_Generation(t *testing.T) {
 		UploadID:          uploadID,
 		EnableMultiPrefix: true,
 		ShardCount:        4,
+		FileChecksums:     true, // #271: capture per-file content checksums
 	}
 
 	// Create and run pipeline
@@ -157,6 +158,22 @@ func TestManifestIntegration_Generation(t *testing.T) {
 		"deep verify should pass on fresh upload: %d OK, %d mismatched, %d missing, %d unverifiable",
 		deepRes.OK, deepRes.Mismatched, deepRes.Missing, deepRes.Unverifiable)
 	assert.Equal(t, len(m.Chunks), deepRes.OK, "every chunk should verify OK")
+
+	// #271 part 2: per-file content checksums. Every non-duplicate file should
+	// carry a checksum captured during archiving, and file-level deep verify
+	// (extract each file, recompute its hash) should PASS on the fresh upload.
+	for i, f := range m.Files {
+		if f.IsDuplicate {
+			continue
+		}
+		assert.NotEmpty(t, f.Checksum, "file %d (%s) should have a content checksum", i, f.Path)
+		assert.Len(t, f.Checksum, 64, "file %d checksum should be a hex SHA-256", i)
+	}
+	fileRes, err := manifest.NewDeepVerifier(m, s3Client).VerifyFiles(ctx)
+	require.NoError(t, err)
+	assert.True(t, fileRes.Passed(),
+		"file-level deep verify should pass on fresh upload: %d OK, %d mismatched, %d missing, %d unverifiable",
+		fileRes.OK, fileRes.Mismatched, fileRes.Missing, fileRes.Unverifiable)
 
 	// #271: corruption is detected. Overwrite one chunk object with garbage and
 	// confirm deep verify now FAILS with a mismatch on that chunk. Derive the

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -499,6 +499,8 @@ func (p *Pipeline) startStages(ctx context.Context, rootPath string) error {
 		EnablePadding:        p.config.EnableArchivePadding,
 		MaxPaddingRatio:      p.config.MaxPaddingRatio,
 		UseLowEntropyPadding: true, // S3-optimized zero-byte padding
+		// #271: per-file content checksums (on by default; see PipelineConfig).
+		FileChecksums: p.config.FileChecksums,
 	}
 
 	// Create uploader stage (real S3 or simulated)

--- a/pkg/pipeline/s3_multiprefix_uploader.go
+++ b/pkg/pipeline/s3_multiprefix_uploader.go
@@ -383,6 +383,10 @@ func (s *S3MultiPrefixUploaderStage) processJob(ctx context.Context, job *Job, p
 			// Update file entries with S3 key and shard ID
 			builder.UpdateFileS3Keys(job.Chunk.ID, shardID, job.S3Key)
 
+			// #271: record per-file content checksums captured during archiving
+			// (no-op when file checksums are disabled).
+			builder.SetFileChecksums(job.Chunk.ID, job.FileChecksums())
+
 			// Add chunk entry (#271: record the SHA-256 of the uploaded archive)
 			builder.AddChunk(manifest.ChunkEntry{
 				ID:               job.Chunk.ID,

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -42,6 +42,40 @@ type Job struct {
 	// reads job.Archive. Valid only after the upload has consumed the stream;
 	// read via ArchiveChecksum(). Nil when checksum capture isn't wired.
 	archiveHasher *hashingReadCloser
+
+	// #271: per-file content SHA-256 (hex) captured by the archiver, keyed by
+	// FileEntry.Path. For split files the value is the hash of that part, keyed
+	// by "path#partIndex". Populated only when FileChecksums is enabled; read
+	// into FileEntry.Checksum by the uploader when the chunk is recorded.
+	fileChecksums   map[string]string
+	fileChecksumsMu sync.Mutex
+}
+
+// SetFileChecksum records the content hash for one archived file/part
+// (thread-safe; the archiver writes tar sequentially but this guards against
+// future concurrency). Keyed by path, or "path#part" for split-file parts.
+func (j *Job) SetFileChecksum(key, hexDigest string) {
+	j.fileChecksumsMu.Lock()
+	defer j.fileChecksumsMu.Unlock()
+	if j.fileChecksums == nil {
+		j.fileChecksums = make(map[string]string)
+	}
+	j.fileChecksums[key] = hexDigest
+}
+
+// FileChecksums returns a copy of the captured per-file content hashes, or nil
+// if none were captured (checksum capture disabled).
+func (j *Job) FileChecksums() map[string]string {
+	j.fileChecksumsMu.Lock()
+	defer j.fileChecksumsMu.Unlock()
+	if len(j.fileChecksums) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(j.fileChecksums))
+	for k, v := range j.fileChecksums {
+		out[k] = v
+	}
+	return out
 }
 
 // ArchiveChecksum returns the hex SHA-256 of the uploaded archive stream, or ""
@@ -197,6 +231,12 @@ type PipelineConfig struct {
 	EnableManifest bool   // Enable manifest generation (default: true for real S3)
 	SourcePath     string // Original source path for manifest
 
+	// #271: FileChecksums captures a per-file content SHA-256 during archiving
+	// so `verify --deep` can confirm end-to-end source->restore identity.
+	// On by default; the upload command exposes --no-file-checksums to disable
+	// it for max-throughput bulk uploads.
+	FileChecksums bool
+
 	// Deduplication configuration (Issue #108)
 	EnableDeduplication bool // Enable cross-shard file deduplication (default: false)
 
@@ -350,6 +390,12 @@ type ArchiverConfig struct {
 	EnablePadding        bool    // Enable zero-byte padding to reach target compressed sizes
 	MaxPaddingRatio      float64 // Maximum allowed padding ratio (default: 0.25 = 25%)
 	UseLowEntropyPadding bool    // Use low-entropy (zero-byte) padding (default: true for S3 optimization)
+
+	// #271: FileChecksums enables per-file content hashing during archiving so
+	// FileEntry.Checksum is populated for every file and `verify --deep` can
+	// confirm end-to-end source->restore identity. On by default; disable for
+	// max-throughput bulk uploads (adds a SHA-256 pass over each file's bytes).
+	FileChecksums bool
 }
 
 // UploaderConfig configures the uploader stage


### PR DESCRIPTION
Completes #271 (part 2 of 2). Builds on PR #272 (chunk-level) to give **end-to-end source→restore identity**, and along the way fixes a silent data-loss bug (#275) that per-file verification uncovered.

## Per-file checksum capture (upload)

- The archiver hashes each file's content during archiving: the in-memory parallel path (default for ≥3 files) hashes the bytes it already holds — no extra I/O; the small-chunk disk path uses a TeeReader (trading the platform splice/sendfile zero-copy for the hash). Digests are collected on the `Job` and written to `FileEntry.Checksum` via `Builder.SetFileChecksums`. Split-file parts hash per part.
- **On by default**; `cargoship upload --no-file-checksums` opts out for max-throughput bulk jobs (`PipelineConfig.FileChecksums` → `ArchiverConfig`).

## File-level verification (consume)

- `DeepVerifier.VerifyFiles` re-downloads each chunk, decompresses, walks the tar, recomputes each file's SHA-256, and compares to `FileEntry.Checksum`. Duplicates skipped; files missing from their chunk → `missing`; no-checksum files → `unverifiable`.
- `verify --deep` now runs **chunk-level AND file-level** checks and exits non-zero on any corrupted/missing/unverifiable file.

## 🐛 Fixes #275 — silent data loss (found by this work)

The archiver goroutine's deferred closes ran in the wrong order: `pw.Close()` fired **before** `encoder.Close()` flushed the final zstd frame, **truncating the last file in every compressed chunk** (short by a ~3KB zstd block). Reordered so the close chain runs tar → encoder → pipe bottom-up, flushing the full stream before the uploader sees EOF.

**The chunk-level checksum did NOT catch this** — it hashed the truncated bytes as-uploaded, so object integrity looked fine. Only per-file content verification detected it. This is precisely the silent-corruption class the trust epic (#270) exists to catch, caught by its own tooling.

## Tests

- `VerifyFiles` unit tests: ok / corrupted-file / missing-from-chunk / unverifiable / duplicate-skip, plus split-name parsing.
- **`TestArchiverStage_Process_NoTruncation`** (#275 regression): drives a multi-file chunk through `Process` and asserts every file decodes to full declared length with a clean tar EOF. (Verified against the emulator: last file was `6288384/6291456` bytes before the fix, full `6291456` after.)
- Emulator integration test extended: every file carries a checksum, and file-level deep verify PASSES on a fresh upload.

Parent: #270. Closes #271, #275.