### PR TITLE
fix(test): de-rot pkg/aws/s3 real-AWS tests; widen real-AWS lane scope (#291)

### DIFF
--- a/.github/workflows/real-aws-integration.yml
+++ b/.github/workflows/real-aws-integration.yml
@@ -86,15 +86,17 @@ jobs:
         if: steps.guard.outputs.configured == 'true'
         run: go mod download
 
-      # Runs the trust-critical //go:build integration suites against real S3:
-      # pkg/manifest (deep verify, batch restore, schema) and pkg/pipeline
-      # (upload → download → restore round-trip, manifest generation). These are
-      # the epic's evidence (#270). Credentials come from the OIDC step's
-      # default chain (no AWS_PROFILE); the bucket from CARGOSHIP_TEST_BUCKET.
+      # Runs the //go:build integration suites that pass against real S3 today:
+      #   - pkg/manifest  — deep verify, batch restore, schema
+      #   - pkg/pipeline  — upload → download → restore round-trip, manifests
+      #   - pkg/aws/s3    — transporter/adaptive S3 paths
+      # These are the trust epic's evidence (#270). Credentials come from the
+      # OIDC step's default chain (no AWS_PROFILE); the bucket from
+      # CARGOSHIP_TEST_BUCKET.
       #
-      # Scope is deliberately these two packages, not ./... — some legacy
-      # pkg/aws/s3 real-AWS tests have bit-rotted (hardcoded buckets, an
-      # empty-BaseEndpoint leak); tracked in #291. Widen once those are fixed.
+      # Not yet ./... — real-AWS tests in pkg/aws/cost, pkg/multiregion, and
+      # cmd/cargoship/cmd have bit-rotted (bucket/region assumptions, 404s);
+      # tracked in #291. Widen the scope as each is fixed.
       - name: Run real-AWS integration tests
         if: steps.guard.outputs.configured == 'true'
         env:
@@ -102,4 +104,4 @@ jobs:
           CARGOSHIP_ENABLE_AWS_INTEGRATION_TESTS: 'true'
           CARGOSHIP_TEST_BUCKET: ${{ vars.AWS_CI_BUCKET }}
           AWS_REGION: ${{ vars.AWS_CI_REGION || 'us-east-1' }}
-        run: go test -tags integration ./pkg/manifest/... ./pkg/pipeline/... -timeout 30m
+        run: go test -tags integration ./pkg/manifest/... ./pkg/pipeline/... ./pkg/aws/s3/... -timeout 30m

--- a/pkg/aws/s3/adaptive_transporter_integration_test.go
+++ b/pkg/aws/s3/adaptive_transporter_integration_test.go
@@ -17,9 +17,16 @@ import (
 )
 
 // createSubstrateS3Client returns an S3 client pointed at the in-process Substrate
-// emulator started by TestMain in integration_test.go.
+// emulator started by TestMain in integration_test.go. This helper is
+// emulator-only — in real-AWS mode substrateURL is empty (no emulator is
+// started), which would produce an invalid empty BaseEndpoint. Tests built on
+// it therefore skip against real AWS; the emulator lane covers them, and the
+// real-AWS evidence lives in the pkg/manifest + pkg/pipeline round-trip suites.
 func createSubstrateS3Client(t *testing.T) *s3.Client {
 	t.Helper()
+	if useRealAWS {
+		t.Skip("emulator-only test (uses Substrate BaseEndpoint); skipped in real-AWS mode")
+	}
 	cfg := aws.Config{
 		Region:       "us-east-1",
 		BaseEndpoint: aws.String(substrateURL),


### PR DESCRIPTION
`TestAdaptiveTransporter_UploadWithAdaptation` is **emulator-only** — its `createSubstrateS3Client` helper sets `BaseEndpoint` to `substrateURL`, which is empty in real-AWS mode (no emulator is started) → *"Custom endpoint '' was not a valid URI"* on upload → `assert` (not `require`) continued → **nil-deref panic** that aborted the entire `pkg/aws/s3` package against real S3.

## Fix
`createSubstrateS3Client` now `t.Skip`s in real-AWS mode — it's fundamentally an emulator helper. The emulator lane still covers this test; real-AWS evidence lives in the `pkg/manifest` + `pkg/pipeline` round-trip suites. **With that one skip, the whole `pkg/aws/s3` real-AWS suite passes** against the cargoship-dev account.

## Lane scope
Widened the real-AWS CI lane to include `./pkg/aws/s3/...` alongside manifest + pipeline (all green on real S3). Full `./...` is still deferred — running it surfaced *separate* real-AWS test rot in `pkg/multiregion` (HeadObject 404s), `pkg/aws/cost` (concurrent-writers), and `cmd/cargoship/cmd` (integration framework). Those are re-scoped under **#291** (which stays open for them).

Emulator mode is unaffected (the skip only triggers with real AWS creds — verified the test still passes on the emulator).