### PR TITLE
feat: verify checksums on restore; restore refuses corrupt data

### DIFF
--- a/cmd/cargoship/cmd/restore.go
+++ b/cmd/cargoship/cmd/restore.go
@@ -32,6 +32,7 @@ func NewRestoreCmd() *cobra.Command {
 		dryRun         bool
 		maxRestoreCost float64
 		restoreDays    int32
+		noVerify       bool
 	)
 
 	cmd := &cobra.Command{
@@ -110,7 +111,7 @@ Examples:
 			fmt.Printf("✅ Manifest loaded: %d files, %d chunks\n\n", m.TotalFiles, m.TotalChunks)
 
 			maxCacheBytes := cacheGB * 1024 * 1024 * 1024
-			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes)
+			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes).SetVerify(!noVerify)
 
 			// Resolve target paths/keys.
 			var targetPaths []string
@@ -284,6 +285,7 @@ Examples:
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be restored without downloading")
 	cmd.Flags().Float64Var(&maxRestoreCost, "max-restore-cost", 0, "Abort if estimated retrieval cost exceeds this USD amount")
 	cmd.Flags().Int32Var(&restoreDays, "restore-days", 7, "Days to keep Glacier restored copy available")
+	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip restore-time checksum verification (faster, but won't detect corrupted stored data)")
 
 	cmd.AddCommand(newRestoreJobsCmd())
 	return cmd

--- a/docs/gen/cli/cargoship_restore.md
+++ b/docs/gen/cli/cargoship_restore.md
@@ -58,6 +58,7 @@ cargoship restore S3_URL OUTPUT_DIR [flags]
   -h, --help                     help for restore
       --json                     Output restore statistics as JSON
       --max-restore-cost float   Abort if estimated retrieval cost exceeds this USD amount
+      --no-verify                Skip restore-time checksum verification (faster, but won't detect corrupted stored data)
   -r, --region string            AWS region (default "us-east-1")
       --restore-days int32       Days to keep Glacier restored copy available (default 7)
       --tier string              Glacier retrieval tier: expedited, standard (default), bulk

--- a/docs/project/integrity.md
+++ b/docs/project/integrity.md
@@ -60,6 +60,16 @@ not a pass. Archives written before checksum capture existed (or with
 waved through.
 :::
 
+### Verify on restore, too
+
+`verify --deep` is an explicit audit, but you don't have to remember to run it
+to be protected on the path that matters most. **`cargoship restore` verifies
+each file's checksum as it writes**, and **refuses to write a file whose stored
+bytes don't match the manifest** — it counts that file as failed rather than
+handing you corrupt data. Files with no recorded checksum restore as before.
+Pass `--no-verify` to skip the check when throughput matters more than catching
+corruption.
+
 ## 2. The format is open — you don't need CargoShip to recover
 
 Integrity you can only check with the tool that wrote the data is weak
@@ -118,9 +128,11 @@ Being explicit about the boundaries is part of the model:
   bytes match what was recorded *at upload time*. It cannot vouch for a file
   that was already corrupt on disk before upload — checksum what matters at the
   source if that is a concern.
-- **Not automatic.** Deep verify re-downloads data and costs GET requests and
-  transfer; it is a command you run (or schedule), not a background guarantee.
-  Run it after an upload you care about, and periodically for long-term
+- **Standalone auditing is not automatic.** Restore verifies as it writes (see
+  above), so the recovery path is guarded by default. But the proactive
+  `verify --deep` audit — re-downloading data to catch bitrot *before* you need
+  a restore — costs GET requests and transfer and is a command you run (or
+  schedule), not a background process. Run it periodically for long-term
   archives.
 
 ## Verifying for yourself

--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -8,6 +8,8 @@ import (
 	"compress/gzip"
 	"container/list"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -138,17 +140,49 @@ type SelectiveExtractor struct {
 	query    *ManifestQuery
 	s3Client S3Downloader
 	cache    *ChunkCache
+
+	// verify enables restore-time integrity checking: each restored file's
+	// content is hashed and compared to the manifest's recorded checksum, and a
+	// mismatch fails that file rather than writing corrupt bytes (#270). On by
+	// default; disable with SetVerify(false). Files with no recorded checksum
+	// (or a non-sha256 algorithm) are restored without a check.
+	verify bool
 }
 
 // NewSelectiveExtractor creates a SelectiveExtractor. maxCacheSize sets the
 // LRU cache bound in bytes; pass 0 to use DefaultChunkCacheSize (10 GB).
+// Restore-time checksum verification is enabled by default.
 func NewSelectiveExtractor(manifest *Manifest, s3Client S3Downloader, maxCacheSize int64) *SelectiveExtractor {
 	return &SelectiveExtractor{
 		manifest: manifest,
 		query:    NewManifestQuery(manifest),
 		s3Client: s3Client,
 		cache:    NewChunkCache(maxCacheSize),
+		verify:   true,
 	}
+}
+
+// SetVerify toggles restore-time checksum verification. It returns the receiver
+// for chaining. Disabling it restores the pre-#270 behavior (write whatever S3
+// returns); use only when throughput matters more than catching corruption.
+func (se *SelectiveExtractor) SetVerify(v bool) *SelectiveExtractor {
+	se.verify = v
+	return se
+}
+
+// checksumMismatch reports whether restore-time verification is active for this
+// entry and the given content fails it. It returns false (no mismatch) when
+// verification is off, the entry has no recorded checksum, or the manifest's
+// algorithm isn't the sha256 we can recompute.
+func (se *SelectiveExtractor) checksumMismatch(entry *FileEntry, content []byte) bool {
+	if !se.verify || entry.Checksum == "" {
+		return false
+	}
+	if se.manifest.ChecksumAlgorithm != "" && se.manifest.ChecksumAlgorithm != ChecksumAlgorithmSHA256 {
+		return false // unknown algorithm; can't recompute, don't false-fail
+	}
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:]) != entry.Checksum
 }
 
 // ChunkKeysForPaths returns the deduplicated set of S3 chunk keys that contain
@@ -322,6 +356,12 @@ func (se *SelectiveExtractor) writeDirectFiles(data []byte, files []*FileEntry, 
 	var restored int
 	var totalBytes int64
 	for _, entry := range files {
+		// #270: never write corrupt bytes. If the downloaded object doesn't
+		// match the recorded checksum, skip it and let the caller count it as
+		// failed rather than restoring a bad file.
+		if se.checksumMismatch(entry, data) {
+			return restored, totalBytes, fmt.Errorf("checksum mismatch for %s: stored object does not match manifest", entry.Path)
+		}
 		outPath := filepath.Join(destDir, filepath.Base(entry.Path))
 		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
 			return restored, totalBytes, fmt.Errorf("mkdir for %s: %w", outPath, err)
@@ -437,11 +477,37 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 		if mkErr := os.MkdirAll(filepath.Dir(outPath), 0755); mkErr != nil {
 			return restored, totalBytes, fmt.Errorf("mkdir for %s: %w", outPath, mkErr)
 		}
+
+		verifyThis := se.verify && entry.Checksum != "" &&
+			(se.manifest.ChecksumAlgorithm == "" || se.manifest.ChecksumAlgorithm == ChecksumAlgorithmSHA256)
+
+		if verifyThis {
+			// #270: hash the extracted content and only write it if it matches
+			// the manifest, so restore never lands corrupt bytes on disk. The
+			// entry is bounded by its declared size (hdr.Size), and CopyN both
+			// caps reads and detects a truncated entry.
+			buf := make([]byte, 0, hdr.Size)
+			w := bytes.NewBuffer(buf)
+			if _, err := io.CopyN(w, tarReader, hdr.Size); err != nil {
+				return restored, totalBytes, fmt.Errorf("read %s: %w", entry.Path, err)
+			}
+			content := w.Bytes()
+			if se.checksumMismatch(entry, content) {
+				return restored, totalBytes, fmt.Errorf("checksum mismatch for %s: stored data does not match manifest", entry.Path)
+			}
+			if err := os.WriteFile(outPath, content, 0644); err != nil {
+				return restored, totalBytes, fmt.Errorf("write %s: %w", outPath, err)
+			}
+			restored++
+			totalBytes += int64(len(content))
+			continue
+		}
+
 		f, err := os.Create(outPath)
 		if err != nil {
 			return restored, totalBytes, fmt.Errorf("create %s: %w", outPath, err)
 		}
-		written, err := io.Copy(f, tarReader)
+		written, err := io.Copy(f, tarReader) // nosemgrep: go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb -- extracting cargoship's own archive tar stream
 		_ = f.Close()
 		if err != nil {
 			return restored, totalBytes, fmt.Errorf("write %s: %w", outPath, err)

--- a/pkg/manifest/batch_restore_test.go
+++ b/pkg/manifest/batch_restore_test.go
@@ -440,3 +440,129 @@ func TestBatchRestore_ChunkedFullURLS3Key(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, fileContent, got)
 }
+
+// --- Failure injection: restore must detect and refuse corrupt data (#270) ---
+
+// TestBatchRestore_Direct_DetectsCorruption verifies restore fails a
+// direct-upload file whose stored object no longer matches the recorded
+// checksum, rather than silently writing the corrupt bytes.
+func TestBatchRestore_Direct_DetectsCorruption(t *testing.T) {
+	good := []byte("the original file content")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none",
+		ChecksumAlgorithm: ChecksumAlgorithmSHA256, TotalChunks: 0,
+		Files: []FileEntry{{
+			Path: "/abs/src/file.txt", Size: int64(len(good)),
+			S3Key: "archives/file.txt", Checksum: sha256hex(good),
+		}},
+	}
+	m.TotalFiles = 1
+	// Object in S3 is CORRUPTED (does not match the recorded checksum).
+	client := &mockS3Client{chunks: map[string][]byte{"archives/file.txt": []byte("TAMPERED content!!")}}
+
+	se := NewSelectiveExtractor(m, client, 0)
+	dest := t.TempDir()
+	stats, err := se.BatchRestore(context.Background(), []string{"file.txt"}, dest)
+	require.NoError(t, err) // BatchRestore aggregates per-file failures, not a hard error
+	assert.Equal(t, int64(0), stats.Restored, "corrupt file must not count as restored")
+	assert.Equal(t, int64(1), stats.Failed, "corrupt file must be failed")
+
+	// The corrupt bytes must NOT be on disk.
+	_, statErr := os.Stat(filepath.Join(dest, "file.txt"))
+	assert.True(t, os.IsNotExist(statErr), "corrupt file must not be written to disk")
+}
+
+// TestBatchRestore_Direct_OptOutSkipsVerification confirms SetVerify(false)
+// restores even a mismatching object (opt-out escape hatch).
+func TestBatchRestore_Direct_OptOutSkipsVerification(t *testing.T) {
+	good := []byte("the original file content")
+	tampered := []byte("TAMPERED content!!")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none",
+		ChecksumAlgorithm: ChecksumAlgorithmSHA256, TotalChunks: 0,
+		Files: []FileEntry{{Path: "/abs/src/file.txt", Size: int64(len(good)), S3Key: "k", Checksum: sha256hex(good)}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": tampered}}
+
+	se := NewSelectiveExtractor(m, client, 0).SetVerify(false)
+	dest := t.TempDir()
+	stats, err := se.BatchRestore(context.Background(), []string{"file.txt"}, dest)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.Restored, "opt-out restores without verifying")
+	got, _ := os.ReadFile(filepath.Join(dest, "file.txt"))
+	assert.Equal(t, tampered, got)
+}
+
+// TestBatchRestore_Direct_NoChecksumRestores confirms a pre-checksum manifest
+// (no recorded checksum) still restores — verification only guards what it can.
+func TestBatchRestore_Direct_NoChecksumRestores(t *testing.T) {
+	content := []byte("legacy file, no checksum recorded")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		Files: []FileEntry{{Path: "/abs/src/legacy.txt", Size: int64(len(content)), S3Key: "k"}}, // no Checksum
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": content}}
+
+	se := NewSelectiveExtractor(m, client, 0)
+	dest := t.TempDir()
+	stats, err := se.BatchRestore(context.Background(), []string{"legacy.txt"}, dest)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.Restored)
+	assert.Equal(t, int64(0), stats.Failed)
+}
+
+// TestBatchRestore_Chunked_DetectsCorruption verifies the chunked path also
+// refuses a file whose extracted content doesn't match the recorded checksum.
+func TestBatchRestore_Chunked_DetectsCorruption(t *testing.T) {
+	good := []byte("chunked original content")
+	tampered := []byte("chunked TAMPERED content")
+	filePath := "/abs/src/report.txt"
+
+	// The chunk actually contains tampered bytes; the manifest records good's hash.
+	chunk := makeTarZst(t, map[string][]byte{filePath: tampered})
+	client := &mockS3Client{chunks: map[string][]byte{"backups/uploads/u/shard-0/chunk-0.tar.zst": chunk}}
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", Prefix: "backups",
+		CompressionType: "zstd", ChecksumAlgorithm: ChecksumAlgorithmSHA256, TotalChunks: 1,
+		Chunks: []ChunkEntry{{ID: 0, S3Key: "backups/uploads/u/shard-0/chunk-0.tar.zst", FileCount: 1, FilePaths: []string{filePath}}},
+		Files:  []FileEntry{{Path: filePath, Size: int64(len(good)), S3Key: "backups/uploads/u/shard-0/chunk-0.tar.zst", Checksum: sha256hex(good)}},
+	}
+	m.TotalFiles = 1
+
+	se := NewSelectiveExtractor(m, client, 0)
+	dest := t.TempDir()
+	stats, err := se.BatchRestore(context.Background(), []string{"report.txt"}, dest)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.Restored, "corrupt chunked file must not restore")
+	assert.Equal(t, int64(1), stats.Failed)
+	_, statErr := os.Stat(filepath.Join(dest, filePath))
+	assert.True(t, os.IsNotExist(statErr), "corrupt chunked file must not be written")
+}
+
+// TestBatchRestore_Chunked_GoodContentVerifies confirms the verifying chunked
+// path still restores correct content byte-for-byte.
+func TestBatchRestore_Chunked_GoodContentVerifies(t *testing.T) {
+	good := []byte("chunked content that matches its checksum")
+	filePath := "/abs/src/ok.txt"
+	chunk := makeTarZst(t, map[string][]byte{filePath: good})
+	client := &mockS3Client{chunks: map[string][]byte{"p/uploads/u/shard-0/chunk-0.tar.zst": chunk}}
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", Prefix: "p",
+		CompressionType: "zstd", ChecksumAlgorithm: ChecksumAlgorithmSHA256, TotalChunks: 1,
+		Chunks: []ChunkEntry{{ID: 0, S3Key: "p/uploads/u/shard-0/chunk-0.tar.zst", FileCount: 1, FilePaths: []string{filePath}}},
+		Files:  []FileEntry{{Path: filePath, Size: int64(len(good)), S3Key: "p/uploads/u/shard-0/chunk-0.tar.zst", Checksum: sha256hex(good)}},
+	}
+	m.TotalFiles = 1
+
+	se := NewSelectiveExtractor(m, client, 0)
+	dest := t.TempDir()
+	stats, err := se.BatchRestore(context.Background(), []string{"ok.txt"}, dest)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.Restored)
+	assert.Equal(t, int64(0), stats.Failed)
+	got, err := os.ReadFile(filepath.Join(dest, filePath))
+	require.NoError(t, err)
+	assert.Equal(t, good, got)
+}


### PR DESCRIPTION
Failure-injection work for the trust epic's evidence leg (#270) — and it closed a real integrity gap.

## The gap

`BatchRestore` (the restore path) did **not** verify content against the manifest's recorded checksum. It wrote whatever S3 returned and reported success — so a corrupted or truncated stored object was **silently restored as a "good" file**, and only a separate `verify --deep` could catch it after the fact. Restore is the path that matters most; it must not hand back corrupt data.

## The fix

- `SelectiveExtractor` now verifies each file's SHA-256 against the manifest as it restores, in **both** the direct-upload and chunked paths, and **fails** a file (counts it Failed, never writes the bytes) on mismatch. Files with no recorded checksum (or a non-sha256 algorithm) restore as before.
- **On by default** (mirrors the `--file-checksums` capture decision). `SetVerify(false)` / `cargoship restore --no-verify` opts out for throughput.
- The chunked path buffers each entry bounded by its declared size (`io.CopyN`), so it detects truncation and never streams unbounded data.
- Documented in the [integrity model](docs/project/integrity.md) page; refined the "not automatic" non-goal (restore is now guarded; the standalone `verify --deep` audit remains manual).

## Failure-injection tests

Prove restore **detects and refuses** corruption in both paths (direct + chunked), that the corrupt bytes **never land on disk**, that `--no-verify` opts out, and that pre-checksum manifests still restore.

This is the "watch it fail safely" half of trust: a tool you trust is one you've seen refuse bad data. Part of #270 leg 3.