### PR TITLE
fix(test): tolerate pre-existing test bucket under least-priv CI role (#291)

### DIFF
--- a/pkg/aws/s3/integration_test.go
+++ b/pkg/aws/s3/integration_test.go
@@ -34,6 +34,7 @@ var (
 	realAWSRegion  string
 	realAWSBucket  string
 	substrateURL   string
+	createdTestBkt bool // true only if THIS run created the bucket (so cleanup may delete it)
 )
 
 // launchSubstrate starts an in-process Substrate server for use in TestMain
@@ -151,9 +152,19 @@ func setupTestEnvironment() error {
 
 	_, err := client.CreateBucket(ctx, createInput)
 	if err != nil {
-		return fmt.Errorf("failed to create test bucket %s: %w", bucket, err)
+		// A pre-existing bucket is fine — in CI, CARGOSHIP_TEST_BUCKET is a
+		// dedicated bucket provisioned ahead of time and the OIDC role has no
+		// s3:CreateBucket (least privilege), so CreateBucket returns 403/409.
+		// Only a genuine "can't reach a usable bucket" is fatal, so verify the
+		// bucket is accessible via HeadBucket before giving up.
+		if _, headErr := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)}); headErr == nil {
+			fmt.Printf("Using pre-existing test bucket: %s\n", bucket)
+			return nil
+		}
+		return fmt.Errorf("failed to create or access test bucket %s: %w", bucket, err)
 	}
 
+	createdTestBkt = true
 	fmt.Printf("Created test bucket: %s\n", bucket)
 
 	// Wait for bucket to be ready
@@ -197,7 +208,14 @@ func cleanupTestEnvironment() {
 		}
 	}
 
-	// Delete bucket
+	// Only delete the bucket if THIS run created it. A pre-existing bucket
+	// (CARGOSHIP_TEST_BUCKET in CI) is shared infra — leave it (its lifecycle
+	// rule expires the objects we just cleaned up anyway), and the least-priv
+	// OIDC role can't DeleteBucket regardless.
+	if !createdTestBkt {
+		fmt.Printf("Leaving pre-existing test bucket in place: %s\n", bucket)
+		return
+	}
 	_, err = client.DeleteBucket(ctx, &s3.DeleteBucketInput{
 		Bucket: aws.String(bucket),
 	})


### PR DESCRIPTION
Follow-up to #293. Widening the real-AWS lane to `pkg/aws/s3` revealed its `TestMain` unconditionally calls `CreateBucket` and treats **any** error as fatal. Under the least-privilege OIDC CI role (no `s3:CreateBucket` — the bucket is provisioned ahead of time), setup failed with `403 AccessDenied` and aborted the package.

## Fix
- **`setupTestEnvironment`**: if `CreateBucket` fails, fall back to `HeadBucket` — a reachable existing bucket is success (authorized by the role's `s3:ListBucket`). Only a genuinely unreachable bucket is fatal. Track `createdTestBkt` only when we actually created it.
- **`cleanupTestEnvironment`**: never `DeleteBucket` a pre-existing (shared) bucket — only one this run created. Objects are still cleaned; the CI bucket's 7-day lifecycle expires anything left.

No IAM policy change needed (the role already has `s3:ListBucket`). Emulator mode unchanged. Verified the full `pkg/aws/s3` real-AWS suite passes against the cargoship-dev account.

This completes the `pkg/aws/s3` slice of #291 under the actual CI credentials (the local verification in #293 used an admin role that *could* create the bucket, masking this). The remaining `pkg/multiregion` / `pkg/aws/cost` / `cmd` rot stays tracked in #291.