### PR TITLE
docs: wait on CI with a watch, not a sleep poll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,12 @@ Tests automatically create and clean up test buckets. Use custom bucket name via
 - Branch naming: `feat/`, `fix/`, `refactor/` prefixes
 - PR per feature/fix; link to issue
 - Close issues via commit message: `Fixes #123`, `Closes #123`
+- **Wait on CI with a watch, never a `sleep` poll.** Use
+  `gh pr checks <pr> --watch --fail-fast` or `gh run watch <id> --exit-status`,
+  backgrounded, so completion wakes you. A full check set takes ~5-8 min (the
+  fuzz burst and race detector are the long tails), so any fixed sleep either
+  wastes wall-clock or wakes early and needs another poll. Same rule for
+  anything with a native wait (`wait`, `--follow`, `--wait`).
 
 ## Pre-commit Checks
 - Run before every commit: `gofmt`, `go vet`, `staticcheck`


### PR DESCRIPTION
One-paragraph convention added to the **Git & GitHub** section of `CLAUDE.md`.

Waiting on CI should use the blocking-watch form, backgrounded, so completion wakes the agent:

```bash
gh pr checks <pr> --watch --fail-fast
gh run watch <run-id> --exit-status
```

Not a fixed `sleep N` followed by a re-check. A full check set here runs ~5-8 minutes — the fuzz burst and race detector are the long tails — so a guessed duration either idles past the finish or wakes early and needs another poll. Extended to anything with a native wait (`wait`, `--follow`, `--wait`).

Docs-only; no code, no behavior change.