### PR TITLE
docs: add the integrity model page; regenerate stale CLI reference

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -178,6 +178,7 @@ const sidebar = {
         { text: 'Architecture', link: '/project/architecture' },
         { text: 'Project maturity & compatibility', link: '/project/maturity' },
         { text: 'Security model', link: '/project/security' },
+        { text: 'Integrity model', link: '/project/integrity' },
         { text: 'API stability & versioning', link: '/project/versioning' },
         { text: 'Attribution & license', link: '/project/attribution' },
       ],

--- a/docs/gen/cli/cargoship_upload.md
+++ b/docs/gen/cli/cargoship_upload.md
@@ -63,6 +63,7 @@ cargoship upload SOURCE_DIR DESTINATION [flags]
       --incremental                      Enable incremental sync: only upload new or changed files
       --interactive                      Enable interactive TUI mode with per-shard progress (Issue #112)
       --kms-key-id string                AWS KMS key ID or ARN for encryption (data chunks encrypted with SSE-KMS)
+      --no-file-checksums                Disable per-file content checksums (faster uploads, but 'verify --deep' can't confirm per-file integrity)
       --optimization                     Enable optimization features (BBR/CUBIC, adaptive staging, BDP) (default true)
       --prev-manifest string             Path to previous manifest JSON (or .json.gz) for incremental sync
       --project string                   Project ID for cost tracking (e.g. 'dvc_cache' for DVC remotes)

--- a/docs/gen/cli/cargoship_verify.md
+++ b/docs/gen/cli/cargoship_verify.md
@@ -44,6 +44,7 @@ cargoship verify [s3://bucket/prefix/uploads/upload-id] [flags]
 
 ```
   -b, --bucket string      S3 bucket name (or provide S3 URL as argument)
+      --deep               Deep verification: re-download stored objects and recompute checksums against the manifest (data-level integrity)
   -h, --help               help for verify
   -p, --prefix string      S3 prefix for upload (default: empty)
       --quick              Quick validation (metadata only, fast)

--- a/docs/project/integrity.md
+++ b/docs/project/integrity.md
@@ -1,0 +1,153 @@
+# Integrity model
+
+This page states what CargoShip promises about the integrity and recoverability
+of your data — and, just as importantly, what it does **not**. It is written
+like a threat model: descriptive, bounded, and backed by mechanisms you can
+inspect and verify yourself, not by assurances you have to take on faith.
+
+::: info Why "integrity model", not "guarantees"
+No tool can promise your bytes are eternally safe — that depends on AWS, the
+network, and hardware nobody controls. What CargoShip *can* do is make a
+**narrow, checkable claim** and give you the tools to falsify it at any time.
+That's the model below. For the separate question of *who can read* your data,
+see the [Security model](/project/security).
+:::
+
+## The core claim
+
+> **Every file CargoShip uploads is recorded with enough information to detect,
+> on restore, any deviation from what was uploaded — and you can verify this
+> yourself, with or without CargoShip.**
+
+This is the same trust model that established backup tools (`restic`, `borg`)
+rely on: integrity is not asserted once, it is **continuously and independently
+checkable**. Three things make the claim real.
+
+## 1. Integrity is checkable — `verify --deep`
+
+Every upload records a SHA-256 checksum at two levels:
+
+- **Per chunk** — the exact bytes of each stored `.tar.zst` object.
+- **Per file** — the content of each individual file inside the archive (on by
+  default; see `--no-file-checksums`).
+
+The algorithm is recorded in the manifest (`checksum_algorithm`), so a reader
+always knows how to recompute.
+
+[`cargoship verify`](/reference/commands/inspect) validates the manifest's
+internal consistency. **`cargoship verify --deep`** goes further: it
+re-downloads the stored objects, recomputes both levels of checksum, and
+compares them to the manifest. It exits non-zero on **any** corrupted, missing,
+or unverifiable file or chunk.
+
+```bash
+# Fast: manifest structure only.
+cargoship verify s3://bucket/prefix/uploads/<upload-id>
+
+# Deep: re-download and re-checksum the actual stored data.
+cargoship verify s3://bucket/prefix/uploads/<upload-id> --deep
+```
+
+Deep verify is the mechanism behind the core claim. It is deliberately strict:
+a manifest that *can't* be verified (no checksums recorded) fails in deep mode
+rather than passing silently — the whole point is to confirm data, and a
+manifest without checksums can't.
+
+::: tip What "unverifiable" means
+Deep verify treats a chunk or file with no recorded checksum as a **failure**,
+not a pass. Archives written before checksum capture existed (or with
+`--no-file-checksums`) are reported honestly as unverifiable rather than
+waved through.
+:::
+
+## 2. The format is open — you don't need CargoShip to recover
+
+Integrity you can only check with the tool that wrote the data is weak
+integrity. CargoShip's on-disk format is **open, documented, and versioned**:
+
+- Chunks are `tar` archives wrapped in a single `zstd` frame — extract with
+  standard `tar` and `zstd`.
+- The manifest is JSON (optionally gzipped) with a
+  [published schema](/reference/format/manifest).
+- The full wire format is specified in the
+  [Archive & Manifest Format Spec](/reference/format/).
+
+This is enforced, not just claimed:
+
+- A **machine-checkable JSON Schema** ships in the repo
+  (`pkg/manifest/schema.json`) and is **drift-checked in CI** against the Go
+  structs, so the schema, the code, and the docs cannot silently diverge.
+- An **independent-reader test** extracts a manifest and a file using only
+  standard-library tooling (`gzip`, `json`, `tar`) plus `zstd` — none of
+  CargoShip's own code — proving the spec is sufficient for a third party to
+  recover data in any language.
+- **Version fixtures** (`2.0`, `1.0`) are checked in and must keep parsing and
+  validating, so a format-version bump can't silently orphan older archives.
+
+If CargoShip disappeared tomorrow, your data would still come back with tools
+that ship on every Unix system.
+
+## 3. The claim is tested continuously
+
+The integrity mechanisms are exercised on every change, not just at release:
+
+- Emulator-based round-trip tests (upload → download → verify) run on every PR,
+  credential-free.
+- A real-AWS integration lane runs the same round-trip against a real S3 bucket
+  on merge to main (plus a weekly canary for environmental drift).
+- The deep-verify path is tested against **deliberately corrupted** objects —
+  the test suite confirms that flipping a byte in storage makes `verify --deep`
+  fail loudly. Detecting corruption is the guarantee; the tests prove it detects.
+
+## What CargoShip does **not** promise
+
+Being explicit about the boundaries is part of the model:
+
+- **Not durability.** CargoShip does not protect against AWS losing an object,
+  a bucket being deleted, or a region outage. That is S3's durability domain
+  (and your bucket policy, versioning, and replication choices). CargoShip lets
+  you **detect** loss on restore; it does not prevent it. Enable S3 Versioning
+  and appropriate replication for durability.
+- **Not tamper-proofing against an attacker with write access.** The checksums
+  detect accidental corruption and bitrot. An adversary who can rewrite *both*
+  a chunk and the manifest it's checksummed in could produce a self-consistent
+  forgery. For confidentiality and authenticated metadata, use
+  [manifest encryption](/project/security); for immutability, use S3 Object
+  Lock.
+- **Not verification of data CargoShip never saw.** Deep verify confirms stored
+  bytes match what was recorded *at upload time*. It cannot vouch for a file
+  that was already corrupt on disk before upload — checksum what matters at the
+  source if that is a concern.
+- **Not automatic.** Deep verify re-downloads data and costs GET requests and
+  transfer; it is a command you run (or schedule), not a background guarantee.
+  Run it after an upload you care about, and periodically for long-term
+  archives.
+
+## Verifying for yourself
+
+You never have to trust this page. To confirm integrity end to end:
+
+```bash
+# 1. Deep-verify a completed upload against its manifest.
+cargoship verify s3://bucket/prefix/uploads/<upload-id> --deep
+
+# 2. Or bypass CargoShip entirely — pull a chunk and extract with standard tools.
+aws s3 cp s3://bucket/prefix/uploads/<upload-id>/shard-0/chunk-0.tar.zst .
+zstd -d chunk-0.tar.zst
+tar xf chunk-0.tar
+
+# 3. Recompute a file's checksum and compare it to the manifest's record.
+sha256sum path/to/restored/file
+```
+
+If step 3's digest matches the `checksum` recorded for that file in the
+manifest, the file is byte-identical to what was uploaded. That check depends on
+nothing but `sha256sum` and a JSON parser — which is the whole point.
+
+## See also
+
+- [`verify` command reference](/reference/commands/inspect)
+- [Archive & Manifest Format Spec](/reference/format/)
+- [Manifest schema](/reference/format/manifest)
+- [Security model](/project/security) — confidentiality and encryption
+- [Recovery & operations runbook](/reference/recovery)


### PR DESCRIPTION
The keystone of the trust epic's continuous-evidence leg (#270): a page that states what CargoShip promises about data integrity/recoverability — and what it does **not**.

## `docs/project/integrity.md`

Named **"Integrity model"** (not "guarantees"): descriptive and bounded, like a threat model, rather than an absolute commitment. Grounded entirely in shipped mechanisms:

- **The checkable claim** — `verify --deep` (per-chunk + per-file SHA-256, #271), including that unverifiable = failure, not a silent pass.
- **The anti-lock-in backing** — the open, drift-checked, independent-reader-proven format (#274): extract with standard `tar`/`zstd`, parse the JSON manifest, recompute a checksum with `sha256sum` — no CargoShip needed.
- **The evidence** — continuous round-trip testing (emulator on PRs, real-AWS on merge), incl. the deliberate-corruption tests that prove deep verify *detects* tampering.

It states **non-goals plainly**: not durability (that's S3 + your versioning/replication), not tamper-proofing against a writer who can rewrite both chunk and manifest, not verification of pre-upload corruption, not automatic. And it shows a copy-paste "verify it yourself without CargoShip" recipe. Linked in the Project sidebar beside the Security model.

## Also: regenerated stale CLI reference

`docs/gen/cli/` was missing `--deep` (verify, #272) and `--no-file-checksums` (upload, #276) — added to the commands but never regenerated. Latent drift the doc-consistency gate would have caught on the next docs build; fixed here. Verified with a full `docs` build (`npm run build`) — new page, sidebar, and all links resolve.

Part of #270.