### PR TITLE
feat: real-manifest schema validation + version-compat fixtures (#274 PR2)

### DIFF
--- a/pkg/manifest/schema_validate.go
+++ b/pkg/manifest/schema_validate.go
@@ -22,7 +22,12 @@ func ValidateAgainstSchema(manifestJSON []byte) ([]string, error) {
 	if err := json.Unmarshal(SchemaJSON, &schema); err != nil {
 		return nil, fmt.Errorf("parse embedded schema: %w", err)
 	}
-	var doc interface{}
+	// Decoding into interface{} is intentional and required: a schema validator
+	// must inspect an arbitrary, untyped document (including unexpected/extra
+	// fields). Unmarshaling into a typed struct would silently drop exactly the
+	// deviations we exist to detect. The decoded value is only walked/compared,
+	// never used to construct types or drive behavior.
+	var doc interface{} //nolint:gosec // nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- schema validation requires an untyped document; value is only inspected
 	if err := json.Unmarshal(manifestJSON, &doc); err != nil {
 		return nil, fmt.Errorf("parse manifest: %w", err)
 	}

--- a/pkg/manifest/schema_validate.go
+++ b/pkg/manifest/schema_validate.go
@@ -1,0 +1,192 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ValidateAgainstSchema checks that a manifest JSON document conforms to the
+// embedded manifest schema (schema.json). It is a focused validator for the
+// draft-07 subset the manifest schema actually uses — object/array/string/
+// integer/number/boolean types (including ["object","null"] unions), required
+// field lists, declared properties, local "#/definitions/..." $refs, and typed
+// array items. It is NOT a general-purpose JSON Schema engine; it exists so
+// real uploaded manifests can be proven to comply with the documented schema
+// (#274) without adding a dependency.
+//
+// It returns a sorted list of human-readable violations (empty means valid).
+func ValidateAgainstSchema(manifestJSON []byte) ([]string, error) {
+	var schema map[string]json.RawMessage
+	if err := json.Unmarshal(SchemaJSON, &schema); err != nil {
+		return nil, fmt.Errorf("parse embedded schema: %w", err)
+	}
+	var doc interface{}
+	if err := json.Unmarshal(manifestJSON, &doc); err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+
+	v := &schemaValidator{root: schema}
+	v.validate("(root)", schema, doc)
+	sort.Strings(v.errs)
+	return v.errs, nil
+}
+
+type schemaValidator struct {
+	root map[string]json.RawMessage
+	errs []string
+}
+
+func (v *schemaValidator) fail(path, format string, args ...interface{}) {
+	v.errs = append(v.errs, path+": "+fmt.Sprintf(format, args...))
+}
+
+// resolveRef returns the schema object a "#/definitions/x" ref points at.
+func (v *schemaValidator) resolveRef(ref string) (map[string]json.RawMessage, bool) {
+	const prefix = "#/definitions/"
+	if !strings.HasPrefix(ref, prefix) {
+		return nil, false
+	}
+	var defs map[string]json.RawMessage
+	if raw, ok := v.root["definitions"]; ok {
+		if err := json.Unmarshal(raw, &defs); err != nil {
+			return nil, false
+		}
+	}
+	raw, ok := defs[strings.TrimPrefix(ref, prefix)]
+	if !ok {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, false
+	}
+	return obj, true
+}
+
+// validate checks value against a schema node.
+func (v *schemaValidator) validate(path string, node map[string]json.RawMessage, value interface{}) {
+	// Follow a local $ref first.
+	if raw, ok := node["$ref"]; ok {
+		var ref string
+		if err := json.Unmarshal(raw, &ref); err == nil {
+			if target, ok := v.resolveRef(ref); ok {
+				v.validate(path, target, value)
+			} else {
+				v.fail(path, "unresolvable $ref %q", ref)
+			}
+		}
+		return
+	}
+
+	if raw, ok := node["type"]; ok {
+		if !v.checkType(path, raw, value) {
+			return // wrong type; deeper checks would be noise
+		}
+	}
+
+	// Object: required + properties.
+	if obj, isObj := value.(map[string]interface{}); isObj {
+		if raw, ok := node["required"]; ok {
+			var required []string
+			_ = json.Unmarshal(raw, &required)
+			for _, r := range required {
+				if _, present := obj[r]; !present {
+					v.fail(path, "missing required field %q", r)
+				}
+			}
+		}
+		if raw, ok := node["properties"]; ok {
+			var props map[string]json.RawMessage
+			_ = json.Unmarshal(raw, &props)
+			for name, propSchemaRaw := range props {
+				child, present := obj[name]
+				if !present {
+					continue // presence enforced by "required", not here
+				}
+				var propSchema map[string]json.RawMessage
+				if err := json.Unmarshal(propSchemaRaw, &propSchema); err == nil {
+					v.validate(path+"."+name, propSchema, child)
+				}
+			}
+		}
+	}
+
+	// Array items.
+	if arr, isArr := value.([]interface{}); isArr {
+		if raw, ok := node["items"]; ok {
+			var itemSchema map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &itemSchema); err == nil {
+				for i, item := range arr {
+					v.validate(fmt.Sprintf("%s[%d]", path, i), itemSchema, item)
+				}
+			}
+		}
+	}
+}
+
+// checkType validates value against the schema "type" (a string or array of
+// strings). Returns false on mismatch. JSON numbers decode to float64; an
+// "integer" type accepts a float64 with no fractional part.
+func (v *schemaValidator) checkType(path string, raw json.RawMessage, value interface{}) bool {
+	var types []string
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		types = []string{single}
+	} else if err := json.Unmarshal(raw, &types); err != nil {
+		return true // unrecognized type spec; don't block
+	}
+
+	for _, ty := range types {
+		if matchesType(ty, value) {
+			return true
+		}
+	}
+	v.fail(path, "expected type %v, got %s", types, jsonTypeOf(value))
+	return false
+}
+
+func matchesType(ty string, value interface{}) bool {
+	switch ty {
+	case "null":
+		return value == nil
+	case "object":
+		_, ok := value.(map[string]interface{})
+		return ok
+	case "array":
+		_, ok := value.([]interface{})
+		return ok
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "number":
+		_, ok := value.(float64)
+		return ok
+	case "integer":
+		f, ok := value.(float64)
+		return ok && f == float64(int64(f))
+	}
+	return false
+}
+
+func jsonTypeOf(value interface{}) string {
+	switch value.(type) {
+	case nil:
+		return "null"
+	case map[string]interface{}:
+		return "object"
+	case []interface{}:
+		return "array"
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
+	case float64:
+		return "number"
+	}
+	return "unknown"
+}

--- a/pkg/manifest/schema_validate_test.go
+++ b/pkg/manifest/schema_validate_test.go
@@ -1,0 +1,141 @@
+package manifest
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildRealManifest constructs a manifest through the actual Builder API the
+// pipeline uses, so the validator is exercised against genuine CargoShip output
+// shape (not a hand-rolled document).
+func buildRealManifest(t *testing.T) *Manifest {
+	t.Helper()
+	b, err := NewBuilder("20260724-abc123", "/tmp/src", "example-bucket", "backups", "us-east-1")
+	require.NoError(t, err)
+
+	b.SetShardCount(1)
+	b.AddFile(FileEntry{
+		Path: "data/a.txt", Size: 100, ModTime: time.Unix(1_700_000_000, 0),
+		ChunkID: 0, ShardID: 0, S3Key: "backups/uploads/20260724-abc123/shard-0/chunk-0.tar.zst",
+		Checksum: "abc123",
+	})
+	b.AddChunk(ChunkEntry{
+		ID: 0, ShardID: 0, S3Key: "backups/uploads/20260724-abc123/shard-0/chunk-0.tar.zst",
+		FileCount: 1, FilePaths: []string{"data/a.txt"},
+		UncompressedSize: 100, CompressedSize: 50,
+		CreatedAt: time.Unix(1_700_000_000, 0), UploadedAt: time.Unix(1_700_000_060, 0),
+		Checksum: "def456",
+	})
+	b.UpdateShardStats(0, "backups/uploads/20260724-abc123/shard-0/chunk-0.tar.zst", 1, 100, 50)
+	b.SetCompression("zstd", 3, 0.5)
+	return b.Finalize()
+}
+
+// TestValidateAgainstSchema_RealOutput proves that a manifest produced by the
+// real Builder validates against the embedded schema (#274) — closing the
+// "real CargoShip output complies with the spec" half of compliance.
+func TestValidateAgainstSchema_RealOutput(t *testing.T) {
+	m := buildRealManifest(t)
+	data, err := m.ToJSON()
+	require.NoError(t, err)
+
+	violations, err := ValidateAgainstSchema(data)
+	require.NoError(t, err)
+	assert.Empty(t, violations, "real manifest should satisfy the schema; violations: %v", violations)
+}
+
+// TestValidateAgainstSchema_MissingRequired flags a dropped required field.
+func TestValidateAgainstSchema_MissingRequired(t *testing.T) {
+	m := buildRealManifest(t)
+	data, err := m.ToJSON()
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &obj))
+	delete(obj, "bucket") // required
+	mangled, _ := json.Marshal(obj)
+
+	violations, err := ValidateAgainstSchema(mangled)
+	require.NoError(t, err)
+	assert.Contains(t, violationsJoined(violations), `missing required field "bucket"`)
+}
+
+// TestValidateAgainstSchema_WrongType flags a field with the wrong JSON type.
+func TestValidateAgainstSchema_WrongType(t *testing.T) {
+	m := buildRealManifest(t)
+	data, err := m.ToJSON()
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &obj))
+	obj["total_files"] = "not-a-number" // should be integer
+	mangled, _ := json.Marshal(obj)
+
+	violations, err := ValidateAgainstSchema(mangled)
+	require.NoError(t, err)
+	assert.Contains(t, violationsJoined(violations), "total_files")
+}
+
+// TestValidateAgainstSchema_NestedWrongType flags a bad field inside a file entry.
+func TestValidateAgainstSchema_NestedWrongType(t *testing.T) {
+	m := buildRealManifest(t)
+	data, err := m.ToJSON()
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &obj))
+	files := obj["files"].([]interface{})
+	files[0].(map[string]interface{})["size"] = "big" // should be integer
+	mangled, _ := json.Marshal(obj)
+
+	violations, err := ValidateAgainstSchema(mangled)
+	require.NoError(t, err)
+	assert.Contains(t, violationsJoined(violations), "files[0].size")
+}
+
+// TestValidateAgainstSchema_MissingNestedRequired flags a chunk missing s3_key.
+func TestValidateAgainstSchema_MissingNestedRequired(t *testing.T) {
+	m := buildRealManifest(t)
+	data, err := m.ToJSON()
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &obj))
+	chunks := obj["chunks"].([]interface{})
+	delete(chunks[0].(map[string]interface{}), "s3_key")
+	mangled, _ := json.Marshal(obj)
+
+	violations, err := ValidateAgainstSchema(mangled)
+	require.NoError(t, err)
+	assert.Contains(t, violationsJoined(violations), `chunks[0]: missing required field "s3_key"`)
+}
+
+// TestValidateAgainstSchema_OptionalNullBlocks confirms nullable optional blocks
+// (encryption/deduplication/etc.) validate whether absent, null, or an object.
+func TestValidateAgainstSchema_OptionalNullBlocks(t *testing.T) {
+	m := buildRealManifest(t)
+	data, err := m.ToJSON()
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &obj))
+	obj["encryption"] = nil                                        // null allowed
+	obj["deduplication"] = map[string]interface{}{"enabled": true} // object allowed
+	mangled, _ := json.Marshal(obj)
+
+	violations, err := ValidateAgainstSchema(mangled)
+	require.NoError(t, err)
+	assert.Empty(t, violations, "nullable optional blocks should validate: %v", violations)
+}
+
+func violationsJoined(v []string) string {
+	out := ""
+	for _, s := range v {
+		out += s + "\n"
+	}
+	return out
+}

--- a/pkg/manifest/testdata/manifests/v1.0.json
+++ b/pkg/manifest/testdata/manifests/v1.0.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "upload_id": "20231114-legacy1",
+  "created_at": "2023-11-14T22:13:20Z",
+  "completed_at": "2023-11-14T22:14:20Z",
+  "source_path": "/tmp/src",
+  "hostname": "fixture-host",
+  "bucket": "example-bucket",
+  "prefix": "backups",
+  "region": "us-east-1",
+  "total_files": 1,
+  "total_bytes": 100,
+  "total_chunks": 1,
+  "shard_count": 1,
+  "compression_type": "zstd",
+  "compression_level": 3,
+  "compression_ratio": 0.5,
+  "files": [
+    {
+      "path": "data/a.txt",
+      "size": 100,
+      "mod_time": "2023-11-14T22:00:00Z",
+      "chunk_id": 0,
+      "shard_id": 0,
+      "s3_key": "backups/uploads/20231114-legacy1/shard-0/chunk-0.tar.zst"
+    }
+  ],
+  "chunks": [
+    {
+      "id": 0,
+      "shard_id": 0,
+      "s3_key": "backups/uploads/20231114-legacy1/shard-0/chunk-0.tar.zst",
+      "file_count": 1,
+      "file_paths": ["data/a.txt"],
+      "uncompressed_size": 100,
+      "compressed_size": 50,
+      "created_at": "2023-11-14T22:13:20Z",
+      "uploaded_at": "2023-11-14T22:14:20Z"
+    }
+  ],
+  "shards": [
+    {
+      "id": 0,
+      "prefix": "backups/uploads/20231114-legacy1/shard-0",
+      "chunk_count": 1,
+      "file_count": 1,
+      "uncompressed_size": 100,
+      "compressed_size": 50,
+      "chunk_keys": ["backups/uploads/20231114-legacy1/shard-0/chunk-0.tar.zst"]
+    }
+  ]
+}

--- a/pkg/manifest/testdata/manifests/v2.0.json
+++ b/pkg/manifest/testdata/manifests/v2.0.json
@@ -1,0 +1,59 @@
+{
+  "version": "2.0",
+  "upload_id": "20260724-fixture",
+  "created_at": "2026-07-24T00:00:00Z",
+  "completed_at": "2026-07-24T00:01:00Z",
+  "source_path": "/tmp/src",
+  "hostname": "fixture-host",
+  "bucket": "example-bucket",
+  "prefix": "backups",
+  "region": "us-east-1",
+  "total_files": 1,
+  "total_bytes": 100,
+  "total_chunks": 1,
+  "shard_count": 1,
+  "compression_type": "zstd",
+  "compression_level": 3,
+  "compression_ratio": 0.5,
+  "checksum_algorithm": "sha256",
+  "files": [
+    {
+      "path": "data/a.txt",
+      "size": 100,
+      "mod_time": "2023-11-14T22:13:20Z",
+      "chunk_id": 0,
+      "shard_id": 0,
+      "s3_key": "backups/uploads/20260724-fixture/shard-0/chunk-0.tar.zst",
+      "checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  ],
+  "chunks": [
+    {
+      "id": 0,
+      "shard_id": 0,
+      "s3_key": "backups/uploads/20260724-fixture/shard-0/chunk-0.tar.zst",
+      "file_count": 1,
+      "file_paths": [
+        "data/a.txt"
+      ],
+      "uncompressed_size": 100,
+      "compressed_size": 50,
+      "created_at": "2023-11-14T22:13:20Z",
+      "uploaded_at": "2023-11-14T22:14:20Z",
+      "checksum": "abc"
+    }
+  ],
+  "shards": [
+    {
+      "id": 0,
+      "prefix": "backups/uploads/20260724-fixture/shard-0",
+      "chunk_count": 1,
+      "file_count": 1,
+      "uncompressed_size": 100,
+      "compressed_size": 50,
+      "chunk_keys": [
+        "backups/uploads/20260724-fixture/shard-0/chunk-0.tar.zst"
+      ]
+    }
+  ]
+}

--- a/pkg/manifest/version_fixtures_test.go
+++ b/pkg/manifest/version_fixtures_test.go
@@ -1,0 +1,62 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVersionFixturesParseAndValidate is the version-compatibility guard (#274):
+// committed manifest fixtures for each supported format version must keep
+// parsing via FromJSON AND satisfy the embedded schema. If a future change to
+// the structs or schema breaks an older version, this fails — so a version bump
+// can't silently orphan archives written by an earlier CargoShip.
+func TestVersionFixturesParseAndValidate(t *testing.T) {
+	fixtures := []struct {
+		file        string
+		wantVersion string
+	}{
+		{"v2.0.json", "2.0"},
+		{"v1.0.json", "1.0"},
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("testdata", "manifests", f.file))
+			require.NoError(t, err, "fixture must exist")
+
+			// 1. It must still parse through the public loader.
+			m, err := FromJSON(data)
+			require.NoError(t, err, "%s must parse via FromJSON", f.file)
+			assert.Equal(t, f.wantVersion, m.Version)
+			assert.NotEmpty(t, m.Files, "parsed manifest should retain files")
+			assert.NotEmpty(t, m.Chunks, "parsed manifest should retain chunks")
+
+			// 2. It must satisfy the embedded schema.
+			violations, err := ValidateAgainstSchema(data)
+			require.NoError(t, err)
+			assert.Empty(t, violations, "%s must satisfy the schema; violations: %v", f.file, violations)
+		})
+	}
+}
+
+// TestVersionFixture_RoundTripReserialize confirms a parsed fixture re-serializes
+// to schema-valid JSON (a parse that silently dropped required data would fail
+// re-validation).
+func TestVersionFixture_RoundTripReserialize(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "manifests", "v2.0.json"))
+	require.NoError(t, err)
+
+	m, err := FromJSON(data)
+	require.NoError(t, err)
+
+	reserialized, err := m.ToJSON()
+	require.NoError(t, err)
+
+	violations, err := ValidateAgainstSchema(reserialized)
+	require.NoError(t, err)
+	assert.Empty(t, violations, "re-serialized manifest must still satisfy the schema: %v", violations)
+}

--- a/pkg/pipeline/manifest_integration_test.go
+++ b/pkg/pipeline/manifest_integration_test.go
@@ -112,6 +112,15 @@ func TestManifestIntegration_Generation(t *testing.T) {
 	m, err := manifest.FromJSONCompressed(manifestBytes)
 	require.NoError(t, err, "Manifest should deserialize successfully")
 
+	// #274: a REAL uploaded manifest must satisfy the published JSON Schema.
+	// This is the "real output complies with the spec" compliance check —
+	// distinct from the struct↔schema drift test, which only checks shapes.
+	realJSON, err := m.ToJSON()
+	require.NoError(t, err)
+	schemaViolations, err := manifest.ValidateAgainstSchema(realJSON)
+	require.NoError(t, err)
+	assert.Empty(t, schemaViolations, "uploaded manifest must satisfy schema.json; violations: %v", schemaViolations)
+
 	// Verify manifest contents
 	assert.Equal(t, uploadID, m.UploadID, "Upload ID should match")
 	assert.Equal(t, bucket, m.Bucket, "Bucket should match")


### PR DESCRIPTION
Second and final PR for #274. Builds on PR #277 (schema + drift + independent reader) to close the compliance leg: **prove real output conforms, and guard older versions.**

## Changes

- **`ValidateAgainstSchema`** — a dependency-free validator for the draft-07 subset `schema.json` actually uses (`type` incl. `["object","null"]` unions, `required`, `properties`, local `$ref`, typed array `items`). Returns human-readable violations. Deliberately **not** a general JSON-Schema engine — scoped to the manifest so we add **no dependency** (per CLAUDE.md's stdlib-first rule).
- **Real-output compliance**: the emulator round-trip integration test now validates the **actual uploaded manifest** against `schema.json` — distinct from the struct↔schema drift test (which only checks shapes). Unit tests validate a manifest built via the real `Builder` and confirm missing-required / wrong-type / nested-wrong-type / missing-nested-required are all caught.
- **Version-compat fixtures**: committed `testdata/manifests/v2.0.json` (generated from the real Builder, then normalized to deterministic values) and `v1.0.json` (legacy). Both must keep **parsing via `FromJSON` AND satisfying the schema**, so a version bump can't silently orphan archives written by an earlier CargoShip. Plus a parse→reserialize→revalidate round-trip.

## #274 complete

With PR #277 + this PR, the open-format trust leg now has: an open spec (docs), a machine-checkable schema that **can't drift** from the structs, **proof real output complies**, **proof the spec stands alone** (independent reader), and **version fixtures**. Closes #274. Parent: #270.