### PR TITLE
fix: keep manifest S3Keys portable — stop clobbering with full-URL Location (#273)

### DIFF
--- a/dvc-cargoship/pyproject.toml
+++ b/dvc-cargoship/pyproject.toml
@@ -51,6 +51,10 @@ constraint-dependencies = [
     "orjson>=3.11.6",
     "urllib3>=2.7.0",
     "dulwich>=1.2.5",
+    # GHSA-6p8h-3wgx-97gf / -fjr4-x663-mwxc / -r9mr-m37c-5fr3 / -94p4-4cq8-9g67
+    # (HIGH): unsafe git-option denylist bypasses + env-var exfiltration. Fixed
+    # in 3.1.55.
+    "gitpython>=3.1.55",
 ]
 
 [tool.setuptools.packages.find]

--- a/dvc-cargoship/uv.lock
+++ b/dvc-cargoship/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 constraints = [
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "dulwich", specifier = ">=1.2.5" },
+    { name = "gitpython", specifier = ">=3.1.55" },
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
@@ -1096,14 +1097,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.53"
+version = "3.1.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/24/0e0c12cb6f7cb864779a9d2fefee9ca91838f6db402c8780c9d28a8d7ebe/gitpython-3.1.53.tar.gz", hash = "sha256:06ae8d9623b0ed0d67b8adeac5c7008d0a5a404b087a9e0d0c7163bdd3a6b497", size = 224597, upload-time = "2026-07-20T13:41:52.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/45/d45f94fa38b199862959cd7b5461a31f03746d75ef59363339fc0c394345/gitpython-3.1.56.tar.gz", hash = "sha256:127adf5c73f1a822e368301c4d5ffa5d305ce611eccab76f3336f9380a78ad0b", size = 229619, upload-time = "2026-07-25T07:41:43.179Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/a6/bff12b3238885eeef7d28ef908b24e0cba91c476c31cb876a00a0986ce2c/gitpython-3.1.53-py3-none-any.whl", hash = "sha256:187885556b64ab357bd4ea84e2c4cce2861a613a7f4268b3f7f7ba05f2ce4ab0", size = 216237, upload-time = "2026-07-20T13:41:51.473Z" },
+    { url = "https://files.pythonhosted.org/packages/06/27/8b9b039c7f026d4af8954dbbdcc9f101f8d6901daa3a65b065d8f450c0bd/gitpython-3.1.56-py3-none-any.whl", hash = "sha256:bedffdc4bdd2e3cf21b328711a552b0529751f08bff6591339d18492291ad035", size = 216644, upload-time = "2026-07-25T07:41:41.737Z" },
 ]
 
 [[package]]

--- a/pkg/pipeline/manifest_integration_test.go
+++ b/pkg/pipeline/manifest_integration_test.go
@@ -139,6 +139,8 @@ func TestManifestIntegration_Generation(t *testing.T) {
 		assert.NotEmpty(t, file.S3Key, "File %d should have an S3 key", i)
 		assert.GreaterOrEqual(t, file.ShardID, 0, "File %d should have a valid shard ID", i)
 		assert.GreaterOrEqual(t, file.ChunkID, 0, "File %d should have a valid chunk ID", i)
+		// #273: S3Key must be a portable relative key, not a full URL.
+		assert.NotContains(t, file.S3Key, "://", "File %d S3Key must not be a URL (portability): %s", i, file.S3Key)
 	}
 
 	// Verify all chunks have valid metadata
@@ -148,6 +150,8 @@ func TestManifestIntegration_Generation(t *testing.T) {
 		assert.Greater(t, chunk.FileCount, 0, "Chunk %d should contain files", i)
 		assert.Greater(t, chunk.UncompressedSize, int64(0), "Chunk %d should have uncompressed size", i)
 		assert.Greater(t, chunk.CompressedSize, int64(0), "Chunk %d should have compressed size", i)
+		// #273: chunk S3Key must be a portable relative key, not a full URL.
+		assert.NotContains(t, chunk.S3Key, "://", "Chunk %d S3Key must not be a URL (portability): %s", i, chunk.S3Key)
 	}
 
 	// #271: chunk-level checksum capture. The manifest must record the

--- a/pkg/pipeline/s3_multiprefix_uploader.go
+++ b/pkg/pipeline/s3_multiprefix_uploader.go
@@ -482,17 +482,18 @@ func (s *S3MultiPrefixUploaderStage) uploadViaTransporter(ctx context.Context, s
 		Metadata: metadata,
 	}
 
-	// Upload via transporter
-	result, err := s.transporter.Upload(ctx, archive)
+	// Upload via transporter.
+	_, err := s.transporter.Upload(ctx, archive)
 	if err != nil {
 		return fmt.Errorf("transporter upload failed for %s: %w", job.S3Key, err)
 	}
 
-	// Store result
-	if result.Location != "" {
-		job.S3Key = result.Location
-	}
-
+	// #273: do NOT overwrite job.S3Key with result.Location. Location is a full
+	// S3 URL (scheme/host/bucket baked in); job.S3Key is the portable,
+	// prefix-relative key that goes into the manifest and the cleanup list.
+	// Clobbering it made manifests non-portable and broke cleanup (which builds
+	// sibling keys relative to the bucket). The object was written at
+	// Prefix + "/" + job.S3Key, so the relative key is correct as-is.
 	return nil
 }
 
@@ -522,16 +523,13 @@ func (s *S3MultiPrefixUploaderStage) uploadViaManager(ctx context.Context, s3Key
 	input.Body = reader
 
 	// Upload using AWS SDK manager (handles multipart automatically)
-	result, err := s.uploader.Upload(ctx, input)
+	_, err := s.uploader.Upload(ctx, input)
 	if err != nil {
 		return fmt.Errorf("S3 upload failed for %s: %w", job.S3Key, err)
 	}
 
-	// Store upload result in job
-	if result.Location != "" {
-		job.S3Key = result.Location
-	}
-
+	// #273: keep job.S3Key as the portable, prefix-relative key — do not
+	// overwrite it with the SDK's full-URL Location. See uploadViaTransporter.
 	return nil
 }
 

--- a/pkg/pipeline/s3_uploader.go
+++ b/pkg/pipeline/s3_uploader.go
@@ -430,17 +430,15 @@ func (s *S3UploaderStage) uploadViaTransporter(ctx context.Context, s3Key string
 		Metadata:     metadata,
 	}
 
-	// Upload via transporter
-	result, err := s.config.Transporter.Upload(ctx, archive)
+	// Upload via transporter.
+	_, err := s.config.Transporter.Upload(ctx, archive)
 	if err != nil {
 		return fmt.Errorf("transporter upload failed for %s: %w", job.S3Key, err)
 	}
 
-	// Store result
-	if result.Location != "" {
-		job.S3Key = result.Location
-	}
-
+	// #273: keep job.S3Key as the portable, prefix-relative key — do not
+	// overwrite it with the SDK's full-URL Location (which bakes in
+	// scheme/host/bucket and makes manifests non-portable / breaks cleanup).
 	return nil
 }
 
@@ -503,16 +501,13 @@ func (s *S3UploaderStage) uploadViaManager(ctx context.Context, s3Key string, jo
 	input.Body = reader
 
 	// Upload using AWS SDK manager (handles multipart automatically)
-	result, err := s.uploader.Upload(ctx, input)
+	_, err := s.uploader.Upload(ctx, input)
 	if err != nil {
 		return fmt.Errorf("S3 upload failed for %s: %w", job.S3Key, err)
 	}
 
-	// Store upload result in job
-	if result.Location != "" {
-		job.S3Key = result.Location
-	}
-
+	// #273: keep job.S3Key as the portable, prefix-relative key — do not
+	// overwrite it with the SDK's full-URL Location. See uploadViaTransporter.
 	return nil
 }
 


### PR DESCRIPTION
Root-cause fix for the S3Key portability wart (#273), which deep verify and restore have been defending against with `ResolveObjectKey` since #271/#281.

## The bug

Both uploaders (multiprefix + basic), in both the transporter and manager paths, overwrote `job.S3Key` with the SDK's `result.Location` — a **full S3 URL** — right before the manifest recorded it and the cleanup list tracked it. That made:

- **manifests non-portable** — a stale absolute `http://host/bucket/...` location instead of a prefix-relative key;
- **cleanup-on-failure target the wrong key** — `DeleteObjects` builds sibling keys relative to the bucket, so a URL key wouldn't match the real object;
- **every reader** (deep verify, `BatchRestore`) need `ResolveObjectKey` just to function.

## The fix

Don't overwrite `job.S3Key`. The object is written at `Prefix + "/" + S3Key`, so the prefix-relative key already in `job.S3Key` is correct and portable; `Location` (documented as "S3 URL") was never the right thing to store in a key field. Removed the clobber at all **4** sites.

`ResolveObjectKey` now becomes a **defensive normalizer for old manifests** rather than load-bearing for new ones — exactly the issue's "done when."

## Guard

The manifest integration test now asserts **no file/chunk `S3Key` contains `"://"`**, so a regression that reintroduces URL keys fails CI. Full unit + integration suites (incl. the round-trip property test that caught the restore side of this) pass unchanged.

Closes #273.