### PR TITLE
docs: cover v0.16.0 trust features in the user-facing guides

### DIFF
--- a/docs/guides/restoring.md
+++ b/docs/guides/restoring.md
@@ -44,6 +44,42 @@ records at upload time, so you can reconstruct exactly the inputs or outputs of 
 pipeline run. See [DVC integration](/reference/commands/dvc) for how stages are
 tracked.
 
+## Integrity: verified as it restores
+
+Restore verifies content **as it writes**. Each file's SHA-256 is recomputed
+from the bytes coming out of the archive and compared against the checksum
+recorded at upload time; on a mismatch CargoShip fails that file rather than
+writing corrupt data to disk. This is on by default and covers both direct and
+chunked storage.
+
+- `--no-verify` skips restore-time verification (faster, but a corrupted stored
+  object would be written out silently). Leave it on unless you have a specific
+  reason not to.
+
+For the guarantee this backs and how to audit it yourself, see the
+[Integrity model](/project/integrity).
+
+## Output layout
+
+By default, restored files are written under `OUTPUT_DIR` with their paths
+reconstructed **relative to the upload root** — so a file uploaded from
+`project/data/train.csv` lands at `OUTPUT_DIR/data/train.csv`. Paths are always
+sanitized and confined to `OUTPUT_DIR` (absolute paths and `..` components can't
+escape it).
+
+- `--flatten` writes each restored file by **basename** directly into
+  `OUTPUT_DIR`, ignoring its directory structure — convenient for pulling a
+  handful of specific files without recreating deep trees. Basenames must be
+  unique across your selection to avoid collisions.
+
+```bash
+# Recreate the directory structure (default)
+cargoship restore s3://my-bucket/.../20260721-a1b2c3 ./out --file data/train.csv
+
+# Drop the file straight into ./out as train.csv
+cargoship restore s3://my-bucket/.../20260721-a1b2c3 ./out --file data/train.csv --flatten
+```
+
 ## Glacier & Deep Archive {#glacier}
 
 When the chunks you want live in Glacier Flexible Retrieval or Deep Archive, they
@@ -136,6 +172,7 @@ flags.
 
 ## See also
 
+- [Integrity model](/project/integrity) — verify-on-restore and the byte-identity claim.
 - [Downloading & extracting](/guides/downloading) — for readable storage classes.
 - [Concepts: restore vs. download](/intro/concepts#restore-vs-download).
 - [Tier-aware storage](/guides/features/tiering) — how files end up in Glacier.

--- a/docs/guides/uploading.md
+++ b/docs/guides/uploading.md
@@ -78,6 +78,22 @@ cargoship upload ./my-data s3://my-bucket/archives/ \
 Data chunks are written with SSE-KMS; `--encrypt-manifest` additionally
 envelope-encrypts the manifest. See [Encryption](/guides/features/encryption).
 
+## Integrity checksums
+
+Every upload records a SHA-256 checksum at two levels: per stored chunk, and
+**per file**. These are what let [`verify --deep`](/guides/verifying) confirm the
+stored bytes still match, and what [restore](/guides/restoring) checks as it
+writes files back. Per-file checksums are **on by default**.
+
+```bash
+# Faster uploads, but verify --deep can no longer confirm per-file integrity
+cargoship upload ./my-data s3://my-bucket/archives/ --no-file-checksums
+```
+
+Only use `--no-file-checksums` when upload speed matters more than per-file
+verifiability; chunk-level checksums are still recorded either way. See the
+[Integrity model](/project/integrity) for what the checksums guarantee.
+
 ## Incremental sync
 
 Upload only what's new or changed since a previous run:
@@ -108,6 +124,8 @@ Then see [Budgets & quotas](/guides/cost/budgets) and
 - **Set a region default** (`AWS_REGION`) or pass `--region` to match your bucket.
 - **Leave shard count on auto** unless benchmarking — it's tuned to your workload.
 - **Turn on `--enable-dedup`** only when you expect duplicate files; it costs a hash pass.
+- **Keep per-file checksums on** (the default) so `verify --deep` and restore can
+  confirm per-file integrity; only add `--no-file-checksums` when speed wins.
 - **Tag `--project`** from day one so cost reporting is meaningful later.
 - **Use `--quiet`** in scripts and cron; keep the progress UI for interactive runs.
 :::

--- a/docs/guides/verifying.md
+++ b/docs/guides/verifying.md
@@ -4,8 +4,10 @@
 by validating its manifest and the checksums recorded in it. It downloads the
 manifest (~30 KB), checks that shard counts, file counts, and size totals agree,
 looks for missing or corrupted metadata, and validates checksum coverage where
-present — all without downloading the archive data itself. The full flag list
-lives in the [command reference](/reference/commands/inspect).
+present — all without downloading the archive data itself. Add `--deep` to go
+further and re-download the stored objects to confirm the bytes still match
+their recorded checksums. The full flag list lives in the
+[command reference](/reference/commands/inspect).
 
 ```bash
 cargoship verify S3_URL
@@ -61,15 +63,34 @@ value, and actual value, then exits non-zero:
      Actual:   9
 ```
 
-## Quick vs. full
+## Three levels: quick, full, deep
 
-- **Full** (default) runs every consistency and checksum-coverage check.
+`verify` runs at three depths, trading cost for assurance:
+
 - **`--quick`** does a fast, metadata-only pass — it validates structure and
-  consistency but skips the deeper checks. Use it as a cheap smoke test.
+  consistency but skips the checksum checks. Use it as a cheap smoke test.
+- **Full** (default) runs every consistency and checksum-coverage check against
+  the manifest. It reads only the manifest, so a full verify of a multi-terabyte
+  upload still finishes in seconds.
+- **`--deep`** performs **data-level** verification: it re-downloads every stored
+  object and recomputes its SHA-256, comparing against the checksums recorded at
+  upload time. This is the only level that catches bit-rot or tampering in the
+  stored data itself — a corrupted or missing object fails the check and exits
+  non-zero. Because it transfers the archive data, it incurs GET requests and
+  egress; run it periodically for long-term archives rather than on every check.
 
 ```bash
+# Cheap metadata smoke test
 cargoship verify s3://my-bucket/archives/uploads/20260721-a1b2c3 --quick
+
+# Data-level integrity — re-download and re-hash the stored bytes
+cargoship verify s3://my-bucket/archives/uploads/20260721-a1b2c3 --deep
 ```
+
+Deep verify depends on the per-file checksums recorded at upload time (on by
+default; disabled by `upload --no-file-checksums`). It also checks chunk-level
+checksums regardless. For the full mechanics, see the
+[Integrity model](/project/integrity).
 
 Add `--verbose` for per-error and per-warning detail. Like `info` and `verify`'s
 sibling commands, you can address the upload with an S3 URL or with
@@ -103,11 +124,16 @@ schedule for compliance or audit requirements.
   archive.
 - **Schedule a periodic `--quick` sweep** across critical uploads and alert on a
   non-zero exit.
+- **Run `--deep` on a slower cadence** for long-term archives — it's the only
+  level that detects bit-rot in the stored data, at the cost of GET requests and
+  egress.
 - **Use `--verbose`** when a check fails to see exactly which field diverged.
 :::
 
 ## See also
 
+- [Integrity model](/project/integrity) — what the byte-identity claim is and how
+  `--deep` and verify-on-restore make it checkable.
 - [Listing & inspecting uploads](/guides/inspecting).
 - [Verify & restore it](/start/verify-and-restore) — the round-trip walkthrough.
 - [Concepts: manifest](/intro/concepts#manifest).

--- a/docs/intro/costs-and-safety.md
+++ b/docs/intro/costs-and-safety.md
@@ -28,9 +28,13 @@ See [Estimating costs](/guides/cost/estimate), and set guardrails with
 ## Safety guarantees
 
 - **Nothing is deleted on upload.** Uploading never touches your source files.
-- **Integrity is verifiable.** Every upload records checksums in its manifest;
-  [`cargoship verify`](/guides/verifying) proves the archive matches, and a
-  restore round-trip proves you can get data back.
+- **Integrity is verifiable.** Every upload records per-chunk and per-file
+  SHA-256 checksums. [`cargoship verify --deep`](/guides/verifying) re-downloads
+  the stored bytes and re-hashes them to prove the archive still matches, and
+  [restore verifies each file as it writes](/guides/restoring) so it never hands
+  back corrupt data. Every release is validated against real S3 and ships a
+  [verification report](/project/verification-reports). See the
+  [Integrity model](/project/integrity) for the exact, bounded claim.
 - **Destructive commands require confirmation.** They prompt before acting and
   support `--dry-run` to preview.
 

--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -47,6 +47,7 @@ cargoship balance s3://my-bucket/archives/uploads/20260721-a1b2c3
 ```bash
 cargoship verify s3://my-bucket/archives/uploads/20260721-a1b2c3
 cargoship verify s3://my-bucket/archives/uploads/20260721-a1b2c3 --quick
+cargoship verify s3://my-bucket/archives/uploads/20260721-a1b2c3 --deep   # re-download & re-hash stored bytes
 # exit 0 = passed, 1 = failed
 ```
 
@@ -56,8 +57,11 @@ cargoship verify s3://my-bucket/archives/uploads/20260721-a1b2c3 --quick
 # Download from a readable storage class
 cargoship download s3://my-bucket/archives/uploads/20260721-a1b2c3 ./out --pattern "*.log"
 
-# Restore specific files (handles Glacier)
+# Restore specific files (handles Glacier; verifies each file as it writes)
 cargoship restore s3://my-bucket/archives/uploads/20260721-a1b2c3 ./out --file data/train.csv
+
+# Flatten restored files into ./out by basename (no directory tree)
+cargoship restore s3://my-bucket/archives/uploads/20260721-a1b2c3 ./out --file data/train.csv --flatten
 
 # Restore from Glacier, wait for thaw, cap the cost
 cargoship restore s3://my-bucket/archives/uploads/20260721-a1b2c3 ./out \

--- a/docs/start/verify-and-restore.md
+++ b/docs/start/verify-and-restore.md
@@ -39,7 +39,8 @@ cargoship verify s3://my-bucket/archives/uploads/20260721-a1b2c3
 
 `verify` checks the archive against the checksums recorded in the manifest and
 exits non-zero if anything is missing or corrupt — so it's safe to use in scripts
-and CI. Use `--quick` for a fast metadata-only check.
+and CI. Use `--quick` for a fast metadata-only check, or `--deep` to re-download
+the stored objects and re-hash them for data-level integrity.
 
 ## Restore a file
 


### PR DESCRIPTION
## Summary

Ahead of re-review, brings the **prose documentation** up to date with v0.16.0. The auto-generated CLI reference already carried the new flags (drift check is green), but the hand-written guides still described pre-v0.16.0 behavior — e.g. `verifying.md` said verify only checks "checksum coverage" with no mention of the flagship `--deep` data-level verification.

## Changes

| File | Update |
|---|---|
| `guides/verifying.md` | Three verification levels (quick / full / **`--deep`**); `--deep` = re-download + re-hash stored bytes for data-level integrity; cost note; links Integrity model |
| `guides/restoring.md` | **Verify-on-restore** (`--no-verify`) and dataset-relative **output layout + `--flatten`** |
| `guides/uploading.md` | **Per-file checksums** (on by default) + `--no-file-checksums` |
| `intro/costs-and-safety.md` | Integrity framing → `verify --deep`, verify-on-restore, per-release verification report |
| `reference/cheatsheet.md` | `--deep` and `--flatten` examples |
| `start/verify-and-restore.md` | `--deep` in the round-trip walkthrough |

## Verification

- **CLI drift:** 0 (reference regenerated, no changes).
- **doc-consistency:** passes — version declarations match 0.16.0, no denylisted tokens, all local links resolve.
- **VitePress build:** clean.

All new cross-links (`/project/integrity`, `/project/verification-reports`, `/start/verify-and-restore`) resolve to existing pages.