### PR TITLE
ci: widen real-AWS lane to ./...; gate multiregion tests behind opt-in (#291)

### DIFF
--- a/.github/workflows/real-aws-integration.yml
+++ b/.github/workflows/real-aws-integration.yml
@@ -86,17 +86,13 @@ jobs:
         if: steps.guard.outputs.configured == 'true'
         run: go mod download
 
-      # Runs the //go:build integration suites that pass against real S3 today:
-      #   - pkg/manifest  — deep verify, batch restore, schema
-      #   - pkg/pipeline  — upload → download → restore round-trip, manifests
-      #   - pkg/aws/s3    — transporter/adaptive S3 paths
-      # These are the trust epic's evidence (#270). Credentials come from the
-      # OIDC step's default chain (no AWS_PROFILE); the bucket from
-      # CARGOSHIP_TEST_BUCKET.
-      #
-      # Not yet ./... — real-AWS tests in pkg/aws/cost, pkg/multiregion, and
-      # cmd/cargoship/cmd have bit-rotted (bucket/region assumptions, 404s);
-      # tracked in #291. Widen the scope as each is fixed.
+      # Runs the whole //go:build integration suite against real S3 (the trust
+      # epic's evidence, #270). Credentials come from the OIDC step's default
+      # chain (no AWS_PROFILE); the bucket from CARGOSHIP_TEST_BUCKET. Suites
+      # that don't touch S3 (or gate on the emulator / other opt-ins) self-skip
+      # — e.g. pkg/multiregion needs multi-region bucket-creating creds and a
+      # coordinator S3 write path (#296), gated behind
+      # CARGOSHIP_ENABLE_MULTIREGION_TESTS.
       #
       # -p 1 (serial packages): all suites share the single CARGOSHIP_TEST_BUCKET,
       # and pkg/aws/s3's cleanup wipes the whole bucket. Running packages in
@@ -110,4 +106,4 @@ jobs:
           CARGOSHIP_ENABLE_AWS_INTEGRATION_TESTS: 'true'
           CARGOSHIP_TEST_BUCKET: ${{ vars.AWS_CI_BUCKET }}
           AWS_REGION: ${{ vars.AWS_CI_REGION || 'us-east-1' }}
-        run: go test -tags integration -p 1 ./pkg/manifest/... ./pkg/pipeline/... ./pkg/aws/s3/... -timeout 30m
+        run: go test -tags integration -p 1 ./... -timeout 30m

--- a/pkg/multiregion/integration_test.go
+++ b/pkg/multiregion/integration_test.go
@@ -32,6 +32,17 @@ func skipIfNoAWS(t *testing.T) {
 		t.Skip("Skipping AWS integration test (set CARGOSHIP_ENABLE_AWS_INTEGRATION_TESTS=true to enable)")
 	}
 
+	// These tests provision their OWN buckets in two regions (createTestBucket
+	// with s3:CreateBucket) and then assert real S3 state after a coordinator
+	// upload. They don't fit the shared-single-bucket, least-privilege CI lane,
+	// and the coordinator's real S3 write path needs work before the HeadObject
+	// assertions hold (see #296). Opt in explicitly with
+	// CARGOSHIP_ENABLE_MULTIREGION_TESTS=true once you have multi-region,
+	// bucket-creating credentials.
+	if os.Getenv("CARGOSHIP_ENABLE_MULTIREGION_TESTS") != "true" {
+		t.Skip("Skipping multi-region integration test: needs multi-region bucket-creating creds and coordinator S3 write path (#296); set CARGOSHIP_ENABLE_MULTIREGION_TESTS=true to run")
+	}
+
 	// Check for AWS credentials
 	cfg, err := awsconfig.LoadDefaultConfig(context.Background())
 	if err != nil {


### PR DESCRIPTION
Completes the widening goal of #291.

## Findings
Re-running each package against the cargoship-dev account revealed the earlier `./...` failures were **two different things**:

- **`pkg/aws/cost` + `cmd/cargoship/cmd`** — passed in isolation; their `./...` failures were the **shared-bucket wipe race** (`pkg/aws/s3`'s full-bucket cleanup deleting other packages' in-flight objects). Already fixed by `-p 1`. No code change needed.
- **`pkg/multiregion`** — genuine, deeper rot: the tests provision their own buckets in **two regions** (needs `s3:CreateBucket`, which the least-priv CI role lacks) and assert real S3 state after `coordinator.Upload(...)`, which **404s even with admin creds + real buckets** — the coordinator's region→bucket write path looks incomplete. Split to **#296**.

## Changes
- `pkg/multiregion`: `skipIfNoAWS` now also skips unless `CARGOSHIP_ENABLE_MULTIREGION_TESTS=true`, so these don't block the lane.
- Widen the real-AWS lane from three packages to **`go test -p 1 ./...`** — everything self-skips appropriately.

## Verified
Full `./...` real-AWS suite passes with `-p 1` against cargoship-dev: **45 packages ok, multiregion skips**. Emulator lane unaffected.

Closes the widening goal of #291; the multiregion coordinator work is tracked in #296.