### PR TITLE
fix(security): route download through the shared extractor; add gosec + deadcode audits

### DIFF
--- a/.github/workflows/deadcode.yml
+++ b/.github/workflows/deadcode.yml
@@ -1,0 +1,106 @@
+name: Dead Code Audit
+
+# Unreachable code is where bugs go to hide. CargoShip has now been bitten twice
+# by the same mechanism: a second implementation of an operation stops being
+# called, stops being reviewed, and quietly misses every fix the live copy gets.
+#
+#   #308 — manifest.Extractor still carried the #282 path traversal, unfixed,
+#          on a code path with no non-test caller.
+#   #311 — download's own tar loop carried a THIRD copy of it, and had also
+#          missed verify-on-restore (#283) and the #287 layout.
+#
+# Neither was caught by the `unused` linter in golangci-lint, which only sees
+# unexported symbols. `deadcode` does whole-program reachability from the real
+# entry points, so an exported-but-uncalled function shows up.
+#
+# NON-BLOCKING, and scoped, on purpose:
+#   * Whole-repo deadcode reports ~1800 findings — unusable as a gate. Scoped to
+#     the trust packages (manifest/restore/archivefs/glacier) it's ~35, which a
+#     human can actually read.
+#   * Run WITHOUT `-test`. That's the important flag choice: in `-test` mode,
+#     code reachable from its own tests counts as live, and extract.go had
+#     passing tests — so `-test` mode would have reported ZERO findings for the
+#     exact bug this job exists to surface.
+#   * The consequence of omitting `-test` is that genuinely test-only code
+#     (fuzz-target subjects like ValidateAgainstSchema, helper APIs kept for
+#     library consumers) also appears. That's expected noise, not a defect.
+#     Read the report; don't delete on sight.
+#
+# The question to ask of each entry: is this reachable by anyone, and if not, is
+# there a live copy of it elsewhere that has diverged?
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Mondays 09:00 UTC — after the mutation run, off the PR path
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'Regexp of package paths to report on (deadcode -filter)'
+        default: '^github.com/scttfrdmn/cargoship/pkg/(manifest|restore|archivefs|glacier)'
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: '1.26'
+  DEFAULT_FILTER: '^github.com/scttfrdmn/cargoship/pkg/(manifest|restore|archivefs|glacier)'
+
+jobs:
+  deadcode:
+    name: Dead code audit (weekly, non-blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install deadcode
+        run: go install golang.org/x/tools/cmd/deadcode@latest
+
+      - name: Run deadcode
+        env:
+          # Route the workflow input through env rather than interpolating
+          # ${{ github.event.inputs }} into the script directly — inline
+          # interpolation of github-context data in a run: step is a shell
+          # injection vector (Semgrep enforces this repo-wide).
+          INPUT_FILTER: ${{ github.event.inputs.filter }}
+        run: |
+          set -u
+          filter="$INPUT_FILTER"
+          [ -z "$filter" ] && filter="$DEFAULT_FILTER"
+          mkdir -p deadcode-results
+          # Never fail the job: the report is the deliverable.
+          deadcode -filter "$filter" ./... > deadcode-results/report.txt 2>&1 || true
+          wc -l < deadcode-results/report.txt > deadcode-results/count.txt
+
+      - name: Summarize
+        if: always()
+        run: |
+          count=$(cat deadcode-results/count.txt 2>/dev/null || echo 0)
+          {
+            echo "## Dead code audit — ${count} unreachable function(s)"
+            echo ""
+            echo "Whole-program reachability from the real entry points, scoped to the trust packages, run **without** \`-test\`."
+            echo ""
+            echo "For each entry ask: **is there a live copy of this elsewhere that has diverged?** That is the #308 / #311 failure mode — an uncalled duplicate that silently missed a security fix the live copy received."
+            echo ""
+            echo "Expected noise: code reachable only from tests (fuzz-target subjects, e.g. \`ValidateAgainstSchema\`) and API kept for library consumers. Read before deleting."
+            echo ""
+            echo '```'
+            cat deadcode-results/report.txt 2>/dev/null || echo '(no report)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deadcode-report
+          path: deadcode-results/
+          retention-days: 30

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,6 +41,33 @@ jobs:
           done
           exit $fail
 
+  gosec:
+    name: Go SAST (gosec)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.26'
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+      - name: gosec scan
+        # Gated at HIGH severity AND HIGH confidence, which is currently zero
+        # findings and so is enforceable. The lower tiers are dominated by
+        # G115 (integer conversion) and G304 (variable file path) — for an
+        # archiving tool that reads user-named files by design, those are
+        # thousands-strong and not individually actionable, so blocking on them
+        # would just teach us to ignore the job. Triaged findings are annotated
+        # inline with `#nosec <rule> -- <reason>`.
+        #
+        # gosec is what found #311: a live path traversal in `download` that
+        # every other scanner in this workflow missed.
+        run: gosec -severity=high -confidence=high ./...
+      - name: gosec full report (informational)
+        if: always()
+        run: gosec -no-fail -fmt=text ./... || true
+
   gitleaks:
     name: Secret Scan (gitleaks)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Path traversal in `cargoship download` on chunked archives (#311).**
+  `download` carried its own tar-extraction loop that joined the untrusted tar
+  `header.Name` onto the output directory with no containment check, so a
+  crafted archive could write outside the destination. This was a third copy of
+  the #282 traversal — the first was fixed in `SelectiveExtractor`, the second
+  deleted with the dead `manifest.Extractor` (#308) — and the only live one.
+  `download` now routes both storage layouts through `SelectiveExtractor`, and
+  the duplicate loop is gone.
+- **`download` did not verify checksums or preserve restore layout (#311).**
+  Because it never went through the shared extractor, `download` also missed
+  verify-on-restore (#283) — it would write corrupt bytes where `restore`
+  refuses to — and the dataset-relative layout (#287), so the two commands
+  disagreed on where files landed. They now behave identically and expose the
+  same `--no-verify` and `--flatten` controls.
+
+### Added
+- **Restore preserves modification times (#311).** Both `restore` and
+  `download` now stamp each restored file with the mtime recorded in the
+  manifest, across direct and chunked storage. Previously only `download`'s
+  now-removed loop did this, and only for chunked archives.
+- **`gosec` runs in CI (#311).** A static-analysis pass over the Go source, in
+  the Security workflow alongside govulncheck, gitleaks, Trivy, and Semgrep.
+  Its first run is what found the traversal above.
+- **Weekly dead-code audit.** A non-blocking scheduled `deadcode` report over
+  the trust packages, so unreachable code — which is where the #308 and #311
+  traversals survived unfixed — surfaces on its own.
+
 ### Removed
 - **The superseded `manifest.Extractor` API (#308).** `pkg/manifest/extract.go`
   held the original selective-extraction implementation from #93. It had no
   non-test caller — every restore path (`restore`, `download`, `browse`,
-  `shell`, the TUI) goes through `SelectiveExtractor` — and it carried an
+  `shell`, the TUI) reaches `SelectiveExtractor` — and it carried an
   unfixed copy of the #282 path traversal: `getOutputPath` joined an untrusted
   tar `header.Name` onto the output directory with no containment check.
   Deleted rather than patched, so there is one extraction path and one

--- a/cmd/cargoship/cmd/config.go
+++ b/cmd/cargoship/cmd/config.go
@@ -485,7 +485,11 @@ func editConfig() error {
 
 	fmt.Printf("Opening %s with %s...\n", configPath, editor)
 
-	// Execute editor
+	// Execute editor. The command is the user's own $EDITOR/$VISUAL, resolved
+	// via exec.LookPath above, and the only argument is CargoShip's own config
+	// path — the "taint" is the invoking user's environment, and they could run
+	// the editor directly anyway.
+	// #nosec G702,G204 -- launches the user's configured editor by design
 	cmd := exec.Command(editor, configPath) // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command -- launches user-configured  by design
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/cmd/cargoship/cmd/download.go
+++ b/cmd/cargoship/cmd/download.go
@@ -1,22 +1,17 @@
 package cmd
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/dustin/go-humanize"
-	"github.com/klauspost/compress/zstd"
 	"github.com/spf13/cobra"
 
 	"github.com/scttfrdmn/cargoship/pkg/manifest"
@@ -32,6 +27,8 @@ func NewDownloadCmd() *cobra.Command {
 		verbose  bool
 		dryRun   bool
 		workers  int
+		noVerify bool
+		flatten  bool
 	)
 
 	cmd := &cobra.Command{
@@ -165,60 +162,37 @@ Examples:
 			fmt.Printf("📦 Selected %d files (%s uncompressed)\n\n",
 				len(filesToDownload), humanize.Bytes(uint64(totalSize)))
 
-			// Direct-upload manifests have no chunks: each file is its own S3
-			// object (not a tar.zst chunk), so the chunk-download path below can't
-			// extract them. Route through the shared SelectiveExtractor, which
-			// handles direct-upload restore (writing raw object bytes). Mirrors the
-			// restore command's fix. (#228 / #238 Phase 2)
-			if m.TotalChunks == 0 {
+			// Step 3: Report the chunk fan-in, and for a dry run stop here.
+			// Chunked manifests pack many files per S3 object, so the interesting
+			// number is how many objects have to be fetched; direct-upload
+			// manifests (TotalChunks == 0) store one object per file.
+			if m.TotalChunks > 0 {
+				chunkFiles := make(map[int][]manifest.FileEntry)
+				for _, file := range filesToDownload {
+					chunkFiles[file.ChunkID] = append(chunkFiles[file.ChunkID], file)
+				}
+
+				fmt.Printf("🎯 Need to download %d chunks (out of %d total)\n\n", len(chunkFiles), m.TotalChunks)
+
 				if dryRun {
-					fmt.Println("🔍 Dry run - would download (direct-upload objects):")
-					for _, file := range filesToDownload {
-						fmt.Printf("    - %s (%s)\n", file.Path, humanize.Bytes(uint64(file.Size)))
+					fmt.Println("🔍 Dry run - would download:")
+					for chunkID, files := range chunkFiles {
+						chunk := findChunk(m, chunkID)
+						if chunk != nil {
+							fmt.Printf("\n  Chunk %d (s3://%s/%s, %s compressed):\n",
+								chunkID, bucket, chunk.S3Key, humanize.Bytes(uint64(chunk.CompressedSize)))
+							for _, file := range files {
+								fmt.Printf("    - %s (%s)\n", file.Path, humanize.Bytes(uint64(file.Size)))
+							}
+						}
 					}
 					fmt.Printf("\nTotal: %d files, %s\n", len(filesToDownload), humanize.Bytes(uint64(totalSize)))
 					return nil
 				}
-				if err := os.MkdirAll(outputDir, 0755); err != nil {
-					return fmt.Errorf("failed to create output directory: %w", err)
-				}
-				targets := make([]string, len(filesToDownload))
-				for i, file := range filesToDownload {
-					targets[i] = file.Path
-				}
-				extractor := manifest.NewSelectiveExtractor(m, s3Client, 0)
-				stats, err := extractor.BatchRestore(ctx, targets, outputDir)
-				if err != nil {
-					return fmt.Errorf("failed to download direct-upload files: %w", err)
-				}
-				fmt.Printf("✅ Downloaded %d files (%s) — %d failed\n",
-					stats.Restored, humanize.Bytes(uint64(stats.Bytes)), stats.Failed)
-				if stats.Failed > 0 {
-					return fmt.Errorf("%d file(s) failed to download", stats.Failed)
-				}
-				return nil
-			}
-
-			// Step 3: Group files by chunk to minimize chunk downloads
-			chunkFiles := make(map[int][]manifest.FileEntry)
-			for _, file := range filesToDownload {
-				chunkFiles[file.ChunkID] = append(chunkFiles[file.ChunkID], file)
-			}
-
-			fmt.Printf("🎯 Need to download %d chunks (out of %d total)\n\n", len(chunkFiles), m.TotalChunks)
-
-			// Dry run - just show what would be downloaded
-			if dryRun {
-				fmt.Println("🔍 Dry run - would download:")
-				for chunkID, files := range chunkFiles {
-					chunk := findChunk(m, chunkID)
-					if chunk != nil {
-						fmt.Printf("\n  Chunk %d (s3://%s/%s, %s compressed):\n",
-							chunkID, bucket, chunk.S3Key, humanize.Bytes(uint64(chunk.CompressedSize)))
-						for _, file := range files {
-							fmt.Printf("    - %s (%s)\n", file.Path, humanize.Bytes(uint64(file.Size)))
-						}
-					}
+			} else if dryRun {
+				fmt.Println("🔍 Dry run - would download (direct-upload objects):")
+				for _, file := range filesToDownload {
+					fmt.Printf("    - %s (%s)\n", file.Path, humanize.Bytes(uint64(file.Size)))
 				}
 				fmt.Printf("\nTotal: %d files, %s\n", len(filesToDownload), humanize.Bytes(uint64(totalSize)))
 				return nil
@@ -229,56 +203,42 @@ Examples:
 				return fmt.Errorf("failed to create output directory: %w", err)
 			}
 
-			// Step 5: Download and extract chunks
+			// Step 5: Download and extract through the shared SelectiveExtractor.
+			//
+			// Both storage layouts go through the same extractor. `download`
+			// used to carry its own tar loop for the chunked case, which joined
+			// the untrusted tar header name onto the output directory with no
+			// containment check — a live copy of the #282 path traversal — and,
+			// because it was never routed through the shared code, also missed
+			// verify-on-restore (#283) and the dataset-relative layout (#287).
+			// One extraction path, one sanitizer. (#311)
 			startTime := time.Now()
-			extractedCount := 0
-			var extractedSize int64
-
-			for chunkID, chunkFileList := range chunkFiles {
-				chunk := findChunk(m, chunkID)
-				if chunk == nil {
-					fmt.Printf("⚠️  Warning: chunk %d not found in manifest\n", chunkID)
-					continue
-				}
-
-				fmt.Printf("📥 Downloading chunk %d/%d: %s (%s)\n",
-					chunkID+1, len(chunkFiles), chunk.S3Key, humanize.Bytes(uint64(chunk.CompressedSize)))
-
-				// Download chunk from S3
-				chunkResult, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
-					Bucket: aws.String(bucket),
-					Key:    aws.String(chunk.S3Key),
-				})
-				if err != nil {
-					fmt.Printf("❌ Failed to download chunk %d: %v\n", chunkID, err)
-					continue
-				}
-
-				// Extract files from chunk
-				extracted, size, err := extractFilesFromChunk(chunkResult.Body, chunkFileList, outputDir, m.CompressionType, verbose)
-				if err != nil {
-					fmt.Printf("❌ Failed to extract chunk %d: %v\n", chunkID, err)
-					_ = chunkResult.Body.Close()
-					continue
-				}
-
-				_ = chunkResult.Body.Close()
-				extractedCount += extracted
-				extractedSize += size
-
-				fmt.Printf("✅ Extracted %d files (%s) from chunk %d\n\n", extracted, humanize.Bytes(uint64(size)), chunkID)
+			targets := make([]string, len(filesToDownload))
+			for i, file := range filesToDownload {
+				targets[i] = file.Path
+			}
+			extractor := manifest.NewSelectiveExtractor(m, s3Client, 0).
+				SetVerify(!noVerify).
+				SetFlatten(flatten)
+			stats, err := extractor.BatchRestore(ctx, targets, outputDir)
+			if err != nil {
+				return fmt.Errorf("failed to download files: %w", err)
 			}
 
 			duration := time.Since(startTime)
-			throughput := float64(extractedSize) / duration.Seconds() / 1024 / 1024 // MB/s
+			throughput := float64(stats.Bytes) / duration.Seconds() / 1024 / 1024 // MB/s
 
 			fmt.Printf("✅ Download complete!\n")
-			fmt.Printf("   Files extracted: %d files\n", extractedCount)
-			fmt.Printf("   Data size: %s\n", humanize.Bytes(uint64(extractedSize)))
+			fmt.Printf("   Files extracted: %d files\n", stats.Restored)
+			fmt.Printf("   Chunks downloaded: %d\n", stats.ChunksDownloaded)
+			fmt.Printf("   Data size: %s\n", humanize.Bytes(uint64(stats.Bytes)))
 			fmt.Printf("   Duration: %s\n", duration.Round(time.Millisecond))
 			fmt.Printf("   Throughput: %.2f MB/s\n", throughput)
 			fmt.Printf("   Output directory: %s\n", outputDir)
 
+			if stats.Failed > 0 {
+				return fmt.Errorf("%d file(s) failed to download", stats.Failed)
+			}
 			return nil
 		},
 	}
@@ -290,6 +250,8 @@ Examples:
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show verbose output (list each file as extracted)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be downloaded without actually downloading")
 	cmd.Flags().IntVar(&workers, "workers", 4, "Number of parallel download workers (future use)")
+	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip restore-time checksum verification (faster, but won't detect corrupted stored data)")
+	cmd.Flags().BoolVar(&flatten, "flatten", false, "Write downloaded files by basename into the output dir instead of recreating their directory structure")
 
 	return cmd
 }
@@ -338,105 +300,4 @@ func findChunk(m *manifest.Manifest, chunkID int) *manifest.ChunkEntry {
 		}
 	}
 	return nil
-}
-
-// extractFilesFromChunk extracts selected files from a compressed tar archive
-func extractFilesFromChunk(reader io.Reader, filesToExtract []manifest.FileEntry, outputDir, compressionType string, verbose bool) (int, int64, error) {
-	// Build a map of files to extract for fast lookup
-	fileMap := make(map[string]manifest.FileEntry)
-	for _, file := range filesToExtract {
-		fileMap[file.Path] = file
-	}
-
-	// Decompress based on compression type
-	var decompressor io.Reader
-
-	switch compressionType {
-	case "zstd":
-		decoder, err := zstd.NewReader(reader)
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to create zstd decoder: %w", err)
-		}
-		defer decoder.Close()
-		decompressor = decoder
-
-	case "gzip":
-		decoder, err := gzip.NewReader(reader)
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to create gzip decoder: %w", err)
-		}
-		defer func() { _ = decoder.Close() }()
-		decompressor = decoder
-
-	default:
-		return 0, 0, fmt.Errorf("unsupported compression type: %s", compressionType)
-	}
-
-	// Extract files from tar archive
-	tarReader := tar.NewReader(decompressor)
-	extractedCount := 0
-	var extractedSize int64
-
-	for {
-		header, err := tarReader.Next()
-		if err == io.EOF {
-			break // End of archive
-		}
-		if err != nil {
-			return extractedCount, extractedSize, fmt.Errorf("failed to read tar header: %w", err)
-		}
-
-		// Check if this file should be extracted
-		fileEntry, shouldExtract := fileMap[header.Name]
-		if !shouldExtract {
-			continue
-		}
-
-		// Create output file path
-		outputPath := filepath.Join(outputDir, header.Name)
-
-		// Create parent directories
-		if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
-			return extractedCount, extractedSize, fmt.Errorf("failed to create directory for %s: %w", header.Name, err)
-		}
-
-		// Extract file
-		switch header.Typeflag {
-		case tar.TypeReg:
-			// Regular file
-			outFile, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
-			if err != nil {
-				return extractedCount, extractedSize, fmt.Errorf("failed to create file %s: %w", outputPath, err)
-			}
-
-			written, err := io.Copy(outFile, tarReader) // nosemgrep: go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb -- extracting cargoship's own archive tar stream
-			_ = outFile.Close()
-			if err != nil {
-				return extractedCount, extractedSize, fmt.Errorf("failed to extract file %s: %w", header.Name, err)
-			}
-
-			// Restore modification time
-			if err := os.Chtimes(outputPath, time.Now(), fileEntry.ModTime); err != nil {
-				// Non-fatal, just warn
-				if verbose {
-					fmt.Printf("⚠️  Warning: failed to restore mod time for %s: %v\n", header.Name, err)
-				}
-			}
-
-			extractedCount++
-			extractedSize += written
-
-			if verbose {
-				fmt.Printf("  ✓ %s (%s)\n", header.Name, humanize.Bytes(uint64(written)))
-			}
-
-		case tar.TypeDir:
-			// Directory
-			if err := os.MkdirAll(outputPath, os.FileMode(header.Mode)); err != nil {
-				return extractedCount, extractedSize, fmt.Errorf("failed to create directory %s: %w", outputPath, err)
-			}
-		}
-	}
-
-	return extractedCount, extractedSize, nil
 }

--- a/cmd/cargoship/cmd/download_test.go
+++ b/cmd/cargoship/cmd/download_test.go
@@ -249,3 +249,35 @@ func TestDownloadCmd_UsageOutput(t *testing.T) {
 	assert.Contains(t, usage, "--files", "Usage should list files flag")
 	assert.Contains(t, usage, "--shard-ids", "Usage should list shard-ids flag")
 }
+
+// TestDownloadCmd_SafetyFlagParity pins download's safety surface to restore's.
+// download used to carry its own tar-extraction loop that bypassed the shared
+// SelectiveExtractor, and so silently lacked verify-on-restore (#283) and the
+// dataset-relative layout (#287) that restore had. Both commands now route
+// through the same extractor, so they must expose the same controls over it —
+// if one grows a flag the other doesn't, they have diverged again. (#311)
+func TestDownloadCmd_SafetyFlagParity(t *testing.T) {
+	dl := NewDownloadCmd()
+	rs := NewRestoreCmd()
+
+	for _, name := range []string{"no-verify", "flatten"} {
+		t.Run(name, func(t *testing.T) {
+			d := dl.Flags().Lookup(name)
+			require.NotNil(t, d, "download must expose --%s", name)
+			r := rs.Flags().Lookup(name)
+			require.NotNil(t, r, "restore must expose --%s", name)
+			// Same default, so the same command line means the same thing.
+			assert.Equal(t, r.DefValue, d.DefValue,
+				"--%s default differs between download and restore", name)
+		})
+	}
+}
+
+// TestDownloadCmd_VerifiesByDefault asserts integrity checking is opt-out, not
+// opt-in: a download that silently writes corrupt bytes is worse than a slow
+// one. (#283 / #311)
+func TestDownloadCmd_VerifiesByDefault(t *testing.T) {
+	f := NewDownloadCmd().Flags().Lookup("no-verify")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue, "verification must be on by default")
+}

--- a/docs/gen/cli/cargoship_download.md
+++ b/docs/gen/cli/cargoship_download.md
@@ -46,7 +46,9 @@ cargoship download S3_URL OUTPUT_DIR [flags]
 ```
       --dry-run          Show what would be downloaded without actually downloading
       --files strings    Comma-separated list of exact file paths to download
+      --flatten          Write downloaded files by basename into the output dir instead of recreating their directory structure
   -h, --help             help for download
+      --no-verify        Skip restore-time checksum verification (faster, but won't detect corrupted stored data)
       --pattern string   Filter files by glob pattern (e.g., '*.log')
   -r, --region string    AWS region (default "us-west-2")
       --shard-ids ints   Comma-separated list of shard IDs to download (0-7)

--- a/pkg/extraction/extractor.go
+++ b/pkg/extraction/extractor.go
@@ -205,7 +205,7 @@ func (e *Extractor) extractFiles(ctx context.Context, tarReader *tar.Reader) err
 // extractFile extracts a single file from the tar archive
 func (e *Extractor) extractFile(tarReader *tar.Reader, header *tar.Header) error {
 	// Construct output path
-	outputPath := filepath.Join(e.config.OutputDir, header.Name)
+	outputPath := filepath.Join(e.config.OutputDir, header.Name) // #nosec G305 -- containment is verified immediately below
 
 	// Security: prevent path traversal attacks
 	if !strings.HasPrefix(outputPath, filepath.Clean(e.config.OutputDir)+string(os.PathSeparator)) {
@@ -292,7 +292,7 @@ func (e *Extractor) createSymlink(path string, header *tar.Header) error {
 	}
 
 	// Resolve what the symlink would point to and ensure it stays inside OutputDir.
-	resolvedTarget := filepath.Join(filepath.Dir(path), header.Linkname)
+	resolvedTarget := filepath.Join(filepath.Dir(path), header.Linkname) // #nosec G305 -- containment is verified immediately below
 	outputDir := filepath.Clean(e.config.OutputDir) + string(os.PathSeparator)
 	if !strings.HasPrefix(filepath.Clean(resolvedTarget)+string(os.PathSeparator), outputDir) {
 		return fmt.Errorf("symlink target %q escapes extraction directory", header.Linkname)

--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -248,6 +249,18 @@ func (se *SelectiveExtractor) restorePath(destDir, entryPath string) (string, er
 	return out, nil
 }
 
+// restoreModTime stamps a restored file with the modification time the manifest
+// recorded at upload. Archival restores should reproduce the source tree, not
+// the time of the restore. A failure here is deliberately non-fatal: the file
+// content is already correct on disk, and refusing the restore over a timestamp
+// would be worse than an imprecise timestamp. (#311)
+func restoreModTime(path string, modTime time.Time) {
+	if modTime.IsZero() {
+		return
+	}
+	_ = os.Chtimes(path, modTime, modTime)
+}
+
 // relativeEntryPath returns entryPath relative to the manifest's SourcePath (the
 // upload root) when it sits under it; otherwise it returns entryPath unchanged
 // (the sanitizer in restorePath still makes it destDir-safe). This is what makes
@@ -458,6 +471,7 @@ func (se *SelectiveExtractor) writeDirectFiles(data []byte, files []*FileEntry, 
 		if err := os.WriteFile(outPath, data, 0644); err != nil {
 			return restored, totalBytes, fmt.Errorf("write %s: %w", outPath, err)
 		}
+		restoreModTime(outPath, entry.ModTime)
 		restored++
 		totalBytes += int64(len(data))
 	}
@@ -591,6 +605,7 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 			if err := os.WriteFile(outPath, content, 0644); err != nil {
 				return restored, totalBytes, fmt.Errorf("write %s: %w", outPath, err)
 			}
+			restoreModTime(outPath, entry.ModTime)
 			restored++
 			totalBytes += int64(len(content))
 			continue
@@ -605,6 +620,7 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 		if err != nil {
 			return restored, totalBytes, fmt.Errorf("write %s: %w", outPath, err)
 		}
+		restoreModTime(outPath, entry.ModTime)
 		restored++
 		totalBytes += written
 	}

--- a/pkg/manifest/batch_restore_test.go
+++ b/pkg/manifest/batch_restore_test.go
@@ -761,3 +761,105 @@ func TestBatchRestore_FlattenLayout(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, content, got)
 }
+
+// --- #311: chunked-mode containment and mtime preservation ---
+
+// TestBatchRestore_ChunkedTraversalIsContained is the chunked-storage twin of
+// TestBatchRestore_TraversalIsContained. `download` carried its own tar loop for
+// this path that joined the untrusted tar header name straight onto the output
+// directory (#311); this pins the shared path's guard so a future caller can't
+// reintroduce the escape.
+func TestBatchRestore_ChunkedTraversalIsContained(t *testing.T) {
+	content := []byte("chunked payload")
+	evil := "../../../../tmp/evil-chunked.txt"
+	chunk := makeTarZst(t, map[string][]byte{evil: content})
+
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "zstd", TotalChunks: 1,
+		Chunks: []ChunkEntry{{ID: 0, S3Key: "c0", FileCount: 1, FilePaths: []string{evil}}},
+		Files:  []FileEntry{{Path: evil, Size: int64(len(content)), S3Key: "c0"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"c0": chunk}}
+
+	dest := t.TempDir()
+	stats, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{evil}, dest)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.Restored)
+
+	// Sanitized to a contained path, not the traversal target.
+	got, err := os.ReadFile(filepath.Join(dest, "tmp", "evil-chunked.txt"))
+	require.NoError(t, err, "file should be contained within dest")
+	assert.Equal(t, content, got)
+	assert.True(t, filepathHasPrefix(filepath.Join(dest, "tmp", "evil-chunked.txt"), dest))
+}
+
+// TestBatchRestore_PreservesModTime checks restore reproduces the source tree's
+// modification times rather than stamping the time of the restore. An archival
+// tool that loses mtimes has lost metadata the manifest recorded. Covers both
+// storage layouts (#311).
+func TestBatchRestore_PreservesModTime(t *testing.T) {
+	content := []byte("timestamped")
+	// Truncated to whole seconds: tar and some filesystems don't keep sub-second
+	// resolution, so comparing at second granularity is what's portable.
+	want := time.Date(2019, 3, 14, 15, 9, 26, 0, time.UTC)
+
+	t.Run("direct", func(t *testing.T) {
+		m := &Manifest{
+			Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+			Files: []FileEntry{{Path: "a.txt", Size: int64(len(content)), S3Key: "obj", ModTime: want}},
+		}
+		m.TotalFiles = 1
+		client := &mockS3Client{chunks: map[string][]byte{"obj": content}}
+		dest := t.TempDir()
+		_, err := NewSelectiveExtractor(m, client, 0).
+			BatchRestore(context.Background(), []string{"a.txt"}, dest)
+		require.NoError(t, err)
+
+		fi, err := os.Stat(filepath.Join(dest, "a.txt"))
+		require.NoError(t, err)
+		assert.WithinDuration(t, want, fi.ModTime(), time.Second)
+	})
+
+	t.Run("chunked", func(t *testing.T) {
+		chunk := makeTarZst(t, map[string][]byte{"a.txt": content})
+		m := &Manifest{
+			Version: ManifestVersion, Bucket: "b", CompressionType: "zstd", TotalChunks: 1,
+			Chunks: []ChunkEntry{{ID: 0, S3Key: "c0", FileCount: 1, FilePaths: []string{"a.txt"}}},
+			Files:  []FileEntry{{Path: "a.txt", Size: int64(len(content)), S3Key: "c0", ModTime: want}},
+		}
+		m.TotalFiles = 1
+		client := &mockS3Client{chunks: map[string][]byte{"c0": chunk}}
+		dest := t.TempDir()
+		_, err := NewSelectiveExtractor(m, client, 0).
+			BatchRestore(context.Background(), []string{"a.txt"}, dest)
+		require.NoError(t, err)
+
+		fi, err := os.Stat(filepath.Join(dest, "a.txt"))
+		require.NoError(t, err)
+		assert.WithinDuration(t, want, fi.ModTime(), time.Second)
+	})
+}
+
+// TestBatchRestore_ZeroModTimeLeavesFileAlone confirms a manifest with no
+// recorded ModTime doesn't get stamped with the zero time (year 1), which some
+// filesystems reject outright.
+func TestBatchRestore_ZeroModTimeLeavesFileAlone(t *testing.T) {
+	content := []byte("no mtime")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		Files: []FileEntry{{Path: "a.txt", Size: int64(len(content)), S3Key: "obj"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"obj": content}}
+	dest := t.TempDir()
+	_, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{"a.txt"}, dest)
+	require.NoError(t, err)
+
+	fi, err := os.Stat(filepath.Join(dest, "a.txt"))
+	require.NoError(t, err)
+	assert.False(t, fi.ModTime().IsZero(), "should keep the write time, not stamp year 1")
+	assert.True(t, fi.ModTime().Year() > 2000, "got %s", fi.ModTime())
+}

--- a/pkg/profiling/runtime.go
+++ b/pkg/profiling/runtime.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof" // Register pprof handlers
+	// #nosec G108 -- pprof handlers are registered on DefaultServeMux by this
+	// import, but nothing serves DefaultServeMux: they are only reachable via
+	// the profiler's own mux below, which is started solely by the opt-in
+	// `--pprof` flag and binds localhost:6060 by default.
+	_ "net/http/pprof"
 	"time"
 )
 


### PR DESCRIPTION
Fixes #311.

## The bug

`cargoship download` had its own tar-extraction loop for **chunked** manifests
that never went through `SelectiveExtractor`:

```go
outputPath := filepath.Join(outputDir, header.Name)   // untrusted, unchecked
```

That's a live third copy of the #282 path traversal — #282 fixed it in
`SelectiveExtractor`, #308 deleted a second dead copy in `manifest.Extractor`,
and this one was reachable from the CLI on the default `download` path.

Confirmed before fixing, with a crafted chunk whose tar entry is named
`../../escaped.txt`:

```
extracted=1 err=<nil>
TRAVERSAL CONFIRMED: wrote outside outputDir at .../001/escaped.txt
```

Because that loop was never routed through the shared code, it had **also**
missed two later fixes:

| | `restore` | `download` (before) |
|---|---|---|
| #282 containment | yes | **no** |
| #283 verify-on-restore | yes | **no** — writes corrupt bytes |
| #287 dataset-relative layout | yes | **no** — wrote `out/home/user/proj/a.txt` |

Two commands documented as two ways to get the same bytes back disagreed on
safety, integrity, and output layout.

## The fix

Delete the duplicate loop; route both storage layouts through
`SelectiveExtractor.BatchRestore` — which `download`'s direct-upload path
already did (#228/#238). One extraction path, one sanitizer, same reasoning as
#308. `download` gains `--no-verify` and `--flatten` to match `restore`.

`SelectiveExtractor` gains **mtime preservation** so the dedup isn't a
regression: the removed loop was the only code that restored mtimes, and only
for chunked archives. `restore` gets it too, which is correct for an archival
tool.

## Tests

All fail without the corresponding change:

- `TestBatchRestore_ChunkedTraversalIsContained` — chunked twin of the existing
  direct-mode containment test.
- `TestBatchRestore_PreservesModTime` (direct + chunked) — verified failing on a
  stashed `batch_restore.go`, off by ~64,754h.
- `TestBatchRestore_ZeroModTimeLeavesFileAlone` — a manifest with no ModTime
  mustn't get stamped with year 1.
- `TestDownloadCmd_SafetyFlagParity` — asserts `download` and `restore` expose
  the same safety flags with the same defaults, so they can't silently diverge
  again. This is the test that would have caught the original divergence.

## Also in here (the "how do we catch this class earlier" half)

**`gosec` in the Security workflow.** This is what found the bug — govulncheck,
gitleaks, Trivy, and Semgrep all missed it. Gated at `-severity=high
-confidence=high`, which is currently **zero** findings and so is genuinely
enforceable. The lower tiers are ~200 findings dominated by G115 (integer
conversion) and G304 (variable file path) — for a tool that reads user-named
files by design those aren't individually actionable, and blocking on them
would just train us to ignore the job. The two real HIGH/HIGH findings are
annotated: pprof registration (opt-in `--pprof` only, nothing serves
`DefaultServeMux`) and `config edit` launching the user's own `$EDITOR`.

**Weekly non-blocking `deadcode` audit** over the trust packages. Note the flag
choice: it runs **without** `-test`. In `-test` mode, code reachable from its
own tests counts as live — and both #308 and #311 had passing tests, so `-test`
mode reports zero findings for exactly the bugs this job exists to surface. The
cost is that genuinely test-only code (fuzz-target subjects) also appears; the
workflow header says so, so nobody deletes on sight. Scoped: ~35 findings vs
~1800 repo-wide.

## Note on #310

I've added these to the `[Unreleased]` CHANGELOG block. Since the v0.17.0
release PR (#310) is still open, this should land **before** the tag so v0.17.0
ships the traversal fix. Merging this first means #310 needs a rebase to pick
the entries up under the `[0.17.0]` heading.

Also corrected a claim in the #308 CHANGELOG entry: it said every restore path
"goes through `SelectiveExtractor`", which — as this PR shows — wasn't true of
`download`'s chunked path at the time.
