### PR TITLE
fix: consistent, escape-safe restore layout across direct & chunked modes (#282)

### DIFF
--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -185,6 +185,50 @@ func (se *SelectiveExtractor) checksumMismatch(entry *FileEntry, content []byte)
 	return hex.EncodeToString(sum[:]) != entry.Checksum
 }
 
+// safeRestorePath maps a manifest FileEntry.Path to a destination path under
+// destDir, preserving directory structure while guaranteeing the result stays
+// inside destDir (#282). Manifests store the original source path, which may be
+// absolute (`/abs/src/f`) or, in a crafted/hostile manifest, contain `..`
+// traversal — and filepath.Join(destDir, "/abs") or Join(destDir, "../x")
+// escapes destDir. We strip any volume/leading separator and drop `..`
+// segments so a file always lands within destDir, then verify containment as a
+// belt-and-suspenders check. Both restore paths (direct + chunked) use this, so
+// their output layout is identical and escape-safe.
+func safeRestorePath(destDir, entryPath string) (string, error) {
+	// Normalize to slash form, drop any volume (Windows) and leading slashes.
+	rel := filepath.ToSlash(entryPath)
+	rel = strings.TrimPrefix(rel, filepath.VolumeName(entryPath))
+	rel = strings.TrimLeft(rel, "/")
+
+	// Drop "." and ".." segments so the path can't climb out of destDir.
+	var clean []string
+	for _, seg := range strings.Split(rel, "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			continue
+		}
+		clean = append(clean, seg)
+	}
+	if len(clean) == 0 {
+		return "", fmt.Errorf("refusing to restore %q: no safe path components", entryPath)
+	}
+
+	out := filepath.Join(append([]string{destDir}, clean...)...)
+
+	// Belt-and-suspenders: confirm the result is within destDir.
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", err
+	}
+	absOut, err := filepath.Abs(out)
+	if err != nil {
+		return "", err
+	}
+	if absOut != absDest && !strings.HasPrefix(absOut, absDest+string(filepath.Separator)) {
+		return "", fmt.Errorf("refusing to restore %q: path escapes destination", entryPath)
+	}
+	return out, nil
+}
+
 // ChunkKeysForPaths returns the deduplicated set of S3 chunk keys that contain
 // the requested file paths. Unknown paths are silently skipped. Use this to
 // obtain the keys for a Glacier pre-flight check before calling BatchRestore.
@@ -362,7 +406,11 @@ func (se *SelectiveExtractor) writeDirectFiles(data []byte, files []*FileEntry, 
 		if se.checksumMismatch(entry, data) {
 			return restored, totalBytes, fmt.Errorf("checksum mismatch for %s: stored object does not match manifest", entry.Path)
 		}
-		outPath := filepath.Join(destDir, filepath.Base(entry.Path))
+		// #282: preserve directory structure under destDir, escape-safe.
+		outPath, err := safeRestorePath(destDir, entry.Path)
+		if err != nil {
+			return restored, totalBytes, err
+		}
 		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
 			return restored, totalBytes, fmt.Errorf("mkdir for %s: %w", outPath, err)
 		}
@@ -473,7 +521,11 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 		if !ok {
 			continue
 		}
-		outPath := filepath.Join(destDir, entry.Path)
+		// #282: same escape-safe, structure-preserving layout as the direct path.
+		outPath, err := safeRestorePath(destDir, entry.Path)
+		if err != nil {
+			return restored, totalBytes, err
+		}
 		if mkErr := os.MkdirAll(filepath.Dir(outPath), 0755); mkErr != nil {
 			return restored, totalBytes, fmt.Errorf("mkdir for %s: %w", outPath, mkErr)
 		}

--- a/pkg/manifest/batch_restore_test.go
+++ b/pkg/manifest/batch_restore_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -467,8 +468,8 @@ func TestBatchRestore_Direct_DetectsCorruption(t *testing.T) {
 	assert.Equal(t, int64(0), stats.Restored, "corrupt file must not count as restored")
 	assert.Equal(t, int64(1), stats.Failed, "corrupt file must be failed")
 
-	// The corrupt bytes must NOT be on disk.
-	_, statErr := os.Stat(filepath.Join(dest, "file.txt"))
+	// The corrupt bytes must NOT be on disk (structure-preserving path, #282).
+	_, statErr := os.Stat(filepath.Join(dest, "abs/src/file.txt"))
 	assert.True(t, os.IsNotExist(statErr), "corrupt file must not be written to disk")
 }
 
@@ -490,7 +491,7 @@ func TestBatchRestore_Direct_OptOutSkipsVerification(t *testing.T) {
 	stats, err := se.BatchRestore(context.Background(), []string{"file.txt"}, dest)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), stats.Restored, "opt-out restores without verifying")
-	got, _ := os.ReadFile(filepath.Join(dest, "file.txt"))
+	got, _ := os.ReadFile(filepath.Join(dest, "abs/src/file.txt"))
 	assert.Equal(t, tampered, got)
 }
 
@@ -565,4 +566,115 @@ func TestBatchRestore_Chunked_GoodContentVerifies(t *testing.T) {
 	got, err := os.ReadFile(filepath.Join(dest, filePath))
 	require.NoError(t, err)
 	assert.Equal(t, good, got)
+}
+
+// --- #282: restore layout parity + path-traversal safety ---
+
+// TestSafeRestorePath covers the escape-safe, structure-preserving mapping used
+// by both restore paths.
+func TestSafeRestorePath(t *testing.T) {
+	dest := t.TempDir()
+	tests := []struct {
+		name      string
+		entryPath string
+		wantRel   string // expected path relative to dest ("" = expect error)
+	}{
+		{"relative", "data/a.txt", "data/a.txt"},
+		{"absolute source path", "/abs/src/data/a.txt", "abs/src/data/a.txt"},
+		{"nested", "a/b/c/deep.bin", "a/b/c/deep.bin"},
+		{"dot segments stripped", "a/./b/c.txt", "a/b/c.txt"},
+		{"parent traversal stripped", "../../etc/passwd", "etc/passwd"},
+		{"embedded traversal stripped", "a/../../b/c.txt", "a/b/c.txt"},
+		{"all traversal -> error", "../../..", ""},
+		{"empty -> error", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safeRestorePath(dest, tt.entryPath)
+			if tt.wantRel == "" {
+				assert.Error(t, err, "should reject %q", tt.entryPath)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, filepath.Join(dest, filepath.FromSlash(tt.wantRel)), got)
+			// Never escapes dest.
+			assert.True(t, got == dest || filepathHasPrefix(got, dest),
+				"%q resolved outside dest: %s", tt.entryPath, got)
+		})
+	}
+}
+
+func filepathHasPrefix(p, dir string) bool {
+	rel, err := filepath.Rel(dir, p)
+	if err != nil || filepath.IsAbs(rel) {
+		return false
+	}
+	// Contained iff the relative path doesn't start with a ".." segment.
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// TestBatchRestore_TraversalIsContained proves a hostile manifest whose
+// FileEntry.Path tries to escape the destination cannot write outside destDir.
+func TestBatchRestore_TraversalIsContained(t *testing.T) {
+	content := []byte("payload")
+	// Manifest claims the file lives at a traversal path.
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		Files: []FileEntry{{Path: "../../../../tmp/evil.txt", Size: int64(len(content)), S3Key: "k"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": content}}
+
+	se := NewSelectiveExtractor(m, client, 0)
+	dest := t.TempDir()
+	stats, err := se.BatchRestore(context.Background(), []string{"evil.txt"}, dest)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.Restored)
+
+	// It must land inside dest (as tmp/evil.txt), never at the traversal target.
+	got, err := os.ReadFile(filepath.Join(dest, "tmp/evil.txt"))
+	require.NoError(t, err, "file should be contained within dest")
+	assert.Equal(t, content, got)
+}
+
+// TestBatchRestore_LayoutParity confirms direct and chunked modes restore the
+// same logical file to the SAME location under destDir (#282).
+func TestBatchRestore_LayoutParity(t *testing.T) {
+	content := []byte("parity content")
+	srcPath := "/abs/src/dir/report.txt"
+	wantRel := "abs/src/dir/report.txt"
+
+	// Direct manifest.
+	directM := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		Files: []FileEntry{{Path: srcPath, Size: int64(len(content)), S3Key: "obj"}},
+	}
+	directM.TotalFiles = 1
+	directClient := &mockS3Client{chunks: map[string][]byte{"obj": content}}
+	directDest := t.TempDir()
+	_, err := NewSelectiveExtractor(directM, directClient, 0).
+		BatchRestore(context.Background(), []string{srcPath}, directDest)
+	require.NoError(t, err)
+
+	// Chunked manifest with the same file.
+	chunk := makeTarZst(t, map[string][]byte{srcPath: content})
+	chunkedM := &Manifest{
+		Version: ManifestVersion, Bucket: "b", Prefix: "p", CompressionType: "zstd", TotalChunks: 1,
+		Chunks: []ChunkEntry{{ID: 0, S3Key: "p/uploads/u/shard-0/chunk-0.tar.zst", FileCount: 1, FilePaths: []string{srcPath}}},
+		Files:  []FileEntry{{Path: srcPath, Size: int64(len(content)), S3Key: "p/uploads/u/shard-0/chunk-0.tar.zst"}},
+	}
+	chunkedM.TotalFiles = 1
+	chunkedClient := &mockS3Client{chunks: map[string][]byte{"p/uploads/u/shard-0/chunk-0.tar.zst": chunk}}
+	chunkedDest := t.TempDir()
+	_, err = NewSelectiveExtractor(chunkedM, chunkedClient, 0).
+		BatchRestore(context.Background(), []string{srcPath}, chunkedDest)
+	require.NoError(t, err)
+
+	// Both landed at the identical relative location.
+	d, err := os.ReadFile(filepath.Join(directDest, wantRel))
+	require.NoError(t, err, "direct mode should write to %s", wantRel)
+	c, err := os.ReadFile(filepath.Join(chunkedDest, wantRel))
+	require.NoError(t, err, "chunked mode should write to the SAME %s", wantRel)
+	assert.Equal(t, content, d)
+	assert.Equal(t, content, c)
 }

--- a/pkg/manifest/direct_restore_test.go
+++ b/pkg/manifest/direct_restore_test.go
@@ -77,8 +77,9 @@ func TestBatchRestore_DirectUpload_WritesRawFile(t *testing.T) {
 	assert.Equal(t, int64(1), stats.Restored)
 	assert.Equal(t, int64(0), stats.Failed)
 
-	// File written by basename under dest, with the original raw content.
-	got, err := os.ReadFile(filepath.Join(dest, "greeting.txt"))
+	// File written under dest preserving structure (source path minus leading
+	// slash), escape-safe (#282), with the original raw content.
+	got, err := os.ReadFile(filepath.Join(dest, "abs/src/greeting.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "hello cargoship", string(got))
 }

--- a/tests/e2e/quickstart_test.go
+++ b/tests/e2e/quickstart_test.go
@@ -92,7 +92,12 @@ func TestQuickStart_RoundTrip(t *testing.T) {
 	restoreDir := t.TempDir()
 	runCargoship(t, "restore", uploadURL, restoreDir, "--file", "greeting.txt", "--region", "us-east-1")
 
-	got, err := os.ReadFile(filepath.Join(restoreDir, "greeting.txt"))
+	// Restore preserves the source directory structure under restoreDir
+	// (escape-safe; source path minus leading slash — see #282), so locate the
+	// restored file by basename wherever it landed rather than assuming a flat
+	// layout.
+	restored := findFileByBase(t, restoreDir, "greeting.txt")
+	got, err := os.ReadFile(restored)
 	if err != nil {
 		t.Fatalf("read restored file: %v", err)
 	}
@@ -108,6 +113,29 @@ func writeFile(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+// findFileByBase walks dir and returns the full path of the first regular file
+// with the given basename, failing if none is found.
+func findFileByBase(t *testing.T, dir, base string) string {
+	t.Helper()
+	var found string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && filepath.Base(path) == base {
+			found = path
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	if found == "" {
+		t.Fatalf("restored file %q not found under %s", base, dir)
+	}
+	return found
 }
 
 // runCargoship runs the built binary with the given args, failing the test on a


### PR DESCRIPTION
`BatchRestore` wrote restored files to **different locations by mode** — direct flattened to basename (`destDir/base`), chunked used the full source path (`destDir/entry.Path`). Beyond the surprising inconsistency (flagged by the #281 round-trip test), the chunked path was a **path-traversal risk**: `filepath.Join(destDir, entry.Path)` with an absolute or `..`-laden manifest path escapes destDir — `Join("/out", "../../etc/passwd")` == `/etc/passwd`.

## Fix

- **`safeRestorePath`** maps `FileEntry.Path` to a destination under destDir: preserves directory structure, but strips volume/leading-slash and drops `.`/`..` segments, then verifies containment as a belt-and-suspenders check. **Both** write paths (`writeDirectFiles` + `extractFromChunkData`) use it, so the layout is identical and can't escape destDir.
- **Chosen layout:** structure-preserving (source path minus leading slash) — more useful for real restores than basename-flattening, and what the chunked path already did for relative paths.

## Tests

- `safeRestorePath` unit table: relative / absolute / dot-segment / traversal / all-traversal-rejected / empty-rejected.
- **`TestBatchRestore_TraversalIsContained`** — a hostile `../../../../tmp/evil.txt` manifest path lands *inside* dest (as `tmp/evil.txt`), never at the traversal target.
- **`TestBatchRestore_LayoutParity`** — direct and chunked modes restore the same file to the **same** location.
- Updated existing direct-path assertions to the structure-preserving location.

Closes #282. (The round-trip property test from #281, which located files by basename, still passes.)