### PR TITLE
fix(test): never delete the shared CI bucket; serialize real-AWS packages (#291)

### DIFF
--- a/.github/workflows/real-aws-integration.yml
+++ b/.github/workflows/real-aws-integration.yml
@@ -97,6 +97,12 @@ jobs:
       # Not yet ./... — real-AWS tests in pkg/aws/cost, pkg/multiregion, and
       # cmd/cargoship/cmd have bit-rotted (bucket/region assumptions, 404s);
       # tracked in #291. Widen the scope as each is fixed.
+      #
+      # -p 1 (serial packages): all suites share the single CARGOSHIP_TEST_BUCKET,
+      # and pkg/aws/s3's cleanup wipes the whole bucket. Running packages in
+      # parallel (the default) lets one package's cleanup delete another's
+      # in-flight objects → spurious NoSuchBucket/missing-object failures. Serial
+      # execution isolates them on the shared bucket.
       - name: Run real-AWS integration tests
         if: steps.guard.outputs.configured == 'true'
         env:
@@ -104,4 +110,4 @@ jobs:
           CARGOSHIP_ENABLE_AWS_INTEGRATION_TESTS: 'true'
           CARGOSHIP_TEST_BUCKET: ${{ vars.AWS_CI_BUCKET }}
           AWS_REGION: ${{ vars.AWS_CI_REGION || 'us-east-1' }}
-        run: go test -tags integration ./pkg/manifest/... ./pkg/pipeline/... ./pkg/aws/s3/... -timeout 30m
+        run: go test -tags integration -p 1 ./pkg/manifest/... ./pkg/pipeline/... ./pkg/aws/s3/... -timeout 30m

--- a/pkg/aws/s3/integration_test.go
+++ b/pkg/aws/s3/integration_test.go
@@ -35,6 +35,7 @@ var (
 	realAWSBucket  string
 	substrateURL   string
 	createdTestBkt bool // true only if THIS run created the bucket (so cleanup may delete it)
+	externalBucket bool // true when CARGOSHIP_TEST_BUCKET was supplied — never delete it
 )
 
 // launchSubstrate starts an in-process Substrate server for use in TestMain
@@ -96,6 +97,12 @@ func TestMain(m *testing.M) {
 		realAWSBucket = os.Getenv("CARGOSHIP_TEST_BUCKET")
 		if realAWSBucket == "" {
 			realAWSBucket = "cargoship-integration-test-" + fmt.Sprintf("%d", time.Now().Unix())
+		} else {
+			// A caller-supplied bucket is shared, provisioned infra — never
+			// delete it in cleanup, whatever CreateBucket returns. (In us-east-1
+			// CreateBucket on your own existing bucket succeeds silently, so we
+			// can't infer "we created it" from that call alone.)
+			externalBucket = true
 		}
 
 		fmt.Printf("Running integration tests against REAL AWS\n")
@@ -208,12 +215,12 @@ func cleanupTestEnvironment() {
 		}
 	}
 
-	// Only delete the bucket if THIS run created it. A pre-existing bucket
-	// (CARGOSHIP_TEST_BUCKET in CI) is shared infra — leave it (its lifecycle
-	// rule expires the objects we just cleaned up anyway), and the least-priv
-	// OIDC role can't DeleteBucket regardless.
-	if !createdTestBkt {
-		fmt.Printf("Leaving pre-existing test bucket in place: %s\n", bucket)
+	// Never delete a caller-supplied bucket (CARGOSHIP_TEST_BUCKET) — it's
+	// shared, provisioned infra. Only delete a bucket THIS run created with an
+	// auto-generated name. (Its objects were just cleaned above; a CI bucket's
+	// lifecycle rule also expires anything left.)
+	if externalBucket || !createdTestBkt {
+		fmt.Printf("Leaving test bucket in place (not created by this run): %s\n", bucket)
 		return
 	}
 	_, err = client.DeleteBucket(ctx, &s3.DeleteBucketInput{


### PR DESCRIPTION
Follow-up to #294 — found while validating the widened real-AWS lane.

## The bug (dangerous)
`pkg/aws/s3`'s cleanup was **deleting the shared `CARGOSHIP_TEST_BUCKET`** between runs. Root cause: in **us-east-1**, `CreateBucket` on a bucket you already own returns **200** (not `BucketAlreadyOwnedByYou`), so the `createdTestBkt=true` path fired even for a pre-existing bucket → cleanup's `DeleteBucket` destroyed it. I hit this the hard way — it deleted the cargoship-dev CI bucket twice during local verification under an admin role.

## Fix
- Track `externalBucket = (CARGOSHIP_TEST_BUCKET was supplied)` and **never** `DeleteBucket` in that case, whatever `CreateBucket` returns. A caller-supplied bucket is shared, provisioned infra; only an auto-named bucket this run actually created is deleted. Verified the bucket **survives repeated isolated + parallel runs**.
- Run the lane's packages **serially (`-p 1`)**: they share one real bucket and `pkg/aws/s3`'s cleanup wipes it, so parallel packages could delete each other's in-flight objects. Defensive; ~1 min, removes that flake class.

Emulator mode unchanged. All three packages (manifest, pipeline, aws/s3) pass against the cargoship-dev account. Completes the `pkg/aws/s3` slice of #291; remaining rot (pkg/multiregion, pkg/aws/cost, cmd) stays tracked there.