### PR TITLE
test(fuzz): check the normalized prefix in the idempotence guard

### DIFF
--- a/pkg/manifest/fuzz_test.go
+++ b/pkg/manifest/fuzz_test.go
@@ -289,7 +289,11 @@ func FuzzResolveObjectKey(f *testing.F) {
 		// bucket-qualified key or a key with a top-level "bucket" directory —
 		// and no resolver can be idempotent over an ambiguous encoding. With a
 		// prefix (the real-world case) the ambiguity disappears.
-		ambiguous := prefix == "" && bucket != "" && strings.HasPrefix(got, bucket+"/")
+		// Test the NORMALIZED prefix: "/" and "" are the same prefix to the
+		// resolver, so checking the raw value here let a genuinely-ambiguous
+		// case through the guard and report a false idempotence failure.
+		ambiguous := strings.Trim(prefix, "/") == "" && bucket != "" &&
+			strings.HasPrefix(got, bucket+"/")
 		if again := ResolveObjectKey(prefix, bucket, got); !ambiguous && again != got {
 			t.Fatalf("not idempotent: prefix=%q bucket=%q s3Key=%q -> %q -> %q",
 				prefix, bucket, s3Key, got, again)

--- a/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/45d525fe9931ea1b
+++ b/pkg/manifest/testdata/fuzz/FuzzResolveObjectKey/45d525fe9931ea1b
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("/")
+string(":")
+string(":/:/")


### PR DESCRIPTION
The `Fuzz (short burst)` lane failed on main after #305 merged. **It is not a regression from the action bumps** — it's a new input the fuzzer reached (it passed on both PRs), and the bug is in my test, not the product.

```
fuzz_test.go:294: not idempotent: prefix="/" bucket=":" s3Key=":/:/" -> ":/" -> ""
```

`FuzzResolveObjectKey`'s ambiguity guard tested the **raw** prefix for `""`:

```go
ambiguous := prefix == "" && bucket != "" && strings.HasPrefix(got, bucket+"/")
```

But the resolver normalizes surrounding slashes, so `prefix="/"` *is* the empty prefix as far as the function is concerned. The guard therefore didn't fire, and the genuinely-ambiguous bucket-qualified case — which the guard already documents as un-idempotent by nature, because `bucket/x` can't be distinguished from a key with a top-level `bucket` directory — got reported as a failure.

Fixed by comparing against `strings.Trim(prefix, "/")`. This is the same raw-vs-normalized mistake as the prefix-scoping check in #302, which I fixed there but missed one line below.

`ResolveObjectKey` itself is unchanged and correct.

- Crashing input committed to `testdata/fuzz/FuzzResolveObjectKey/45d525fe9931ea1b` as permanent corpus.
- 20M executions locally after the fix: clean.
- Full `pkg/manifest` suite green.

Worth noting the process worked as intended: the lane caught its own false positive on a real input within minutes of merge, and the corpus now pins the case forever.