### PR TITLE
fix(docs): read the site version banner from version.txt

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -15,6 +15,14 @@ const DOCS_BASE = process.env.DOCS_BASE || '/'
 const DOCS_VERSION_LABEL = process.env.DOCS_VERSION_LABEL || 'latest'
 const IS_DEV_TREE = DOCS_BASE === '/dev/'
 
+// Read the release version from the single canonical source (PR #260) — the same
+// file the release process bumps and check-doc-versions.sh enforces — and inject
+// it into the browser bundle via `define` (below). The theme used to hardcode
+// this with an "update when cutting a release" comment and went stale by four
+// releases, because nothing checked it.
+const LATEST_RELEASE =
+  'v' + fs.readFileSync(path.resolve(__dirname, '../../internal/version/version.txt'), 'utf-8').trim()
+
 // One global sidebar (keyed on '/') applied to every page, so the whole site
 // reads as a single progressive-disclosure path: Introduction → Get Started →
 // Tutorials → Core Workflows → Cost & Budget → Features → DVC → Configuration →
@@ -221,6 +229,15 @@ export default defineConfig({
 
   // Set per deploy: '/' for the latest tree, '/dev/' for the unreleased tree.
   base: DOCS_BASE,
+
+  // Values the theme needs but can't compute: it is compiled into the browser
+  // bundle, so it has no filesystem and no process.env.
+  vite: {
+    define: {
+      __CARGOSHIP_VERSION__: JSON.stringify(LATEST_RELEASE),
+      __CARGOSHIP_IS_DEV_TREE__: JSON.stringify(IS_DEV_TREE),
+    },
+  },
 
   // Emit sitemap.xml for search + AI indexers (VitePress only generates it when
   // a hostname is set). Only the latest (root) tree is indexed; the dev tree is

--- a/docs/.vitepress/env.d.ts
+++ b/docs/.vitepress/env.d.ts
@@ -1,0 +1,5 @@
+// Ambient declarations for the build-time constants injected by Vite `define`
+// in config.mts. The theme runs in the browser bundle, so these are the only
+// way it can see Node-side values (the canonical version, the active base).
+declare const __CARGOSHIP_VERSION__: string
+declare const __CARGOSHIP_IS_DEV_TREE__: boolean

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,26 +2,37 @@ import DefaultTheme from 'vitepress/theme'
 import { h } from 'vue'
 import './custom.css'
 
-// Site-wide banner noting that the docs track `main` (the development branch),
-// not necessarily the latest tagged release. Update LATEST_RELEASE when cutting a
-// release. Rendered via the built-in `layout-top` slot so it appears on every
-// page, including the home layout.
-const LATEST_RELEASE = 'v0.13.2'
+// The version comes from internal/version/version.txt — the single canonical
+// source (PR #260), the same file the release process bumps and
+// scripts/ci/check-doc-versions.sh enforces. It used to be a hardcoded constant
+// here with an "update this when cutting a release" comment, which went stale by
+// four releases (it still advertised v0.13.2 on the day v0.17.0 shipped)
+// because nothing checked it.
+// Both values are injected at build time via `define` in config.mts, which
+// reads them on the Node side. This theme file is compiled into the browser
+// bundle, so it can neither read the filesystem nor see process.env.
+const LATEST_RELEASE = __CARGOSHIP_VERSION__
+
+// The banner only belongs on the dev tree. The root tree IS the latest release,
+// so telling its readers "these docs track main" was wrong as well as stale.
+const IS_DEV_TREE = __CARGOSHIP_IS_DEV_TREE__
 
 export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
       'layout-top': () =>
-        h(
-          'div',
-          { class: 'cs-dev-banner' },
-          [
-            'These docs track the development branch (',
-            h('code', null, 'main'),
-            `). Latest release: ${LATEST_RELEASE}.`,
-          ],
-        ),
+        IS_DEV_TREE
+          ? h(
+              'div',
+              { class: 'cs-dev-banner' },
+              [
+                'These docs track the development branch (',
+                h('code', null, 'main'),
+                `). Latest release: ${LATEST_RELEASE}.`,
+              ],
+            )
+          : null,
     })
   },
 }


### PR DESCRIPTION
Found while verifying the v0.17.0 release: cargoship.app was advertising **v0.13.2**.

## The bug

`docs/.vitepress/theme/index.ts` hardcoded the version:

```ts
// Update LATEST_RELEASE when cutting a release.
const LATEST_RELEASE = 'v0.13.2'
```

Nothing checked it, so it went stale by four releases. `scripts/ci/check-doc-versions.sh` only greps `*.md` (see its `git ls-files` set), so it never saw a constant in a `.ts` file — the same class of drift the version-source work (#260) was supposed to end, just outside the guarded file set.

Second, smaller wrong thing: the banner rendered on **both** doc trees. The root tree *is* the latest release, so "These docs track the development branch (`main`)" was misinformation there, not just a stale number.

## The fix

Read `internal/version/version.txt` — the single canonical source the release process already bumps — instead of duplicating it. There is now no constant to forget.

The read has to happen in `config.mts`, not the theme: the theme compiles into the **browser** bundle, so it has neither a filesystem nor `process.env`. Both values cross over via Vite `define`, with an ambient `.d.ts` so they typecheck.

The banner is now gated on `IS_DEV_TREE`.

## Verified locally (both trees)

| build | result |
|---|---|
| `npx vitepress build` (root) | `grep -c cs-dev-banner` → **0** — banner correctly absent |
| `DOCS_BASE=/dev/ npx vitepress build` | `cs-dev-banner">These docs track the development branch (<code>main</code>). Latest release: v0.17.0.` |

## Not doing

No new `check-doc-versions.sh` check. A guard would assert the constant matches version.txt — but there's no longer a constant to drift. Adding a grep for a value that's now derived would be guarding the wrong thing.