### PR TITLE
test(fuzz): extend fuzzing to the trust/integrity surface (#302)

### DIFF
--- a/.github/workflows/fuzz-deep.yml
+++ b/.github/workflows/fuzz-deep.yml
@@ -1,0 +1,121 @@
+name: Fuzz (deep)
+
+# Long-running fuzzing over the trust/integrity surface, deliberately OFF the PR
+# critical path. The "Fuzz (short burst)" job in test.yml guards every pull
+# request with ~500k executions per target; this lane runs the same targets for
+# roughly 40x longer, which is where the deeper crashers actually live.
+#
+# Why a separate lane rather than a longer PR job: fuzzing finds new inputs
+# sublinearly, so the marginal value of minutes 5-60 is real but nowhere near
+# worth adding an hour to every PR. Splitting keeps PR feedback fast while still
+# accumulating coverage over time. Same reasoning as real-aws-integration.yml.
+#
+# When this lane finds a crasher it uploads the minimized input as an artifact.
+# The fix workflow is: download it into testdata/fuzz/<Target>/, confirm it fails
+# as a unit test, fix the bug, and commit the input as permanent regression
+# corpus (it then runs on every PR forever, via `go test`).
+#
+# Targets cover the format/verification surface hardened by the trust epic
+# (#270): the restore path sanitizer (a security boundary — #282 was a real
+# traversal), the S3 key resolver (#273/#281), the schema validator (#274), and
+# the manifest (de)serializers. See #302.
+
+on:
+  schedule:
+    # Weekly, Mondays 05:00 UTC — before the real-AWS canary at 07:00 so a
+    # format-level crasher surfaces before the integration lane runs.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: 'Executions per target (a COUNT, e.g. 20000000x — not a duration)'
+        required: false
+        default: '20000000x'
+
+permissions:
+  contents: read
+
+# Serialize: two concurrent deep runs would just duplicate work. Don't cancel an
+# in-progress run — a partially completed fuzz session still has value, and a
+# crasher found late is the whole point.
+concurrency:
+  group: fuzz-deep
+  cancel-in-progress: false
+
+env:
+  GO_VERSION: '1.26'
+
+jobs:
+  fuzz-deep:
+    name: Deep fuzz (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    strategy:
+      # One job per package so a crasher in one target doesn't cut short the
+      # fuzzing of unrelated targets.
+      fail-fast: false
+      matrix:
+        include:
+          - package: ./pkg/manifest/
+            name: manifest
+            targets: >-
+              FuzzFromJSON FuzzFromJSONAuto FuzzManifestRoundTrip FuzzParseS3URL
+              FuzzRestorePath FuzzResolveObjectKey FuzzValidateAgainstSchema
+          - package: ./pkg/chunking/
+            name: chunking
+            targets: FuzzCreateChunks
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      # Budget is an execution COUNT, not a wall-clock duration. A duration
+      # -fuzztime lets the fuzzing coordinator race its own deadline on a
+      # contended runner and fail with a spurious "context deadline exceeded"
+      # rather than a real crasher (#266). A count has no time-based context, so
+      # that flake cannot occur. The job timeout above is the real wall-clock cap.
+      #
+      # `|| true` per target, with failures accumulated: one crashing target must
+      # not stop the others from running, but the job must still fail at the end.
+      - name: Fuzz ${{ matrix.name }} targets
+        id: fuzz
+        run: |
+          set -uo pipefail
+          budget="${{ github.event.inputs.fuzztime || '20000000x' }}"
+          failed=""
+          for target in ${{ matrix.targets }}; do
+            echo "::group::${{ matrix.package }} $target ($budget)"
+            if ! go test "${{ matrix.package }}" -run '^$' -fuzz "^${target}$" -fuzztime "$budget"; then
+              echo "::error::fuzz target $target failed — see the uploaded corpus artifact"
+              failed="$failed $target"
+            fi
+            echo "::endgroup::"
+          done
+          if [ -n "$failed" ]; then
+            echo "failed=$failed" >> "$GITHUB_OUTPUT"
+            echo "Crashers found in:$failed"
+            exit 1
+          fi
+
+      # Any crasher Go finds is written to testdata/fuzz/<Target>/. Upload it so
+      # the input can be committed as regression corpus — without this the
+      # minimized reproducer dies with the runner.
+      - name: Upload crasher corpus
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fuzz-crashers-${{ matrix.name }}
+          path: |
+            pkg/**/testdata/fuzz/**
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/fuzz-deep.yml
+++ b/.github/workflows/fuzz-deep.yml
@@ -87,15 +87,27 @@ jobs:
       #
       # `|| true` per target, with failures accumulated: one crashing target must
       # not stop the others from running, but the job must still fail at the end.
+      # Inputs reach the script through env, never via ${{ }} interpolation into
+      # run: — a dispatch input is untrusted and would otherwise be a shell
+      # injection into the runner. BUDGET is additionally format-checked so it
+      # can't smuggle extra go-test flags.
       - name: Fuzz ${{ matrix.name }} targets
         id: fuzz
+        env:
+          PKG: ${{ matrix.package }}
+          TARGETS: ${{ matrix.targets }}
+          BUDGET: ${{ github.event.inputs.fuzztime || '20000000x' }}
         run: |
           set -uo pipefail
-          budget="${{ github.event.inputs.fuzztime || '20000000x' }}"
+          if ! printf '%s' "$BUDGET" | grep -Eq '^[0-9]+x$'; then
+            echo "::error::fuzztime must be an execution count like 20000000x, got: $BUDGET"
+            exit 1
+          fi
           failed=""
-          for target in ${{ matrix.targets }}; do
-            echo "::group::${{ matrix.package }} $target ($budget)"
-            if ! go test "${{ matrix.package }}" -run '^$' -fuzz "^${target}$" -fuzztime "$budget"; then
+          # Word-split TARGETS deliberately: it is a space-separated list.
+          for target in $TARGETS; do
+            echo "::group::$PKG $target ($BUDGET)"
+            if ! go test "$PKG" -run '^$' -fuzz "^${target}$" -fuzztime "$BUDGET"; then
               echo "::error::fuzz target $target failed — see the uploaded corpus artifact"
               failed="$failed $target"
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,8 @@ jobs:
       # committed seed corpus (which the -short jobs already execute as unit
       # tests). -fuzz runs one target per package invocation, so iterate. Kept
       # brief to stay on the PR critical path; the corpus grows over time via
-      # developers running longer local sessions. (#238 Phase 4)
+      # developers running longer local sessions and the weekly deep lane in
+      # fuzz-deep.yml, which runs the same targets for ~40x longer. (#238 Phase 4)
       #
       # Budget is an execution COUNT, not a wall-clock duration: a duration
       # -fuzztime lets the fuzzing coordinator race its own deadline on a
@@ -133,7 +134,9 @@ jobs:
               echo "::endgroup::"
             done
           }
-          fuzz_pkg ./pkg/manifest/ FuzzFromJSON FuzzFromJSONAuto FuzzManifestRoundTrip FuzzParseS3URL
+          fuzz_pkg ./pkg/manifest/ \
+            FuzzFromJSON FuzzFromJSONAuto FuzzManifestRoundTrip FuzzParseS3URL \
+            FuzzRestorePath FuzzResolveObjectKey FuzzValidateAgainstSchema
           fuzz_pkg ./pkg/chunking/ FuzzCreateChunks
 
   lint:

--- a/docs/project/integrity.md
+++ b/docs/project/integrity.md
@@ -108,6 +108,31 @@ The integrity mechanisms are exercised on every change, not just at release:
 - The deep-verify path is tested against **deliberately corrupted** objects —
   the test suite confirms that flipping a byte in storage makes `verify --deep`
   fail loudly. Detecting corruption is the guarantee; the tests prove it detects.
+- The format and verification code is **fuzzed** — see below.
+
+### Fuzzing the trust surface
+
+Hand-written tests cover the cases someone thought of. Fuzzing covers the ones
+nobody did, which is exactly where integrity bugs hide: a manifest is external
+input, and the code that parses it, resolves S3 keys from it, and turns its
+recorded paths into local filenames is all reachable from data CargoShip did not
+author.
+
+So those functions are fuzzed against **invariants**, not just for crashes:
+
+| Target | Invariant |
+| --- | --- |
+| Restore path sanitizer | An accepted path always lands **inside** the destination directory. A violation is a [path traversal](/project/security), not a wrong answer. |
+| S3 key resolver | A resolved key is never a URL, is always prefix-scoped, and resolving twice changes nothing. |
+| Schema validator | Any manifest CargoShip writes validates against its own [published schema](/reference/format/manifest). |
+| Manifest (de)serializers | Arbitrary bytes never panic; a parsed manifest re-serializes byte-identically. |
+
+Every pull request runs a short burst against each target; a weekly lane runs
+them roughly 40× longer. Every crashing input ever found is committed to the
+repository as permanent regression corpus, so a fixed bug is re-tested on every
+run forever. This has already found real defects that tests missed — including a
+resolver that destroyed any object key containing `://` in a filename, and
+manifests being written in a shape the published schema rejected.
 
 ## What CargoShip does **not** promise
 

--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -128,28 +128,81 @@ func (dv *DeepVerifier) VerifyChunks(ctx context.Context) (*DeepVerifyResult, er
 // only when the key doesn't already contain it. Exported so callers that need
 // the real object location (e.g. tests, tooling) resolve it identically.
 func ResolveObjectKey(prefix, bucket, s3Key string) string {
-	key := s3Key
+	// Drop leading slashes. S3 treats "prefix//key" and "prefix/key" as distinct
+	// objects, so a key stored with a leading "/" would resolve to an object that
+	// doesn't exist. Done first so the scheme check below sees the scheme in
+	// leading position. Found by FuzzResolveObjectKey.
+	key := strings.TrimLeft(s3Key, "/")
 
-	// Strip a scheme://host/ prefix if S3Key was stored as a full URL.
-	if i := strings.Index(key, "://"); i >= 0 {
-		rest := key[i+3:]
-		if slash := strings.Index(rest, "/"); slash >= 0 {
-			key = rest[slash+1:] // drop host, keep path
-		} else {
-			key = ""
+	// Strip a scheme://host/ prefix if S3Key was stored as a full URL. Only a
+	// "://" in true scheme position counts: S3 permits ':' in object keys, so
+	// matching "://" anywhere would mangle a legitimate key (a file named
+	// "weird://name.txt" once resolved to just the bare prefix). Looped, with a
+	// re-trim each pass, so a doubly-wrapped URL can't leave a scheme behind.
+	// Found by FuzzResolveObjectKey.
+	for {
+		i := strings.Index(key, "://")
+		if i <= 0 || !isURLScheme(key[:i]) {
+			break
 		}
+		rest := key[i+3:]
+		slash := strings.Index(rest, "/")
+		if slash < 0 {
+			key = ""
+			break
+		}
+		key = strings.TrimLeft(rest[slash+1:], "/") // drop host, keep path
 	}
 
-	// Strip a leading "bucket/" if present.
+	// The prefix is trimmed of surrounding slashes: a manifest written from a
+	// user-typed "s3://bucket/archives/" carries a trailing slash, and joining
+	// naively would yield "archives//key" — a different object in S3. Found by
+	// FuzzResolveObjectKey.
+	prefix = strings.Trim(prefix, "/")
+
+	// An already prefix-scoped key is the resolved form; return it untouched.
+	// Testing this BEFORE the bucket strip is what makes resolution idempotent:
+	// otherwise a resolved key whose leading segment happens to equal the bucket
+	// name would have that segment stripped on a second pass, silently dropping a
+	// path component. Found by FuzzResolveObjectKey.
+	if prefix != "" && (key == prefix || strings.HasPrefix(key, prefix+"/")) {
+		return key
+	}
+
+	// Strip a leading "bucket/" if present, then re-trim: stripping the bucket
+	// can expose another leading slash ("bucket//key" -> "/key").
 	if bucket != "" {
-		key = strings.TrimPrefix(key, bucket+"/")
+		key = strings.TrimLeft(strings.TrimPrefix(key, bucket+"/"), "/")
 	}
 
 	// Prepend the manifest Prefix unless it's already there (or empty).
-	if prefix != "" && !strings.HasPrefix(key, prefix+"/") {
+	if prefix != "" && key != prefix && !strings.HasPrefix(key, prefix+"/") {
 		key = prefix + "/" + key
 	}
 	return key
+}
+
+// isURLScheme reports whether s is a plausible URI scheme per RFC 3986:
+// ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ). Anything else preceding a "://"
+// is part of an object key, not a scheme.
+func isURLScheme(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z':
+			// always allowed
+		case i == 0:
+			return false // must start with a letter
+		case c >= '0' && c <= '9', c == '+', c == '-', c == '.':
+			// allowed after the first character
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // objectKey resolves a chunk key against this manifest's prefix/bucket.

--- a/pkg/manifest/deep_verify_test.go
+++ b/pkg/manifest/deep_verify_test.go
@@ -171,6 +171,19 @@ func TestResolveObjectKey(t *testing.T) {
 		{"bucket-qualified", "myprefix", "b", "b/myprefix/uploads/u/chunk-0", "myprefix/uploads/u/chunk-0"},
 		{"full URL", "myprefix", "cargoship-test", "http://127.0.0.1:9000/cargoship-test/myprefix/uploads/u/chunk-0", "myprefix/uploads/u/chunk-0"},
 		{"https URL no prefix", "", "b", "https://s3.amazonaws.com/b/uploads/u/chunk-0", "uploads/u/chunk-0"},
+		// S3 permits ':' in object keys, so a "://" that isn't in scheme
+		// position is part of the key and must survive. Previously the whole
+		// key collapsed to the bare prefix. Found by FuzzResolveObjectKey.
+		{"colon-slash-slash inside key", "pfx", "b", "pfx/uploads/u/weird://name.txt", "pfx/uploads/u/weird://name.txt"},
+		{"empty scheme is not a URL", "pfx", "b", "://nohost", "pfx/://nohost"},
+		// Slashes around a prefix are not significant, but "pfx//key" is a
+		// different S3 object than "pfx/key". Found by FuzzResolveObjectKey.
+		{"trailing slash on prefix", "pfx/", "b", "uploads/u/chunk-0", "pfx/uploads/u/chunk-0"},
+		{"leading slash on key", "pfx", "b", "/uploads/u/chunk-0", "pfx/uploads/u/chunk-0"},
+		// A resolved key whose first segment equals the bucket name must not have
+		// that segment eaten on a second resolve pass. Found by FuzzResolveObjectKey.
+		{"prefix-scoped key shadowing bucket name", "b/x", "b", "b/x/chunk-0", "b/x/chunk-0"},
+		{"URL with a leading slash", "pfx", "b", "/http://host/b/pfx/uploads/u/c-0", "pfx/uploads/u/c-0"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/manifest/fuzz_test.go
+++ b/pkg/manifest/fuzz_test.go
@@ -1,6 +1,9 @@
 package manifest
 
 import (
+	"net/url"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -127,6 +130,223 @@ func FuzzParseS3URL(f *testing.F) {
 		if reconstructed != url {
 			t.Fatalf("reconstruct mismatch: url=%q -> bucket=%q prefix=%q -> %q",
 				url, bucket, prefix, reconstructed)
+		}
+	})
+}
+
+// FuzzRestorePath fuzzes the restore path sanitizer, which is a SECURITY
+// boundary: manifests record absolute source paths and a crafted (or corrupt)
+// manifest can contain absolute paths, `..` segments, or Windows volume names.
+// #282 was a real path traversal here — `filepath.Join(destDir, entry.Path)`
+// escaped destDir — so this is exactly the code where table tests cover the
+// cases someone thought of and miss the ones they didn't.
+//
+// The invariant is absolute and holds for every input:
+//
+//	restorePath either returns an error, or returns a path inside destDir.
+//
+// A violation is a path-traversal vulnerability, not merely a wrong answer.
+// Both layout modes (dataset-relative and --flatten) and both empty and
+// populated SourcePath roots are fuzzed, since the sanitizer's behavior depends
+// on all of them.
+func FuzzRestorePath(f *testing.F) {
+	// Seeds: benign, plus the traversal shapes #282 was about.
+	f.Add("data/a.txt", "", false)
+	f.Add("/home/u/project/data/a.txt", "/home/u/project", false)
+	f.Add("../../../etc/passwd", "", false)
+	f.Add("/etc/passwd", "", false)
+	f.Add("..", "", false)
+	f.Add("../", "", true)
+	f.Add("a/../../b", "/a", false)
+	f.Add(`C:\Windows\system32`, "", false)
+	f.Add("//../..//x", "", false)
+	f.Add("", "", false)
+	f.Add(".", "", true)
+	f.Add("日本語/../../x", "", false)
+
+	f.Fuzz(func(t *testing.T, entryPath, sourcePath string, flatten bool) {
+		se := &SelectiveExtractor{
+			manifest: &Manifest{SourcePath: sourcePath},
+			flatten:  flatten,
+		}
+
+		// A fixed, absolute destination so containment is meaningful.
+		destDir := t.TempDir()
+
+		got, err := se.restorePath(destDir, entryPath)
+		if err != nil {
+			return // rejecting input is always an acceptable outcome
+		}
+
+		// THE invariant: an accepted path must stay inside destDir.
+		absDest, aerr := filepath.Abs(destDir)
+		if aerr != nil {
+			t.Skipf("cannot resolve destDir: %v", aerr)
+		}
+		absGot, aerr := filepath.Abs(got)
+		if aerr != nil {
+			t.Fatalf("restorePath returned an unresolvable path %q (entry=%q): %v", got, entryPath, aerr)
+		}
+		if absGot != absDest && !strings.HasPrefix(absGot, absDest+string(filepath.Separator)) {
+			t.Fatalf("PATH TRAVERSAL: entryPath=%q sourcePath=%q flatten=%v escaped destDir\n  destDir: %s\n  result:  %s",
+				entryPath, sourcePath, flatten, absDest, absGot)
+		}
+
+		// A path equal to destDir itself is not a file location; the sanitizer
+		// should have rejected it rather than returning the directory.
+		if absGot == absDest {
+			t.Fatalf("restorePath returned destDir itself for entryPath=%q (no filename component)", entryPath)
+		}
+
+		// In flatten mode the result must live directly in destDir — that is the
+		// whole contract of --flatten (basename into the output dir).
+		if flatten && filepath.Dir(absGot) != absDest {
+			t.Fatalf("flatten=true produced a nested path: entryPath=%q -> %q (want direct child of %q)",
+				entryPath, absGot, absDest)
+		}
+	})
+}
+
+// FuzzResolveObjectKey fuzzes the S3 key normalizer, which has caused two real
+// bugs: #273 (uploaders clobbered manifest S3Keys with the SDK's full-URL
+// Location) and #281 (chunked restore passed a full-URL key to GetObject
+// verbatim and failed every file). It is pure string surgery over prefix,
+// bucket, and key — a good fuzz target.
+//
+// Invariants for any inputs:
+//   - the result is never itself a URL (a URL reaching GetObject is #273/#281)
+//   - when prefix is non-empty, the result is prefix-scoped
+//   - the function never panics
+//
+// Note the first invariant is "is not a URL", not "contains no '://'": S3 permits
+// ':' in object keys, so a file named "weird://name.txt" is a legitimate key and
+// must survive unmangled. net/url is used as an INDEPENDENT oracle here rather
+// than the resolver's own scheme check, so the test can't agree with a buggy
+// implementation by construction.
+func FuzzResolveObjectKey(f *testing.F) {
+	f.Add("prefix", "bucket", "prefix/uploads/x/chunk-0.tar.zst")
+	f.Add("prefix", "bucket", "https://bucket.s3.us-east-1.amazonaws.com/prefix/uploads/x/c.tar.zst")
+	f.Add("prefix", "bucket", "bucket/prefix/uploads/x/c.tar.zst")
+	f.Add("", "", "")
+	f.Add("p", "b", "://")
+	f.Add("p", "b", "s3://")
+	f.Add("p", "b", "://nohost")
+	f.Add("prefix", "prefix", "prefix/prefix/k")
+	f.Add("prefix", "bucket", "prefix/uploads/x/weird://name.txt")
+
+	f.Fuzz(func(t *testing.T, prefix, bucket, s3Key string) {
+		// A manifest Prefix is an S3 key prefix, never a URL — only the stored
+		// S3Key can arrive URL-shaped, which is the bug class this covers. A
+		// URL-shaped prefix is garbage-in, so restrict the domain to reality
+		// rather than assert on nonsense.
+		if strings.Contains(prefix, "://") {
+			t.Skip()
+		}
+
+		got := ResolveObjectKey(prefix, bucket, s3Key)
+
+		// A resolved key is an S3 object key, never a URL. If a scheme+host
+		// survives, GetObject is handed a URL — the #273/#281 failure mode.
+		if u, err := url.Parse(got); err == nil && u.Scheme != "" && u.Host != "" {
+			t.Fatalf("resolved key is still a URL: prefix=%q bucket=%q s3Key=%q -> %q",
+				prefix, bucket, s3Key, got)
+		}
+
+		// With a non-empty prefix the key must be prefix-scoped, otherwise the
+		// object is addressed outside the upload's namespace. Scoping is checked
+		// against the slash-trimmed prefix, since surrounding slashes are not
+		// part of an S3 prefix ("archives/" and "archives" name the same
+		// namespace, and "archives//key" would be a distinct object).
+		if trimmed := strings.Trim(prefix, "/"); trimmed != "" && got != "" {
+			if got != trimmed && !strings.HasPrefix(got, trimmed+"/") {
+				t.Fatalf("resolved key is not prefix-scoped: prefix=%q bucket=%q s3Key=%q -> %q",
+					prefix, bucket, s3Key, got)
+			}
+			// Surrounding slashes on a prefix are not significant — "archives/"
+			// and "archives" name the same S3 namespace — so resolving with
+			// either must give the same key. Without this, a manifest written
+			// from a user-typed "s3://bucket/archives/" resolved to
+			// "archives//key", a distinct object that was never written.
+			if alt := ResolveObjectKey(trimmed, bucket, s3Key); alt != got {
+				t.Fatalf("prefix slash sensitivity: prefix=%q vs %q, bucket=%q s3Key=%q -> %q vs %q",
+					prefix, trimmed, bucket, s3Key, got, alt)
+			}
+		}
+
+		// A resolved key must never have a leading slash: S3 would treat
+		// "/key" and "key" as different objects.
+		if strings.HasPrefix(got, "/") {
+			t.Fatalf("resolved key has a leading slash: prefix=%q bucket=%q s3Key=%q -> %q",
+				prefix, bucket, s3Key, got)
+		}
+
+		// Resolution is idempotent: feeding an already-resolved key back in must
+		// be a no-op, or a key could pick up the prefix twice as it passes
+		// through layers (verify -> restore) that each resolve.
+		//
+		// Excluded: an empty prefix combined with a key whose first segment is
+		// the bucket name. "bucket/x" is then genuinely ambiguous — either a
+		// bucket-qualified key or a key with a top-level "bucket" directory —
+		// and no resolver can be idempotent over an ambiguous encoding. With a
+		// prefix (the real-world case) the ambiguity disappears.
+		ambiguous := prefix == "" && bucket != "" && strings.HasPrefix(got, bucket+"/")
+		if again := ResolveObjectKey(prefix, bucket, got); !ambiguous && again != got {
+			t.Fatalf("not idempotent: prefix=%q bucket=%q s3Key=%q -> %q -> %q",
+				prefix, bucket, s3Key, got, again)
+		}
+	})
+}
+
+// FuzzValidateAgainstSchema differentially fuzzes the hand-rolled draft-07
+// subset validator (schema_validate.go) against the real struct unmarshal.
+// Hand-written validators are a canonical fuzz target, but a crash-only fuzz
+// would miss the more valuable class of bug: DRIFT between what the product
+// accepts and what the published schema claims.
+//
+// Invariants:
+//   - never panics on arbitrary bytes (it is fed manifests downloaded from S3)
+//   - a manifest that FromJSON accepts, re-serialized canonically by the product
+//     itself, must validate cleanly against the schema. Any violation there means
+//     the product writes manifests its own published schema rejects (#274).
+func FuzzValidateAgainstSchema(f *testing.F) {
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"version":"2.0","upload_id":"u","files":[]}`))
+	f.Add([]byte(`{"version":"2.0","files":[{"path":"a.txt","size":1}]}`))
+	f.Add([]byte(`{"files":"not-an-array"}`))
+	f.Add([]byte(`{"total_files":"not-a-number"}`))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`not json`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// 1. Must never panic on arbitrary input.
+		_, _ = ValidateAgainstSchema(data)
+
+		// 2. Differential check. Only proceed for input the product itself
+		//    accepts as a manifest.
+		m, err := FromJSON(data)
+		if err != nil || m == nil {
+			return
+		}
+
+		// Re-serialize through the product's own writer. This is the exact byte
+		// shape CargoShip uploads, so it MUST satisfy the published schema —
+		// regardless of how odd the fuzzer's field values are. (Fuzzing the raw
+		// input directly would flag inputs that merely tolerate extra fields;
+		// what matters is that what we WRITE complies.)
+		out, err := m.ToJSON()
+		if err != nil {
+			return
+		}
+
+		violations, err := ValidateAgainstSchema(out)
+		if err != nil {
+			t.Fatalf("schema validation errored on product-generated manifest: %v\njson: %s", err, out)
+		}
+		if len(violations) > 0 {
+			t.Fatalf("product-generated manifest violates its own published schema (#274):\n  violations: %v\n  json: %s",
+				violations, out)
 		}
 	})
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -322,9 +322,25 @@ func (b *Builder) Build() *Manifest {
 	return b.manifest
 }
 
-// ToJSON serializes the manifest to JSON
+// ToJSON serializes the manifest to JSON.
+//
+// The files, chunks, and shards collections are always emitted as JSON arrays,
+// never null: the published schema declares them required with type "array", and
+// encoding/json renders a nil slice as null. A manifest with an empty section
+// (e.g. an upload that produced no chunks) would otherwise be written in a shape
+// the format's own schema rejects. Found by FuzzValidateAgainstSchema.
 func (m *Manifest) ToJSON() ([]byte, error) {
-	return json.MarshalIndent(m, "", "  ")
+	out := *m
+	if out.Files == nil {
+		out.Files = []FileEntry{}
+	}
+	if out.Chunks == nil {
+		out.Chunks = []ChunkEntry{}
+	}
+	if out.Shards == nil {
+		out.Shards = []ShardEntry{}
+	}
+	return json.MarshalIndent(&out, "", "  ")
 }
 
 // ToJSONCompressed serializes the manifest to gzip-compressed JSON

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/14cd02c75be460c4
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/14cd02c75be460c4
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("A:/")
+string("0")
+string("0")

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/2e6c1c0dbe3cb504
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/2e6c1c0dbe3cb504
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("A:")
+string("0")
+string("/0")

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/45558c11832a7ad6
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/45558c11832a7ad6
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("A:///0")
+string("1")
+string("0")

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/6f7a7bdd44cfad37
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/6f7a7bdd44cfad37
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("A://0")
+string("0")
+string("0")

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/816aa0b19a6c7dec
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/816aa0b19a6c7dec
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("")
+string("prefix")
+string("prefix/prefix/")

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/887a53d8631483d9
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/887a53d8631483d9
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("")
+string("0")
+string("/A://")

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/9613a379f3e21b19
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/9613a379f3e21b19
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("0")
+string("0")
+string(":///://")

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/f219bcff565be0a5
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/f219bcff565be0a5
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("0/0")
+string("0")
+string("0")

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/f664023cc1fc59fb
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/f664023cc1fc59fb
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("0")
+string("1")
+string("0//")

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/f7ba43a75196b780
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/f7ba43a75196b780
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("3")
+string("0")
+string("0//")


### PR DESCRIPTION
Closes #302.

Extends fuzzing from the manifest (de)serializers to the rest of the trust/integrity surface: the code that turns manifest-derived, externally-influenced data into filesystem paths and S3 object keys.

## Why invariants, not just crashes

Crash-only fuzzing would have found **none** of the bugs below. Each new target asserts a property that actually matters:

| Target | Invariant |
| --- | --- |
| `FuzzRestorePath` | For any entry path / sourcePath / flatten mode, `restorePath` either errors or returns a path **inside** `destDir`. This is a security boundary — #282 was a real traversal here. |
| `FuzzResolveObjectKey` | A resolved key is never a URL, is prefix-scoped, has no leading slash, is insensitive to surrounding slashes on the prefix, and is **idempotent**. `net/url` is used as an *independent* oracle rather than the resolver's own scheme check, so the test can't agree with a buggy implementation by construction. |
| `FuzzValidateAgainstSchema` | Differential: any manifest the product itself writes must validate against its own [published schema](https://cargoship.app/reference/format/manifest). |

## Bugs found and fixed

All five were found by the fuzzer, in code that already had passing table tests.

1. **Manifests written in a shape the published schema rejects.** `ToJSON` emitted `files`/`chunks`/`shards` as `null` for empty collections (Go marshals a nil slice as null), but the schema declares them required with `type: array`. Any upload producing no chunks wrote a non-conforming manifest. This is exactly the drift #274's schema guard exists to prevent, on the *write* side.
2. **A legitimate object key destroyed.** `ResolveObjectKey` matched `://` anywhere in the key, so a file named `weird://name.txt` resolved to just the bare prefix — S3 permits `:` in keys. Now only a scheme in true scheme position counts (RFC 3986 scheme charset).
3. **Doubled separators addressing the wrong object.** A trailing slash on the prefix (`s3://bucket/archives/`, which users type) or a leading slash on the key produced `prefix//key` — a *different* object in S3 than `prefix/key`. Verification would look for something that was never written.
4. **Resolution was not idempotent.** A resolved key whose first segment happened to equal the bucket name had that segment stripped on a second pass, silently dropping a path component. Matters because keys pass through layers that each resolve.
5. **A URL-shaped key with a leading slash escaped scheme detection** entirely.

Each fix carries a regression case in `TestResolveObjectKey`, and **all 9 crashing inputs are committed to `testdata/fuzz/`** as permanent corpus — `go test` runs them on every PR forever, so a fixed bug can't silently return.

## CI

- The existing PR lane picks up the three new targets (~500k execs each). Still an execution **count**, not a duration, per #266.
- New `fuzz-deep.yml`: weekly + `workflow_dispatch`, matrixed per package, ~40x the PR budget, off the critical path — same split rationale as `real-aws-integration.yml`. Uploads any crasher as an artifact so the minimized reproducer survives the runner.

## Docs

`docs/project/integrity.md` now documents fuzzing as part of the trust story (invariant table + the defects it caught), since "the claim is tested continuously" is a claim this strengthens.

## Verification

- 15M executions per target locally, clean.
- `gofmt`, `go vet`, `staticcheck`: clean. `go test -short ./...`: green. Docs site builds with no dead links.