### PR TITLE
ci: move every remaining pinned action off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,9 +39,9 @@ jobs:
           go-version: '1.26'
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
@@ -122,10 +122,10 @@ jobs:
           rm -f site/dev/CNAME
 
       - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
@@ -138,4 +138,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/fuzz-deep.yml
+++ b/.github/workflows/fuzz-deep.yml
@@ -124,7 +124,7 @@ jobs:
       # minimized reproducer dies with the runner.
       - name: Upload crasher corpus
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashers-${{ matrix.name }}
           path: |

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload mutation results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutation-results
           path: mutation-results/

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -105,7 +105,7 @@ jobs:
           cat benchmark-comparison.txt
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results
           path: |
@@ -116,7 +116,7 @@ jobs:
 
       - name: Comment PR with results
         if: github.event_name == 'pull_request' && steps.compare.outputs.has_regression == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results-${{ github.run_id }}
           path: |
@@ -102,7 +102,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -35,12 +35,12 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install package and dev dependencies
         run: uv pip install --system -e ".[dev]"
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
 
@@ -70,7 +70,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-dist
           path: dvc-cargoship/dist/
@@ -86,13 +86,13 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-dist
           path: dist/
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
 
@@ -124,7 +124,7 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-dist
           path: dist/

--- a/.github/workflows/real-aws-integration.yml
+++ b/.github/workflows/real-aws-integration.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Configure AWS credentials (OIDC)
         if: steps.guard.outputs.configured == 'true'
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
           aws-region: ${{ vars.AWS_CI_REGION || 'us-east-1' }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload verification report artifact
         if: steps.guard.outputs.configured == 'true' && always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: verification-report
           path: ${{ steps.report.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo "tag ${GITHUB_REF_NAME} matches version.txt (v${file})"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: '~> v2'
           args: release --clean

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,9 +16,9 @@ jobs:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
       - name: Install govulncheck
@@ -45,7 +45,7 @@ jobs:
     name: Secret Scan (gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # full history so leaked-then-removed secrets are caught
       # Run the gitleaks BINARY directly (MIT-licensed, free for orgs). The
@@ -64,7 +64,7 @@ jobs:
     name: Trivy Security Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Trivy filesystem scan (vulns + secrets)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -87,7 +87,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # Enforcing: fails the build on findings. Triaged false-positives are
       # annotated inline with `# nosemgrep: <rule-id> -- <reason>`.
       - name: Semgrep scan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
         run: go mod download
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.10.1
           args: --timeout=10m
@@ -195,11 +195,12 @@ jobs:
         run: bash scripts/ci/coverage-ratchet.sh --profile coverage.out --check
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.out
+          # v7 dropped the singular "file" input in favour of "files".
+          files: ./coverage.out
           flags: unittests
           name: codecov-umbrella
 
@@ -210,7 +211,7 @@ jobs:
           cat coverage.txt
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: |


### PR DESCRIPTION
Follow-up to #305, which moved `checkout` and `setup-go`. This clears the other 13 pinned actions still on the retiring Node 20 runtime, so the deprecation annotations go away and nothing silently stops running when GitHub pulls the runtime.

## Bumps

SHA-pinned as always — only the SHA changes, never the pinning style. The trailing comment records the exact patch version so the next audit doesn't need an API round-trip.

| Action | From | To |
|---|---|---|
| `actions/configure-pages` | v5 | v6.0.0 |
| `actions/deploy-pages` | v4 | v5.0.0 |
| `actions/download-artifact` | v4 | v8.0.1 |
| `actions/github-script` | v7 | v9.0.0 |
| `actions/setup-node` | v4 | v7.0.0 |
| `actions/setup-python` | v5 | v7.0.0 |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `actions/upload-pages-artifact` | v3 | v5.0.0 |
| `astral-sh/setup-uv` | v3 | v9.0.0 |
| `aws-actions/configure-aws-credentials` | v4 | v6.2.3 |
| `codecov/codecov-action` | v4 | v7.0.0 |
| `golangci/golangci-lint-action` | v7 | v9.3.0 |
| `goreleaser/goreleaser-action` | v6 | v7.2.3 |

## One real breaking change caught

Every input this repo passes was diffed against the new `action.yml`. One needed a code change: **codecov v7 dropped the singular `file` input** in favour of `files`. Left alone, the coverage upload would have become a silent no-op.

## The composite trap

`upload-pages-artifact` reports `using: composite`, so a naive runtime audit marks it exempt — but it wraps `upload-artifact@v4` internally, which is Node 20. Verified the transitive deps of every composite pin (`setup-trivy`, `actions/cache`, and the `github-script` inside codecov v7); all are node24 or composite now.

Confirmed by reading `runs.using` from `action.yml` at each pinned SHA: zero Node 20 remaining, directly or transitively.

## Also

- Docs build's own Node 20 → 22. That's the toolchain VitePress runs under, not an action runtime, but 20 is EOL.
- Filled in exact patch versions on `security.yml`'s checkout/setup-go comments, which #305 left as bare majors.

## Behaviour changes worth knowing

- **`download-artifact` v8 defaults `digest-mismatch: error`** — a corrupted artifact now fails the job rather than publishing silently. That's the behaviour we want on `python-publish.yml`'s release path, but it is a new failure mode.
- `upload-artifact` v6+ requires runner ≥ 2.327.1; GitHub-hosted runners are well past that.
- `golangci-lint-action` v8+ requires golangci-lint ≥ v2.1.0; we pin v2.10.1.

## Verification

CI on this PR exercises `test.yml` (incl. the reworded codecov input and golangci-lint v9), `docs.yml`, `security.yml`, and `python-publish.yml`'s test/build/validate jobs — which is every changed workflow except `release.yml`, `real-aws-integration.yml`, `mutation.yml`, `performance*.yml`, and `fuzz-deep.yml`, whose changes are checkout/setup-go/upload-artifact pins already proven by the other lanes.