### PR TITLE
feat: dataset-relative restore layout + --flatten (#287)

### DIFF
--- a/cmd/cargoship/cmd/restore.go
+++ b/cmd/cargoship/cmd/restore.go
@@ -33,6 +33,7 @@ func NewRestoreCmd() *cobra.Command {
 		maxRestoreCost float64
 		restoreDays    int32
 		noVerify       bool
+		flatten        bool
 	)
 
 	cmd := &cobra.Command{
@@ -111,7 +112,7 @@ Examples:
 			fmt.Printf("✅ Manifest loaded: %d files, %d chunks\n\n", m.TotalFiles, m.TotalChunks)
 
 			maxCacheBytes := cacheGB * 1024 * 1024 * 1024
-			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes).SetVerify(!noVerify)
+			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes).SetVerify(!noVerify).SetFlatten(flatten)
 
 			// Resolve target paths/keys.
 			var targetPaths []string
@@ -286,6 +287,7 @@ Examples:
 	cmd.Flags().Float64Var(&maxRestoreCost, "max-restore-cost", 0, "Abort if estimated retrieval cost exceeds this USD amount")
 	cmd.Flags().Int32Var(&restoreDays, "restore-days", 7, "Days to keep Glacier restored copy available")
 	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip restore-time checksum verification (faster, but won't detect corrupted stored data)")
+	cmd.Flags().BoolVar(&flatten, "flatten", false, "Write restored files by basename into the output dir instead of recreating their directory structure")
 
 	cmd.AddCommand(newRestoreJobsCmd())
 	return cmd

--- a/docs/gen/cli/cargoship_restore.md
+++ b/docs/gen/cli/cargoship_restore.md
@@ -53,6 +53,7 @@ cargoship restore S3_URL OUTPUT_DIR [flags]
       --dry-run                  Show what would be restored without downloading
       --dvc-stage string         Restore all files produced by this DVC pipeline stage
       --file stringArray         Exact file path(s) to restore (repeatable)
+      --flatten                  Write restored files by basename into the output dir instead of recreating their directory structure
       --git-commit string        Restore all files from this git commit SHA
       --hash string              MD5 content hash of the file to restore
   -h, --help                     help for restore

--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -147,6 +147,11 @@ type SelectiveExtractor struct {
 	// default; disable with SetVerify(false). Files with no recorded checksum
 	// (or a non-sha256 algorithm) are restored without a check.
 	verify bool
+
+	// flatten writes each restored file at destDir/<basename> instead of the
+	// default dataset-relative layout (#287). Useful for targeted single-file
+	// restores. Set with SetFlatten(true).
+	flatten bool
 }
 
 // NewSelectiveExtractor creates a SelectiveExtractor. maxCacheSize sets the
@@ -170,6 +175,16 @@ func (se *SelectiveExtractor) SetVerify(v bool) *SelectiveExtractor {
 	return se
 }
 
+// SetFlatten toggles flat restore layout (destDir/<basename> per file) instead
+// of the default dataset-relative layout. Returns the receiver for chaining.
+// Handy for targeted restores where the caller just wants the file(s) in one
+// directory; not recommended for full restores that contain same-named files in
+// different directories (later wins).
+func (se *SelectiveExtractor) SetFlatten(f bool) *SelectiveExtractor {
+	se.flatten = f
+	return se
+}
+
 // checksumMismatch reports whether restore-time verification is active for this
 // entry and the given content fails it. It returns false (no mismatch) when
 // verification is off, the entry has no recorded checksum, or the manifest's
@@ -185,22 +200,26 @@ func (se *SelectiveExtractor) checksumMismatch(entry *FileEntry, content []byte)
 	return hex.EncodeToString(sum[:]) != entry.Checksum
 }
 
-// safeRestorePath maps a manifest FileEntry.Path to a destination path under
-// destDir, preserving directory structure while guaranteeing the result stays
-// inside destDir (#282). Manifests store the original source path, which may be
-// absolute (`/abs/src/f`) or, in a crafted/hostile manifest, contain `..`
-// traversal — and filepath.Join(destDir, "/abs") or Join(destDir, "../x")
-// escapes destDir. We strip any volume/leading separator and drop `..`
-// segments so a file always lands within destDir, then verify containment as a
-// belt-and-suspenders check. Both restore paths (direct + chunked) use this, so
-// their output layout is identical and escape-safe.
-func safeRestorePath(destDir, entryPath string) (string, error) {
-	// Normalize to slash form, drop any volume (Windows) and leading slashes.
-	rel := filepath.ToSlash(entryPath)
+// restorePath maps a manifest FileEntry.Path to a destination path under
+// destDir. By default it lays the file out relative to the manifest's
+// SourcePath (the upload root), so `/home/u/project/data/a.txt` uploaded from
+// root `/home/u/project` restores to `destDir/data/a.txt` — the intuitive,
+// dataset-relative layout for full and targeted restores alike (#287). When
+// se.flatten is set, the file lands at destDir/<basename>. In all cases the
+// result is guaranteed to stay inside destDir (#282): manifests store absolute
+// source paths and a crafted manifest could contain `..`, so leading
+// slashes/volume and `.`/`..` segments are stripped and containment verified.
+func (se *SelectiveExtractor) restorePath(destDir, entryPath string) (string, error) {
+	rel := se.relativeEntryPath(entryPath)
+
+	if se.flatten {
+		rel = filepath.Base(filepath.FromSlash(rel))
+	}
+
+	// Sanitize: slash-normalize, drop volume/leading slash and `.`/`..` segs.
+	rel = filepath.ToSlash(rel)
 	rel = strings.TrimPrefix(rel, filepath.VolumeName(entryPath))
 	rel = strings.TrimLeft(rel, "/")
-
-	// Drop "." and ".." segments so the path can't climb out of destDir.
 	var clean []string
 	for _, seg := range strings.Split(rel, "/") {
 		if seg == "" || seg == "." || seg == ".." {
@@ -227,6 +246,28 @@ func safeRestorePath(destDir, entryPath string) (string, error) {
 		return "", fmt.Errorf("refusing to restore %q: path escapes destination", entryPath)
 	}
 	return out, nil
+}
+
+// relativeEntryPath returns entryPath relative to the manifest's SourcePath (the
+// upload root) when it sits under it; otherwise it returns entryPath unchanged
+// (the sanitizer in restorePath still makes it destDir-safe). This is what makes
+// the default layout dataset-relative rather than rooted at "/".
+func (se *SelectiveExtractor) relativeEntryPath(entryPath string) string {
+	root := se.manifest.SourcePath
+	if root == "" {
+		return entryPath
+	}
+	// Compare in slash form; require a path-segment boundary so "/a/bc" isn't
+	// treated as under root "/a/b".
+	e := filepath.ToSlash(entryPath)
+	r := strings.TrimRight(filepath.ToSlash(root), "/")
+	if e == r {
+		return filepath.Base(e)
+	}
+	if strings.HasPrefix(e, r+"/") {
+		return strings.TrimPrefix(e, r+"/")
+	}
+	return entryPath
 }
 
 // ChunkKeysForPaths returns the deduplicated set of S3 chunk keys that contain
@@ -407,7 +448,7 @@ func (se *SelectiveExtractor) writeDirectFiles(data []byte, files []*FileEntry, 
 			return restored, totalBytes, fmt.Errorf("checksum mismatch for %s: stored object does not match manifest", entry.Path)
 		}
 		// #282: preserve directory structure under destDir, escape-safe.
-		outPath, err := safeRestorePath(destDir, entry.Path)
+		outPath, err := se.restorePath(destDir, entry.Path)
 		if err != nil {
 			return restored, totalBytes, err
 		}
@@ -522,7 +563,7 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 			continue
 		}
 		// #282: same escape-safe, structure-preserving layout as the direct path.
-		outPath, err := safeRestorePath(destDir, entry.Path)
+		outPath, err := se.restorePath(destDir, entry.Path)
 		if err != nil {
 			return restored, totalBytes, err
 		}

--- a/pkg/manifest/batch_restore_test.go
+++ b/pkg/manifest/batch_restore_test.go
@@ -588,9 +588,11 @@ func TestSafeRestorePath(t *testing.T) {
 		{"all traversal -> error", "../../..", ""},
 		{"empty -> error", "", ""},
 	}
+	// No SourcePath, no flatten: exercises the sanitization/containment layer.
+	se := &SelectiveExtractor{manifest: &Manifest{}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := safeRestorePath(dest, tt.entryPath)
+			got, err := se.restorePath(dest, tt.entryPath)
 			if tt.wantRel == "" {
 				assert.Error(t, err, "should reject %q", tt.entryPath)
 				return
@@ -677,4 +679,85 @@ func TestBatchRestore_LayoutParity(t *testing.T) {
 	require.NoError(t, err, "chunked mode should write to the SAME %s", wantRel)
 	assert.Equal(t, content, d)
 	assert.Equal(t, content, c)
+}
+
+// --- #287: dataset-relative default layout + --flatten ---
+
+// TestRestorePath_StripsSourceRoot verifies the default layout is relative to
+// the manifest SourcePath (upload root), not rooted at "/".
+func TestRestorePath_StripsSourceRoot(t *testing.T) {
+	dest := t.TempDir()
+	se := &SelectiveExtractor{manifest: &Manifest{SourcePath: "/home/u/project"}}
+
+	tests := []struct {
+		entry, want string
+	}{
+		{"/home/u/project/data/a.txt", "data/a.txt"}, // under root -> relative
+		{"/home/u/project/top.txt", "top.txt"},       // directly under root
+		{"/home/u/project", "project"},               // the root itself -> basename
+		{"/etc/passwd", "etc/passwd"},                // outside root -> sanitized full
+		{"/home/u/project2/x", "home/u/project2/x"},  // sibling, not under root (no false prefix)
+	}
+	for _, tt := range tests {
+		got, err := se.restorePath(dest, tt.entry)
+		require.NoError(t, err, tt.entry)
+		assert.Equal(t, filepath.Join(dest, filepath.FromSlash(tt.want)), got, "entry %s", tt.entry)
+	}
+}
+
+// TestRestorePath_Flatten verifies flatten mode writes basenames into destDir.
+func TestRestorePath_Flatten(t *testing.T) {
+	dest := t.TempDir()
+	se := (&SelectiveExtractor{manifest: &Manifest{SourcePath: "/home/u/project"}}).SetFlatten(true)
+
+	got, err := se.restorePath(dest, "/home/u/project/data/deep/report.txt")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dest, "report.txt"), got)
+}
+
+// TestBatchRestore_SourceRelativeLayout is the end-to-end #287 default: a file
+// uploaded from a source root restores relative to that root.
+func TestBatchRestore_SourceRelativeLayout(t *testing.T) {
+	content := []byte("dataset-relative content")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		SourcePath: "/data/project",
+		Files:      []FileEntry{{Path: "/data/project/sub/report.txt", Size: int64(len(content)), S3Key: "k"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": content}}
+
+	dest := t.TempDir()
+	stats, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{"report.txt"}, dest)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.Restored)
+
+	// Lands at dest/sub/report.txt (root stripped), NOT dest/data/project/sub/...
+	got, err := os.ReadFile(filepath.Join(dest, "sub/report.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+// TestBatchRestore_FlattenLayout is the end-to-end --flatten default: files land
+// at dest/<basename>.
+func TestBatchRestore_FlattenLayout(t *testing.T) {
+	content := []byte("flat content")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		SourcePath: "/data/project",
+		Files:      []FileEntry{{Path: "/data/project/sub/report.txt", Size: int64(len(content)), S3Key: "k"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": content}}
+
+	dest := t.TempDir()
+	stats, err := NewSelectiveExtractor(m, client, 0).SetFlatten(true).
+		BatchRestore(context.Background(), []string{"report.txt"}, dest)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.Restored)
+
+	got, err := os.ReadFile(filepath.Join(dest, "report.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
 }


### PR DESCRIPTION
UX follow-up to #282. After that fix made restore escape-safe, files landed under the **full source path** (`destDir/home/user/project/data/a.txt`) — awkward, especially for targeted single-file restores.

## Changes

- **Default layout is now relative to the manifest's `SourcePath`** (the upload root): a file uploaded from `/home/u/project` restores to `destDir/data/a.txt`, not `destDir/home/u/project/data/a.txt`. Intuitive for full and targeted restores alike, and what most archive tools do. Files not under `SourcePath` fall back to the sanitized full path.
- **`--flatten`** (`SelectiveExtractor.SetFlatten`) writes files by basename into `destDir`, for targeted restores where you just want the file(s) in one place.
- Still **escape-safe** (#282): both the `SourcePath` strip and flatten feed the same sanitizer that drops volume/leading-slash and `.`/`..` and verifies containment. `safeRestorePath` became `(se *SelectiveExtractor).restorePath` so it can see `SourcePath` + flatten.

## Tests

`restorePath` layout table (under-root / at-root / outside-root / no-false-sibling-prefix like `/a/b` vs `/a/bc`), flatten, and end-to-end `BatchRestore` for both source-relative and flatten layouts. Existing tests (manifests without `SourcePath`) are unchanged. Verified against **real S3** (round-trip property test). CLI: `restore --flatten`.

Closes #287.