### PR TITLE
ci: run real-AWS integration on change, not nightly

### DIFF
--- a/.github/workflows/real-aws-integration.yml
+++ b/.github/workflows/real-aws-integration.yml
@@ -1,10 +1,16 @@
-name: Nightly Real-AWS Integration
+name: Real-AWS Integration
 
-# Phase 5 of #238: run the credential-gated real-AWS integration suites against
-# a real S3 bucket in a sandbox account. This is intentionally NOT a PR job —
-# it needs real credentials and mutates a real bucket, so it runs on a schedule
-# (and on demand) instead of slowing every pull request. The emulator-based
-# integration job in test.yml already guards PRs credential-free.
+# Runs the credential-gated real-AWS integration suites against a real S3 bucket
+# in a sandbox account. This is intentionally NOT a PR job — it needs real
+# credentials and mutates a real bucket, so it runs AFTER merge to main (async,
+# off the PR critical path) rather than slowing every pull request. The
+# emulator-based integration job in test.yml already guards PRs credential-free.
+#
+# Trigger model (#274 follow-up): change-driven, not calendar-driven. It runs on
+# every push to main so real changes get real-AWS evidence promptly, plus a
+# low-frequency weekly "canary" to catch environmental drift (AWS API/behavior
+# changes, pinned-action rot) even when the code hasn't moved. Manual dispatch
+# stays available.
 #
 # Credentials are obtained via GitHub OIDC (no long-lived keys). The job is a
 # no-op unless the repository provides the role + bucket, so forks and clones
@@ -14,14 +20,31 @@ name: Nightly Real-AWS Integration
 #   - variable AWS_NIGHTLY_BUCKET — pre-existing test bucket
 
 on:
+  push:
+    branches: [main]
+    # Skip pushes that can't affect the suite (docs-only, etc.) to avoid
+    # burning a real-AWS run — matches "run on change" without churn.
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/real-aws-integration.yml'
   schedule:
-    # 07:00 UTC daily (~midnight US Pacific), off the PR critical path.
-    - cron: '0 7 * * *'
+    # Weekly canary, Mondays 07:00 UTC — catches environmental drift with no
+    # code change (external API/behavior shifts, action rot).
+    - cron: '0 7 * * 1'
   workflow_dispatch: {}
 
 permissions:
   id-token: write # required for OIDC role assumption
   contents: read
+
+# Serialize runs: the suite mutates a single shared sandbox bucket, so two
+# concurrent runs (e.g. rapid merges) could corrupt each other's objects. Queue
+# them instead of cancelling, so every merged change still gets verified.
+concurrency:
+  group: real-aws-integration
+  cancel-in-progress: false
 
 env:
   GO_VERSION: '1.26'


### PR DESCRIPTION
Addresses two points of feedback on the trust epic (#270): the AWS round-trip lane shouldn't run on a calendar when nothing changed, and should run promptly when something does.

## Change

- **Change-driven trigger**: runs on **push to main** (async, off the PR critical path), `paths`-gated to `**.go`/`go.mod`/`go.sum`/the workflow itself so docs-only merges don't burn a real-AWS run.
- **Weekly canary retained**: a low-frequency Monday cron still fires to catch **environmental drift** — AWS API/behavior changes, pinned-action rot — that a change-only trigger would miss. (`paths` filters don't apply to `schedule`, so the canary always runs.)
- **Concurrency guard**: `concurrency: real-aws-integration, cancel-in-progress: false`. The suite mutates a single shared sandbox bucket, so overlapping runs (rapid merges) could corrupt each other's objects. Runs **queue** rather than cancel, so every merged change still gets verified.
- **Renamed** `nightly-aws.yml` → `real-aws-integration.yml` and the workflow name to match — it's no longer nightly. `workflow_dispatch` retained.

No behavior change to the test suite itself; still OIDC-gated and a no-op on forks without the role/bucket configured (the lane remains dormant until `AWS_NIGHTLY_ROLE_ARN` + bucket vars are provisioned).

Part of the continuous-evidence leg of #270.