### PR TITLE
fix(cli): make upload/sync flags actually do what they advertise

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -101,15 +101,16 @@ run_linting() {
 
 # Run tests with coverage
 run_tests() {
-    log_info "Running tests with coverage analysis (excluding LocalStack integration tests)..."
-    
-    # Export environment variables to skip slow/flaky tests
-    export SKIP_LOCALSTACK=1
-    export SKIP_INTEGRATION=1
-    
-    # Run tests with timeout, EXCLUDING LocalStack integration tests for speed
-    # Skip integration tests requiring Docker/LocalStack for fast pre-commit validation
-    # Integration tests should run in CI where Docker is guaranteed available
+    log_info "Running tests with coverage analysis (short mode; integration tests excluded)..."
+
+    # Integration tests are excluded by BUILD TAG, not by an env var: they sit
+    # behind `-tags integration` and this command doesn't pass it. `-short` also
+    # trims the slow in-package tests. There is deliberately nothing to export —
+    # SKIP_LOCALSTACK/SKIP_INTEGRATION used to be set here and were read by
+    # nothing, which made the exclusion look configurable when it wasn't.
+    #
+    # There is no LocalStack any more either: integration tests run against the
+    # in-process Substrate emulator (no Docker), so CI runs them credential-free.
     # Use -p=4 to limit parallel packages and -parallel=4 to limit concurrent tests per package
     # This reduces memory pressure while still maintaining reasonable speed
     # Exclude examples directory from coverage (they're demos, not production code)
@@ -335,10 +336,22 @@ check_test_quality() {
                 fi
             fi
             
-            # Check for LocalStack tests without integration tags
-            if grep -q "LocalStack\|localstack\|4566" "$test_file" 2>/dev/null; then
-                if ! head -5 "$test_file" | grep -q "//go:build integration"; then
-                    quality_issues+=("$test_file: Integration test missing '//go:build integration' tag")
+            # Check for integration tests without the build tag that gates them.
+            # This used to grep for LocalStack/port 4566, which no test has
+            # mentioned since the switch to the in-process Substrate emulator —
+            # so the check could never fire. It now looks for what integration
+            # tests actually use: the emulator, or real-AWS opt-in env vars.
+            # Any of integration/e2e/benchmark counts as gated — all three are
+            # excluded from the default build, which is what matters here.
+            #
+            # A runtime t.Skip() on an opt-in env var counts too: real-AWS tests
+            # are required to self-skip rather than hide behind a tag, so they
+            # compile in the default build on purpose (pkg/multiregion does this).
+            if grep -q "emulator\." "$test_file" 2>/dev/null; then
+                if ! head -5 "$test_file" | grep -qE "//go:build (integration|e2e|benchmark)"; then
+                    if ! grep -q "t\.Skip" "$test_file"; then
+                        quality_issues+=("$test_file: Integration test needs a build tag (integration/e2e/benchmark) or a runtime t.Skip() guard")
+                    fi
                 fi
             fi
             

--- a/.github/workflows/deadcode.yml
+++ b/.github/workflows/deadcode.yml
@@ -8,6 +8,12 @@ name: Dead Code Audit
 #          on a code path with no non-test caller.
 #   #311 — download's own tar loop carried a THIRD copy of it, and had also
 #          missed verify-on-restore (#283) and the #287 layout.
+#   #316 — a FOURTH: ShardCoordinator/ShardPipeline/ShardProgressRenderer in
+#          pkg/pipeline had no production caller, and were the only code that
+#          honored --compression-level. So the flag was accepted by the CLI and
+#          silently did nothing, because the only implementation was unreachable.
+#          pkg/pipeline was outside this filter, which is why it stayed invisible;
+#          it was added to the filter in #316 (see #325 for the triage).
 #
 # Neither was caught by the `unused` linter in golangci-lint, which only sees
 # unexported symbols. `deadcode` does whole-program reachability from the real
@@ -15,8 +21,9 @@ name: Dead Code Audit
 #
 # NON-BLOCKING, and scoped, on purpose:
 #   * Whole-repo deadcode reports ~1800 findings — unusable as a gate. Scoped to
-#     the trust packages (manifest/restore/archivefs/glacier) it's ~35, which a
-#     human can actually read.
+#     the trust packages (manifest/restore/archivefs/glacier) plus pipeline it's
+#     a few hundred, dominated by pipeline's own backlog; still readable, and
+#     that backlog is the point rather than noise to be filtered away.
 #   * Run WITHOUT `-test`. That's the important flag choice: in `-test` mode,
 #     code reachable from its own tests counts as live, and extract.go had
 #     passing tests — so `-test` mode would have reported ZERO findings for the
@@ -36,14 +43,14 @@ on:
     inputs:
       filter:
         description: 'Regexp of package paths to report on (deadcode -filter)'
-        default: '^github.com/scttfrdmn/cargoship/pkg/(manifest|restore|archivefs|glacier)'
+        default: '^github.com/scttfrdmn/cargoship/pkg/(manifest|restore|archivefs|glacier|pipeline)'
 
 permissions:
   contents: read
 
 env:
   GO_VERSION: '1.26'
-  DEFAULT_FILTER: '^github.com/scttfrdmn/cargoship/pkg/(manifest|restore|archivefs|glacier)'
+  DEFAULT_FILTER: '^github.com/scttfrdmn/cargoship/pkg/(manifest|restore|archivefs|glacier|pipeline)'
 
 jobs:
   deadcode:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`upload` and `sync` accepted five flags that had no effect.** The CLI parsed
+  them, printed some of them back, and then dropped them before the pipeline ran.
+  A user who passed `--compression-level 19` for a cold archive got the automatic
+  level instead, with nothing to indicate otherwise — following the published
+  guides produced silent non-compliance. All five now do what they say. (#316)
+  - `--compression-level` is an **override**: an explicitly passed value pins
+    every chunk to that level and turns off content-aware per-chunk selection
+    (#105/#30). Omitting the flag keeps the automatic behavior — the flag's
+    default is *not* forwarded, because doing so would have pinned every existing
+    user's uploads to level 3. Levels outside the pre-built encoder tiers (1/3/6/9)
+    now get their own encoder rather than silently falling back to 3. Note that
+    Go's zstd exposes four internal levels, so 1–22 collapses into four bands;
+    the effective setting is printed at upload start.
+  - `--shard-strategy` now implements all of its advertised values. `hash` hashes
+    the chunk's file identities, `size` picks the least-loaded shard by bytes,
+    `type` groups by predominant content type, and `directory` groups by common
+    path prefix. The default is now `round-robin`, which is what the archiver has
+    always actually done — the flag previously *defaulted* to `hash` while
+    behaving as round-robin. Existing archives are unaffected: each chunk's shard
+    is recorded in the manifest, so restore never recomputes assignment.
+  - `--direct-upload-threshold-mb` and `--direct-upload-workers` are now read.
+  - `--interactive` is hidden. Its per-shard TUI exists only in an unreachable
+    subsystem, so it stays defined (scripts passing it won't break) but is no
+    longer advertised. See #325.
+- **A single shard decision.** The S3 key was built from `job.ID % shardCount`
+  while `selectOutput` separately computed `job.Chunk.ID % shardCount`; the two
+  could disagree. The shard is now chosen once and reused for the key,
+  `job.ShardID`, and the output-channel pick. (#316)
+- **`cargoship config --validate` rejected `round-robin`** — the actual default
+  shard strategy — because `pkg/config` carried its own hardcoded strategy list.
+  A cross-package test now pins the two lists together. (#316)
+- **Traces were labeled `v0.6.2` regardless of the running binary.** The tracing
+  service version now comes from `internal/version`, the single canonical source
+  (#260), and defaults to it when unset rather than emitting an unlabeled
+  attribute. (#318)
+- **The ROADMAP body claimed the current release was v0.13.2** and described
+  already-shipped work as upcoming. Version numbers are now stated once at the
+  top of the file and omitted from the body, so the body cannot drift. (#319)
+- **The shard-count default was documented four different ways** — "8 shards",
+  "10 shards", "4–32 adaptive", and an undocumented fallback of 8. Every mention
+  now reads: CargoShip automatically selects between 4 and 32 shards when
+  `--shard-count` is 0 (the default), falling back to 8 if automatic selection
+  fails. (#324)
+
+### Changed
+
+- The archive-layout spec no longer implies readers can recompute a chunk's
+  shard. The strategy is an upload-time choice that is not recorded in the
+  manifest, so readers must take each chunk's shard from the manifest — a reader
+  assuming `chunk.ID % shard_count` addresses the wrong object for any archive
+  written with a non-default strategy. (#316)
+- The weekly dead-code audit now covers `pkg/pipeline`. The flags above were
+  inert because the only code honoring `--compression-level` lived in an
+  unreachable fourth duplicate implementation, and `pkg/pipeline` was outside the
+  audit's filter — the same duplicate-drift mechanism as #308 and #311. (#316)
+
 ## [0.17.1] - 2026-08-02
 
 A docs-infrastructure patch. No changes to the tool itself — same binaries,

--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ cargoship upload /data/project-2024 s3://my-bucket/project-2024 --shard-count 16
 - **Zero-disk streaming pipeline** — files stream from disk through compression
   to S3 with no local staging; memory stays bounded to `chunk_size × workers`.
 - **Multi-prefix sharding** — chunks are distributed across S3 prefixes, so
-  request-rate capacity scales with the shard count (up to ~8× with the default
-  8 shards). See [sharding](https://cargoship.app/guides/features/sharding).
+  request-rate capacity scales with the shard count. CargoShip automatically
+  selects between 4 and 32 shards when `--shard-count` is 0 (the default); if
+  automatic selection fails, it falls back to 8. See
+  [sharding](https://cargoship.app/guides/features/sharding).
 - **Content-aware compression** — zstd compresses text and code well and skips
   already-compressed data. See [compression](https://cargoship.app/guides/features/compression).
 - **Cost and budget controls** — estimate spend before uploading and enforce

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # CargoShip Roadmap
 
-**Last Updated**: July 2026
+**Last Updated**: August 2026
 **Current Version**: v0.17.1 (Released 2026-08-02)
 
 This is a forward-looking roadmap: it answers "what's next," not "what happened."
@@ -11,24 +11,23 @@ feedback and development progress.
 
 ---
 
-## Current release — v0.13.2
+## Next (in planning)
 
-CI repair and security hardening: multi-scanner security workflow, dependency
-CVE fixes, and the new documentation site. See the [changelog](CHANGELOG.md) for
-details.
+Version numbers are deliberately omitted below (#319): this file describes
+*themes and ordering*, and pinning a number to each one meant the body drifted
+out of date on every release. The version currently released is stated once, at
+the top of this file; what shipped in it is in the [changelog](CHANGELOG.md).
 
-## Next — v0.14.0 (Planning)
-
-Theme: **enterprise budget foundations**. Candidate items (planned/proposed, not
-yet committed to a date):
+Theme: **enterprise budget depth**, building on the durable/shareable budgets
+already shipped. Candidate items (proposed, not committed to a date):
 
 - Multi-grant portfolio management — track multiple concurrent grants/budgets.
 - Hierarchical budget controls — department → lab → project → user inheritance.
 - Advanced burn-rate analytics — predictive spending with seasonality.
 - Budget approval workflows — multi-stage approval for large transfers.
 
-Exact scope will be finalized during planning; some items may land across
-several minor releases.
+Exact scope is finalized during planning; some items may land across several
+minor releases.
 
 ## Near-term (following minor releases)
 
@@ -41,9 +40,10 @@ High-level themes, in rough priority order:
 - **Maturity work** — graduate beta components (DVC integration, distributed
   agents) toward stable; expand test coverage and docs.
 
-## Longer-term — path to v1.0.0
+## Longer-term — path to the first stable release
 
-v1.0.0 is about stability and maturity, not a feature dump:
+The first stable (1.x) release is about stability and maturity, not a feature
+dump:
 
 - **API stabilization** — settle the public Go API package-by-package (today
   it's mixed per `docs/project/maturity.md`) and commit to semver guarantees.

--- a/cmd/cargoship/cmd/config.go
+++ b/cmd/cargoship/cmd/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/dustin/go-humanize"
 	"github.com/scttfrdmn/cargoship/pkg/config"
+	"github.com/scttfrdmn/cargoship/pkg/pipeline"
 	"github.com/spf13/cobra"
 )
 
@@ -294,14 +295,9 @@ func validateConfig(manager *config.Manager, detailed bool) error {
 		fmt.Printf("  ✅ Shard Count: %d\n", cfg.CargoHold.ShardCount)
 	}
 
-	validShardStrategies := []string{"hash", "size", "type", "directory"}
-	shardStrategyValid := false
-	for _, strategy := range validShardStrategies {
-		if cfg.CargoHold.ShardStrategy == strategy {
-			shardStrategyValid = true
-			break
-		}
-	}
+	// #316: single source of truth for the valid set, shared with the
+	// --shard-strategy flag on upload and sync.
+	shardStrategyValid := pipeline.ValidateShardStrategy(cfg.CargoHold.ShardStrategy) == nil
 	if !shardStrategyValid {
 		errors = append(errors, fmt.Sprintf("Invalid shard strategy: %s", cfg.CargoHold.ShardStrategy))
 		fmt.Printf("  ❌ Shard Strategy: %s (invalid)\n", cfg.CargoHold.ShardStrategy)

--- a/cmd/cargoship/cmd/sync.go
+++ b/cmd/cargoship/cmd/sync.go
@@ -94,6 +94,16 @@ Examples:
 				return fmt.Errorf("invalid S3 URL: %w", err)
 			}
 
+			// #316: now that these flags do something, validate them the way
+			// upload does — an unknown strategy should be a usage error, not a
+			// silent fall-through to the default.
+			if err := pipeline.ValidateShardStrategy(shardStrategy); err != nil {
+				return err
+			}
+			if compressionLevel < 1 || compressionLevel > 22 {
+				return fmt.Errorf("compression-level must be between 1 and 22 (zstd range)")
+			}
+
 			if !quiet {
 				fmt.Printf("🔄 CargoShip Sync: %s → s3://%s/%s\n\n", absPath, bucket, prefix)
 			}
@@ -222,6 +232,19 @@ Examples:
 				EnableManifest:    true,
 				SourcePath:        absPath,
 
+				// #316: sync advertised --shard-strategy and --compression-level
+				// and dropped both, without even upload's printout to hint that
+				// they were inert. --compression-level is an override, so only
+				// an explicitly passed value is forwarded; 0 keeps content-aware
+				// per-chunk selection.
+				ShardStrategy: shardStrategy,
+				CompressionLevel: func() int {
+					if cmd.Flags().Changed("compression-level") {
+						return compressionLevel
+					}
+					return 0
+				}(),
+
 				// Issue #148: Incremental sync configuration
 				IncludeOnlyFiles: includeFiles,
 				SyncType:         syncType,
@@ -271,8 +294,11 @@ Examples:
 
 	cmd.Flags().StringVar(&storageClass, "storage-class", "STANDARD", "S3 storage class (STANDARD, GLACIER_IR, DEEP_ARCHIVE)")
 	cmd.Flags().IntVar(&shardCount, "shard-count", 10, "Number of shards for parallel uploads (1-100)")
-	cmd.Flags().StringVar(&shardStrategy, "shard-strategy", "hash", "Shard distribution strategy (hash, size, type, directory)")
-	cmd.Flags().IntVar(&compressionLevel, "compression-level", 3, "Zstd compression level (1-22, recommended 1-19)")
+	// #316: same wording as upload's flags, which these now share behavior with.
+	cmd.Flags().StringVar(&shardStrategy, "shard-strategy", pipeline.ShardStrategyRoundRobin,
+		"Shard distribution strategy (round-robin, hash, size, type, directory)")
+	cmd.Flags().IntVar(&compressionLevel, "compression-level", 3,
+		"Fixed zstd compression level (1-22), overriding per-chunk content-aware selection. Unset = content-aware")
 	cmd.Flags().StringVarP(&region, "region", "r", "us-west-2", "AWS region")
 	cmd.Flags().BoolVar(&useChecksum, "checksum", false, "Use SHA256 checksum comparison (slower but accurate)")
 	cmd.Flags().BoolVar(&trackDeletes, "track-deletes", false, "Track deleted files in manifest")

--- a/cmd/cargoship/cmd/upload.go
+++ b/cmd/cargoship/cmd/upload.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	versionpkg "github.com/scttfrdmn/cargoship/internal/version"
 	cargoconfig "github.com/scttfrdmn/cargoship/pkg/aws/config"
 	"github.com/scttfrdmn/cargoship/pkg/aws/cost"
 	"github.com/scttfrdmn/cargoship/pkg/manifest"
@@ -87,26 +88,38 @@ func NewUploadCmd() *cobra.Command {
 
 CargoHold divides large datasets into multiple shards for parallel uploads,
 providing:
-- Intelligent shard distribution (hash, size, type, or directory-based)
-- Per-shard compression with configurable levels (zstd)
+- Intelligent shard distribution (round-robin, hash, size, type, or directory)
+- Content-aware zstd compression, with an optional fixed-level override
 - Parallel uploads for maximum throughput
 - Automatic manifest generation for easy restore
-- Progress tracking with per-shard visibility
+- Progress tracking
+
+Shard Count:
+  CargoShip automatically selects between 4 and 32 shards when --shard-count is
+  0 (the default). If automatic selection fails, it falls back to 8.
 
 Shard Strategies:
-  hash      - Hash-based distribution (balanced, default)
-  size      - Size-based distribution (large files in separate shards)
-  type      - File type distribution (group by extension)
-  directory - Directory-based distribution (keep directories together)
+  round-robin - Distribute by chunk order (even shards, cheapest; default)
+  hash        - Hash of chunk contents (stable across runs)
+  size        - Least-loaded shard by bytes (evens out uneven chunk sizes)
+  type        - Group chunks by predominant content type
+  directory   - Group chunks by common directory prefix
+
+Compression:
+  By default CargoShip picks a zstd level per chunk from the content it
+  contains — level 1 for already-compressed data, up to level 9 for source
+  code. Passing --compression-level overrides that and pins every chunk to one
+  level. Note that zstd has only four internal levels, so values map in bands
+  (1-2, 3-5, 6-9, 10+); the effective setting is reported at upload start.
 
 Examples:
-  # Upload with default settings (10 shards, hash strategy, compression level 3)
+  # Upload with defaults (auto shard count, round-robin, content-aware compression)
   cargoship upload /data s3://my-bucket/dataset
 
   # Upload with custom shard count and strategy
   cargoship upload /data s3://my-bucket/dataset --shard-count 20 --shard-strategy size
 
-  # Upload with maximum compression
+  # Pin every chunk to maximum compression (disables content-aware selection)
   cargoship upload /data s3://my-bucket/dataset --compression-level 19
 
   # Quiet mode (no progress display)
@@ -135,15 +148,9 @@ Examples:
 				return fmt.Errorf("invalid destination: %w", err)
 			}
 
-			// Validate shard strategy
-			validStrategies := map[string]bool{
-				"hash":      true,
-				"size":      true,
-				"type":      true,
-				"directory": true,
-			}
-			if !validStrategies[shardStrategy] {
-				return fmt.Errorf("invalid shard-strategy: %s (must be hash, size, type, or directory)", shardStrategy)
+			// Validate shard strategy (#316: the pipeline owns the valid set)
+			if err := pipeline.ValidateShardStrategy(shardStrategy); err != nil {
+				return err
 			}
 
 			// Validate compression level (zstd range: 1-22, recommended: 1-19)
@@ -186,6 +193,15 @@ Examples:
 			absPath, err := filepath.Abs(sourceDir)
 			if err != nil {
 				return fmt.Errorf("failed to resolve path %s: %w", sourceDir, err)
+			}
+
+			// #316: --compression-level is an override, so only an explicitly
+			// passed value reaches the pipeline. Sending the flag's default (3)
+			// unconditionally would pin every chunk to level 3 and switch OFF
+			// content-aware compression for everyone who never touched the flag.
+			effectiveCompressionLevel := 0
+			if cmd.Flags().Changed("compression-level") {
+				effectiveCompressionLevel = compressionLevel
 			}
 
 			// Issue #106: Auto-detect optimal shard count if not specified
@@ -282,12 +298,16 @@ Examples:
 			// Initialize distributed tracing if enabled
 			if enableTracing {
 				tracingConfig := tracing.Config{
-					Enabled:        true,
-					ExporterType:   tracingExporter,
-					Endpoint:       tracingEndpoint,
-					SampleRate:     tracingSampleRate,
-					ServiceName:    "cargoship",
-					ServiceVersion: "v0.6.2",
+					Enabled:      true,
+					ExporterType: tracingExporter,
+					Endpoint:     tracingEndpoint,
+					SampleRate:   tracingSampleRate,
+					ServiceName:  "cargoship",
+					// #318: was hardcoded "v0.6.2", so every trace from every
+					// release since has misreported the build. version.Version
+					// is the canonical source (internal/version/version.txt),
+					// and release.yml verifies it matches the pushed tag.
+					ServiceVersion: "v" + versionpkg.Version,
 				}
 
 				tracerProvider, err := tracing.NewTracerProvider(ctx, tracingConfig)
@@ -569,6 +589,11 @@ Examples:
 				ShardCount:        shardCount,
 				WorkersPerPrefix:  2,
 
+				// #316: shard strategy and compression level now reach the
+				// archiver. Both flags were accepted and discarded before this.
+				ShardStrategy:    shardStrategy,
+				CompressionLevel: effectiveCompressionLevel,
+
 				// Progress tracking
 				EnableProgress:   !quiet,
 				ProgressInterval: 100 * 1000000, // 100ms in nanoseconds
@@ -594,6 +619,10 @@ Examples:
 				EnableDirectUpload:     cmd.Flags().Changed("direct-upload"),
 				ForceDirectUpload:      cmd.Flags().Changed("force-direct-upload"),
 				EnableAutoDirectUpload: true, // Auto-enable when thresholds met
+				// #316: these two were advertised but never read, so the
+				// pipeline always used its own defaults (500MB / 256 workers).
+				DirectUploadThresholdMB: func() int { v, _ := cmd.Flags().GetInt("direct-upload-threshold-mb"); return v }(),
+				DirectUploadWorkers:     func() int { v, _ := cmd.Flags().GetInt("direct-upload-workers"); return v }(),
 
 				// Issue #183: DVC budget integration
 				ProjectID: dvcProject,
@@ -604,9 +633,6 @@ Examples:
 				GitMetadataData: gitMetadataData,
 			}
 
-			// Note: Compression level and shard strategy are not yet implemented in the pipeline
-			// These will be added in future enhancements
-			// For now, we log them for visibility
 			if !quiet {
 				fmt.Printf("🚢 CargoHold Upload Configuration:\n")
 				fmt.Printf("   Source:            %s\n", absPath)
@@ -618,7 +644,15 @@ Examples:
 					fmt.Printf("   Shard Count:       %d (auto-selected)\n", shardCount)
 				}
 				fmt.Printf("   Shard Strategy:    %s\n", shardStrategy)
-				fmt.Printf("   Compression Level: %d (zstd)\n", compressionLevel)
+				// #316: report what compression will actually do. zstd has only
+				// four tiers, so echoing the requested number alone would imply
+				// finer control than exists.
+				if effectiveCompressionLevel != 0 {
+					fmt.Printf("   Compression Level: %d (zstd %s, fixed — content-aware selection off)\n",
+						effectiveCompressionLevel, pipeline.EffectiveZstdTier(effectiveCompressionLevel))
+				} else {
+					fmt.Printf("   Compression Level: content-aware (per chunk, zstd 1-9)\n")
+				}
 				fmt.Printf("   Storage Class:     %s\n\n", storageClass)
 			}
 
@@ -810,11 +844,24 @@ Examples:
 
   See: https://github.com/scttfrdmn/cargoship/issues/168`)
 
-	cmd.Flags().IntVar(&shardCount, "shard-count", 0, "Number of shards for parallel uploads (0=auto, 4-32=manual, default: 0)")
-	cmd.Flags().StringVar(&shardStrategy, "shard-strategy", "hash", "Shard distribution strategy (hash, size, type, directory)")
-	cmd.Flags().IntVar(&compressionLevel, "compression-level", 3, "Zstd compression level (1-22, recommended 1-19)")
+	cmd.Flags().IntVar(&shardCount, "shard-count", 0, "Shards for parallel uploads: 0 auto-selects 4-32 (falls back to 8), or set 4-32 manually")
+	// #316: the default is round-robin because that is what CargoShip has always
+	// done. It was previously labelled "hash" while the code did chunkID % count,
+	// so the advertised default named a strategy that was never implemented.
+	// "hash" now genuinely hashes chunk contents; changing the default would
+	// silently redistribute every user's shards, so it stays opt-in.
+	cmd.Flags().StringVar(&shardStrategy, "shard-strategy", pipeline.ShardStrategyRoundRobin,
+		"Shard distribution strategy (round-robin, hash, size, type, directory)")
+	cmd.Flags().IntVar(&compressionLevel, "compression-level", 3,
+		"Fixed zstd compression level (1-22), overriding per-chunk content-aware selection. Unset = content-aware")
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "Disable progress display")
 	cmd.Flags().BoolVar(&interactive, "interactive", false, "Enable interactive TUI mode with per-shard progress (Issue #112)")
+	// #316: --interactive has never had an implementation on the live upload
+	// path — the TUI it refers to (pkg/pipeline/progress.go) is only reachable
+	// from the ShardCoordinator subsystem, which has no production caller (#325).
+	// Hide it rather than keep advertising an inert flag; it stays accepted so
+	// existing scripts don't break. Unhide when real per-shard progress lands.
+	_ = cmd.Flags().MarkHidden("interactive")
 
 	// v0.6.2: Advanced transporter flags
 	cmd.Flags().StringVar(&transporterType, "transporter", "staging", "S3 transporter type: basic, staging, adaptive, optimized, none")

--- a/cmd/cargoship/cmd/upload_test.go
+++ b/cmd/cargoship/cmd/upload_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scttfrdmn/cargoship/pkg/aws/cost"
 	"github.com/scttfrdmn/cargoship/pkg/manifest"
@@ -42,9 +43,81 @@ func TestNewUploadCmd_Structure(t *testing.T) {
 	assert.Equal(t, "us-west-2", cmd.Flags().Lookup("region").DefValue)
 	assert.Equal(t, "STANDARD", cmd.Flags().Lookup("storage-class").DefValue)
 	assert.Equal(t, "0", cmd.Flags().Lookup("shard-count").DefValue) // Issue #106: Auto-select by default
-	assert.Equal(t, "hash", cmd.Flags().Lookup("shard-strategy").DefValue)
+	// #316: the default is round-robin, which is what the archiver has always
+	// actually done. It previously read "hash" while the implementation was
+	// round-robin — and this test passed anyway, which is the point of the
+	// behavioral tests referenced below.
+	assert.Equal(t, pipeline.ShardStrategyRoundRobin, cmd.Flags().Lookup("shard-strategy").DefValue)
 	assert.Equal(t, "3", cmd.Flags().Lookup("compression-level").DefValue)
 	assert.Equal(t, "false", cmd.Flags().Lookup("quiet").DefValue)
+}
+
+// TestUploadCmd_FlagsReachPipelineConfig is the guard for #316: for a decade of
+// commits the assertions above were the *only* coverage these flags had, and they
+// passed while --compression-level, --shard-strategy, --direct-upload-threshold-mb,
+// --direct-upload-workers and --interactive were all accepted and then dropped on
+// the floor. Presence and default assertions cannot detect a flag that does
+// nothing, so this test walks the flag → PipelineConfig path instead.
+//
+// The per-strategy and per-level *behavior* lives in pkg/pipeline
+// (shard_strategy_test.go, archiver_test.go); this only proves the CLI hands the
+// values over.
+func TestUploadCmd_FlagsReachPipelineConfig(t *testing.T) {
+	t.Run("shard strategy is validated against the pipeline's set", func(t *testing.T) {
+		// Every value the flag advertises must be accepted by the assigner that
+		// consumes it. A strategy named in --help but rejected (or silently
+		// ignored) downstream is the #316 defect.
+		for _, s := range pipeline.ShardStrategies() {
+			assert.NoError(t, pipeline.ValidateShardStrategy(s),
+				"upload advertises strategy %q; the pipeline must accept it", s)
+		}
+		assert.Error(t, pipeline.ValidateShardStrategy("balanced"),
+			"an unknown strategy must be rejected at parse time, not ignored at run time")
+	})
+
+	t.Run("compression level is an override, not a floor", func(t *testing.T) {
+		cmd := NewUploadCmd()
+		// Untouched: the pipeline must receive 0 so content-aware selection
+		// stays on. Forwarding the flag's default (3) unconditionally would
+		// pin every chunk to level 3 for every user who never passed the flag.
+		assert.False(t, cmd.Flags().Changed("compression-level"),
+			"a fresh command has not been given the flag")
+
+		require.NoError(t, cmd.Flags().Set("compression-level", "19"))
+		assert.True(t, cmd.Flags().Changed("compression-level"),
+			"Changed() is what distinguishes an explicit 3 from an absent flag")
+		v, err := cmd.Flags().GetInt("compression-level")
+		require.NoError(t, err)
+		assert.Equal(t, 19, v)
+		// 19 is outside the pre-built encoder-pool tiers (1/3/6/9); it must not
+		// be silently downgraded. See TestArchiverStage_CompressionLevelOutOfPoolOverride.
+		assert.Equal(t, "best", pipeline.EffectiveZstdTier(19),
+			"an out-of-tier override must map to the strongest tier, not fall back to 3")
+	})
+
+	t.Run("direct-upload flags are readable ints", func(t *testing.T) {
+		cmd := NewUploadCmd()
+		// These two were defined and never read; upload.go now reads them via
+		// GetInt, so a rename or type change here must break loudly.
+		require.NoError(t, cmd.Flags().Set("direct-upload-threshold-mb", "250"))
+		require.NoError(t, cmd.Flags().Set("direct-upload-workers", "64"))
+
+		threshold, err := cmd.Flags().GetInt("direct-upload-threshold-mb")
+		require.NoError(t, err)
+		assert.Equal(t, 250, threshold)
+
+		workers, err := cmd.Flags().GetInt("direct-upload-workers")
+		require.NoError(t, err)
+		assert.Equal(t, 64, workers)
+	})
+
+	t.Run("interactive is hidden rather than accepted-and-inert", func(t *testing.T) {
+		cmd := NewUploadCmd()
+		f := cmd.Flags().Lookup("interactive")
+		require.NotNil(t, f, "the flag stays defined so existing scripts don't break")
+		assert.True(t, f.Hidden,
+			"--interactive has no live implementation (see #325); it must not be advertised")
+	})
 }
 
 // TestUploadCmd_FlagTypes tests that flags have correct types (Issue #95)
@@ -91,9 +164,9 @@ func TestUploadCmd_HelpText(t *testing.T) {
 			"Help text should mention '%s'", phrase)
 	}
 
-	// Verify shard strategies are documented
-	strategies := []string{"hash", "size", "type", "directory"}
-	for _, strategy := range strategies {
+	// Verify shard strategies are documented. Driven off the pipeline's list, not
+	// a hardcoded copy, so adding a strategy without documenting it fails here.
+	for _, strategy := range pipeline.ShardStrategies() {
 		assert.Contains(t, cmd.Long, strategy,
 			"Help text should document shard strategy '%s'", strategy)
 	}
@@ -215,12 +288,17 @@ func TestUploadCmd_ShardCountRange(t *testing.T) {
 	defaultCount := cmd.Flags().Lookup("shard-count").DefValue
 	assert.Equal(t, "0", defaultCount, "Default shard count should be 0 (auto)")
 
-	// Verify help text mentions valid range and auto mode
+	// Verify help text documents auto mode, the valid range, and the fallback.
+	// #324: the fallback was previously undocumented here and stated three
+	// different ways elsewhere, so a user reading --help couldn't tell what 0
+	// would actually produce.
 	usage := cmd.Flags().Lookup("shard-count").Usage
-	assert.Contains(t, usage, "0=auto",
+	assert.Contains(t, usage, "auto",
 		"Flag usage should document auto mode")
 	assert.Contains(t, usage, "4-32",
 		"Flag usage should document valid range")
+	assert.Contains(t, usage, "8",
+		"Flag usage should document the fallback used when auto-selection fails")
 }
 
 // TestUploadCmd_RequiredArguments tests that command requires 2 arguments (Issue #95)

--- a/docs/enterprise/deployment.md
+++ b/docs/enterprise/deployment.md
@@ -74,11 +74,11 @@ The main levers are compression level and network-matched concurrency.
 
 - **Many small files** — group aggressively, high compression:
   `--compression-level 9`.
-- **Mixed dataset** — defaults are tuned for this; tag `--project` for cost
-  tracking.
-- **Few large / already-compressed files** — use a fast level:
-  `--compression-level 3` (CargoShip skips re-compressing compressed content
-  anyway).
+- **Mixed dataset** — omit `--compression-level` entirely. Content-aware
+  selection picks per chunk, which a single pinned level cannot; tag `--project`
+  for cost tracking.
+- **Few large / already-compressed files** — pin a fast level:
+  `--compression-level 1`.
 
 Match parallelism to your uplink: residential broadband wants a small shard count,
 a datacenter link can drive many. See [Performance tuning](/guides/features/optimization).

--- a/docs/gen/cli/cargoship_sync.md
+++ b/docs/gen/cli/cargoship_sync.md
@@ -46,14 +46,14 @@ cargoship sync SOURCE_DIR S3_URL [flags]
 
 ```
       --checksum                Use SHA256 checksum comparison (slower but accurate)
-      --compression-level int   Zstd compression level (1-22, recommended 1-19) (default 3)
+      --compression-level int   Fixed zstd compression level (1-22), overriding per-chunk content-aware selection. Unset = content-aware (default 3)
       --dry-run                 Show what would be synced without uploading
       --force                   Force full sync (ignore previous manifest)
   -h, --help                    help for sync
   -q, --quiet                   Quiet mode (minimal output)
   -r, --region string           AWS region (default "us-west-2")
       --shard-count int         Number of shards for parallel uploads (1-100) (default 10)
-      --shard-strategy string   Shard distribution strategy (hash, size, type, directory) (default "hash")
+      --shard-strategy string   Shard distribution strategy (round-robin, hash, size, type, directory) (default "round-robin")
       --storage-class string    S3 storage class (STANDARD, GLACIER_IR, DEEP_ARCHIVE) (default "STANDARD")
       --track-deletes           Track deleted files in manifest
 ```

--- a/docs/gen/cli/cargoship_upload.md
+++ b/docs/gen/cli/cargoship_upload.md
@@ -8,26 +8,38 @@ Upload a directory to S3 using CargoHold's intelligent sharding system.
 
 CargoHold divides large datasets into multiple shards for parallel uploads,
 providing:
-- Intelligent shard distribution (hash, size, type, or directory-based)
-- Per-shard compression with configurable levels (zstd)
+- Intelligent shard distribution (round-robin, hash, size, type, or directory)
+- Content-aware zstd compression, with an optional fixed-level override
 - Parallel uploads for maximum throughput
 - Automatic manifest generation for easy restore
-- Progress tracking with per-shard visibility
+- Progress tracking
+
+Shard Count:
+  CargoShip automatically selects between 4 and 32 shards when --shard-count is
+  0 (the default). If automatic selection fails, it falls back to 8.
 
 Shard Strategies:
-  hash      - Hash-based distribution (balanced, default)
-  size      - Size-based distribution (large files in separate shards)
-  type      - File type distribution (group by extension)
-  directory - Directory-based distribution (keep directories together)
+  round-robin - Distribute by chunk order (even shards, cheapest; default)
+  hash        - Hash of chunk contents (stable across runs)
+  size        - Least-loaded shard by bytes (evens out uneven chunk sizes)
+  type        - Group chunks by predominant content type
+  directory   - Group chunks by common directory prefix
+
+Compression:
+  By default CargoShip picks a zstd level per chunk from the content it
+  contains — level 1 for already-compressed data, up to level 9 for source
+  code. Passing --compression-level overrides that and pins every chunk to one
+  level. Note that zstd has only four internal levels, so values map in bands
+  (1-2, 3-5, 6-9, 10+); the effective setting is reported at upload start.
 
 Examples:
-  # Upload with default settings (10 shards, hash strategy, compression level 3)
+  # Upload with defaults (auto shard count, round-robin, content-aware compression)
   cargoship upload /data s3://my-bucket/dataset
 
   # Upload with custom shard count and strategy
   cargoship upload /data s3://my-bucket/dataset --shard-count 20 --shard-strategy size
 
-  # Upload with maximum compression
+  # Pin every chunk to maximum compression (disables content-aware selection)
   cargoship upload /data s3://my-bucket/dataset --compression-level 19
 
   # Quiet mode (no progress display)
@@ -43,7 +55,7 @@ cargoship upload SOURCE_DIR DESTINATION [flags]
 ```
       --auto-tier                        Enable automatic storage tier selection based on file access time
   -b, --bucket string                    S3 bucket name (or use s3:// URL in DESTINATION)
-      --compression-level int            Zstd compression level (1-22, recommended 1-19) (default 3)
+      --compression-level int            Fixed zstd compression level (1-22), overriding per-chunk content-aware selection. Unset = content-aware (default 3)
       --congestion-control string        Congestion control algorithm: bbr, cubic, auto (default "auto")
       --direct-upload                    Enable direct upload mode (bypasses archiving/compression for small files)
       --direct-upload-threshold-mb int   Max total size in MB for auto direct upload (default: 500) (default 500)
@@ -61,7 +73,6 @@ cargoship upload SOURCE_DIR DESTINATION [flags]
       --git-metadata                     Embed Git repository metadata (commit, branch, tag, remote) in the manifest
   -h, --help                             help for upload
       --incremental                      Enable incremental sync: only upload new or changed files
-      --interactive                      Enable interactive TUI mode with per-shard progress (Issue #112)
       --kms-key-id string                AWS KMS key ID or ARN for encryption (data chunks encrypted with SSE-KMS)
       --no-file-checksums                Disable per-file content checksums (faster uploads, but 'verify --deep' can't confirm per-file integrity)
       --optimization                     Enable optimization features (BBR/CUBIC, adaptive staging, BDP) (default true)
@@ -70,8 +81,8 @@ cargoship upload SOURCE_DIR DESTINATION [flags]
       --prometheus-addr string           Prometheus metrics HTTP address (e.g., :9090)
       --quiet                            Disable progress display
   -r, --region string                    AWS region (default "us-west-2")
-      --shard-count int                  Number of shards for parallel uploads (0=auto, 4-32=manual, default: 0)
-      --shard-strategy string            Shard distribution strategy (hash, size, type, directory) (default "hash")
+      --shard-count int                  Shards for parallel uploads: 0 auto-selects 4-32 (falls back to 8), or set 4-32 manually
+      --shard-strategy string            Shard distribution strategy (round-robin, hash, size, type, directory) (default "round-robin")
       --storage-class string             S3 storage class (STANDARD, INTELLIGENT_TIERING, GLACIER, etc.) (default "STANDARD")
       --tag stringArray                  Custom tag in key=value format, repeatable (e.g. --tag dvc_cache=true --tag env=prod)
       --tier-archive-days int            Days since access to consider 'archive' (DEEP_ARCHIVE) (default 180)

--- a/docs/guides/features/benchmarking.md
+++ b/docs/guides/features/benchmarking.md
@@ -2,8 +2,9 @@
 
 `cargoship benchmark` measures how different compression algorithms and levels
 perform on your data, so you can trade archive size against CPU time before
-committing to a `--compression-level` for real uploads. It reports compression
-ratio and throughput for gzip, zlib, zstd, lz4, and s2.
+deciding whether to override the automatic level with `--compression-level` on
+real uploads. It reports compression ratio and throughput for gzip, zlib, zstd,
+lz4, and s2.
 
 ```bash
 # Benchmark against generated data of a given size and type

--- a/docs/guides/features/compression.md
+++ b/docs/guides/features/compression.md
@@ -35,26 +35,37 @@ content types that file extensions miss (code in `.bin` files, misnamed or
 extensionless files).
 
 The practical upshot: **leave levels alone and CargoShip already avoids wasting
-CPU on incompressible data**. The `--compression-level` flag below sets the
-ceiling for content that *is* worth compressing.
+CPU on incompressible data**. The `--compression-level` flag below overrides that
+per-chunk choice.
 
-## Choosing a level
+## Overriding the level
 
 ```bash
 cargoship upload ./my-data s3://my-bucket/archives/ --compression-level 9
 ```
 
-`--compression-level` accepts zstd levels 1–22 (1–19 recommended; the default is
-3, tuned for fast, streaming-friendly throughput). Higher levels compress more
-but cost more CPU, and past a point the extra compression is slower to produce
-than the bandwidth it saves.
+`--compression-level` is an **override**, not a ceiling: passing it pins *every*
+chunk to that level and switches content-aware selection off entirely, including
+the back-off on already-compressed data. Omit the flag to keep automatic
+per-chunk selection, which is the recommended default.
+
+It accepts zstd levels 1–22 (1–19 recommended). Higher levels compress more but
+cost more CPU, and past a point the extra compression is slower to produce than
+the bandwidth it saves.
+
+::: warning Levels map to four bands
+Go's zstd implementation exposes four internal levels, so the 1–22 range
+collapses into four distinct behaviors: **1–2**, **3–5**, **6–9**, and **10+**.
+Level 12 and level 19 produce identical output. CargoShip prints the effective
+setting at upload start so you can see which band you landed in.
+:::
 
 | Level | Speed | Ratio | Good for |
 |-------|-------|-------|----------|
-| 1–3 | Fastest | ~2–2.5:1 | Network-bound uploads, mostly-compressed data (default: 3) |
-| 6–9 | Fast | ~3–4:1 | Balanced general use |
-| 12–15 | Slower | ~4–5:1 | Text-heavy data, CPU to spare |
-| 16–19 | Slowest | ~5:1+ | Cold archives you write once |
+| 1–2 | Fastest | ~2–2.5:1 | Network-bound uploads, mostly-compressed data |
+| 3–5 | Fast | ~2.5–3:1 | Streaming-friendly throughput |
+| 6–9 | Slower | ~3–4:1 | Balanced general use, text-heavy data |
+| 10+ | Slowest | ~4:1+ | Cold archives you write once |
 
 ::: tip Total time, not just ratio
 The fastest level isn't always the fastest *upload*. On a slow link a higher
@@ -71,20 +82,23 @@ encrypted blobs — a high level just burns CPU for no gain. A low level keeps t
 pipeline fast:
 
 ```bash
-cargoship upload ./video-library s3://my-bucket/media/ --compression-level 3
+cargoship upload ./video-library s3://my-bucket/media/ --compression-level 1
 ```
 
 Content-aware selection already backs off on recognized incompressible types, so
-this mainly matters when your whole dataset is pre-compressed.
+this mainly matters when your whole dataset is pre-compressed *and* detection
+can't tell — otherwise omitting the flag gets you the same result without pinning
+the level for everything else in the tree.
 
 ## Best practices
 
 ::: tip
-- **Start with the default** — it streams fast and content-aware selection already
-  avoids wasted work on incompressible files.
-- **Raise to 9–15 for text-heavy archives** (logs, code, CSV/JSON) where the ratio
-  pays off.
-- **Keep it low for media and pre-compressed data** — you won't shrink it.
+- **Omit `--compression-level`** — content-aware selection already picks a high
+  level for text and code and backs off on incompressible files. Passing the flag
+  turns that off for the whole upload.
+- **Override to 9+ only for uniformly text-heavy archives** (logs, code,
+  CSV/JSON), where every chunk wants the same high level anyway.
+- **Override to 1 for media and pre-compressed data** — you won't shrink it.
 - **Enable [Magika](/guides/features/magika)** for mixed or misnamed content so
   detection (and level choice) is accurate.
 - **Benchmark for repeated big jobs** — the best level depends on your link speed

--- a/docs/guides/features/sharding.md
+++ b/docs/guides/features/sharding.md
@@ -39,6 +39,9 @@ get real parallelism) and never more than 32 (past which coordination overhead
 outweighs the gain). It also targets a minimum number of chunks per shard so
 shards stay balanced rather than lopsided.
 
+If automatic selection fails — an unreadable source tree, for example —
+CargoShip falls back to **8** shards and says so.
+
 ```bash
 # Adaptive — recommended
 cargoship upload ./my-data s3://my-bucket/archives/
@@ -64,15 +67,22 @@ almost always matches or beats a hand-picked number.
 
 ## Distribution strategies
 
-`--shard-strategy` controls *which* files go to *which* shard. The default,
-`hash`, keeps shards evenly sized; the others suit specific access patterns.
+`--shard-strategy` controls *which* chunks go to *which* shard. The default,
+`round-robin`, spreads chunks evenly by order; the others suit specific access
+patterns.
 
 | Strategy | Behavior | Use when |
 |----------|----------|----------|
-| `hash` (default) | Even, balanced distribution | General purpose — start here |
-| `size` | Large files isolated into their own shards | Mixed file sizes; keeps big files from unbalancing shards |
-| `type` | Groups files by extension / content type | You'll later download by kind (all `.log`, all `.csv`) |
-| `directory` | Keeps directory trees together in a shard | You'll download or restore by subtree |
+| `round-robin` (default) | Chunk *n* → shard *n mod count* | General purpose — evenest spread by count, no bookkeeping |
+| `hash` | Shard chosen from a hash of the chunk's file paths and sizes | You want assignment to depend on content rather than scan order |
+| `size` | Each chunk goes to the least-loaded shard by bytes | Chunk sizes vary a lot and you want byte-balanced shards |
+| `type` | Groups chunks by predominant content type | You'll later download by kind (all logs, all CSVs) |
+| `directory` | Groups chunks by common directory prefix | You'll download or restore by subtree |
+
+Every strategy is deterministic for a given chunk, and the shard each chunk
+landed on is recorded in the manifest — so restore follows the manifest and
+never recomputes assignment. Changing strategy cannot make an existing archive
+unreadable.
 
 ```bash
 cargoship upload ./my-data s3://my-bucket/archives/ \
@@ -87,8 +97,8 @@ or directory means retrieving a subset touches fewer chunks.
 ::: tip
 - **Leave `--shard-count` on auto** unless you're benchmarking — it's tuned to your
   workload and hardware.
-- **Keep `hash`** for general uploads; reach for `size` only when a few huge files
-  are unbalancing shards.
+- **Keep `round-robin`** for general uploads; reach for `size` only when a few huge
+  chunks are unbalancing shards.
 - **Match strategy to retrieval**: `type` or `directory` if you'll download
   subsets by kind or subtree later.
 - **Scale up (24–32) for TB-scale jobs on fast links**; the ceiling exists because

--- a/docs/guides/sync.md
+++ b/docs/guides/sync.md
@@ -86,10 +86,13 @@ cargoship sync ./my-data s3://my-bucket/backups/ \
   --storage-class GLACIER_IR
 ```
 
-- `--shard-count` — number of parallel shards, 1–100 (default 10).
-- `--shard-strategy` — `hash` (balanced, default), `size`, `type`, `directory`.
-- `--compression-level` — Zstandard 1–22 (default 3). See
-  [Compression](/guides/features/compression).
+- `--shard-count` — number of parallel shards, 1–100 (default 10). Unlike
+  `upload`, `sync` does not auto-select the count.
+- `--shard-strategy` — `round-robin` (default), `hash`, `size`, `type`,
+  `directory`. See [Sharding](/guides/features/sharding).
+- `--compression-level` — Zstandard 1–22. Passing it **overrides** content-aware
+  per-chunk selection and pins every chunk to that level; omit it to keep
+  automatic selection. See [Compression](/guides/features/compression).
 - `--storage-class` — `STANDARD` (default), `GLACIER_IR`, `DEEP_ARCHIVE`, etc.
   See [Lifecycle & storage classes](/guides/cost/lifecycle).
 - `-q`/`--quiet` — minimal output for cron and scripts.

--- a/docs/guides/uploading.md
+++ b/docs/guides/uploading.md
@@ -44,8 +44,9 @@ cap how cold anything goes. See [Tier-aware storage](/guides/features/tiering).
 
 ## Sharding & compression
 
-The [shard count is adaptive](/guides/features/sharding) by default (4–32). Override it,
-or pick a distribution strategy:
+CargoShip [automatically selects](/guides/features/sharding) between 4 and 32
+shards when `--shard-count` is 0 (the default); if automatic selection fails, it
+falls back to 8. Override it, or pick a distribution strategy:
 
 ```bash
 cargoship upload ./my-data s3://my-bucket/archives/ \
@@ -53,10 +54,12 @@ cargoship upload ./my-data s3://my-bucket/archives/ \
   --compression-level 9
 ```
 
-- `--shard-strategy` — `hash` (balanced, default), `size`, `type`, `directory`.
-- `--compression-level` — Zstandard 1–22 (higher = smaller + more CPU).
-  CargoShip still skips re-compressing already-compressed content. See
-  [Compression](/guides/features/compression).
+- `--shard-strategy` — `round-robin` (default), `hash`, `size`, `type`,
+  `directory`. See [Sharding](/guides/features/sharding).
+- `--compression-level` — Zstandard 1–22 (higher = smaller + more CPU). This
+  **overrides** content-aware selection and pins every chunk to one level,
+  including chunks CargoShip would otherwise leave nearly uncompressed. Omit it
+  to keep per-chunk selection. See [Compression](/guides/features/compression).
 
 ## Deduplication
 

--- a/docs/intro/concepts.md
+++ b/docs/intro/concepts.md
@@ -33,8 +33,9 @@ chunks (see [split-file records](/reference/format/split-files)).
 
 An S3 key **prefix** (`shard-0`, `shard-1`, …) that chunks are distributed across
 to parallelize S3 request throughput. The number of shards — the **shard count** —
-is chosen [adaptively](/guides/features/sharding) or set with `--shard-count`.
-Distribution is controlled by `--shard-strategy` (hash, size, type, directory).
+is chosen [adaptively](/guides/features/sharding) (4–32) or set with
+`--shard-count`. Distribution is controlled by `--shard-strategy`
+(round-robin, hash, size, type, directory).
 
 ## CargoHold
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -110,7 +110,7 @@ Sharding subsystem — see [Multi-prefix sharding](/guides/features/sharding).
 |-----|------|---------|-------|
 | `enable` | bool | `true` | Use CargoHold sharding. |
 | `shard_count` | int | `10` | Shards (1–100). The `upload` command defaults to adaptive (`--shard-count 0`). |
-| `shard_strategy` | string | `hash` | One of `hash`, `size`, `type`, `directory`. |
+| `shard_strategy` | string | `hash` | One of `round-robin`, `hash`, `size`, `type`, `directory`. |
 | `compression_level` | int | `3` | Zstandard level (1–22). |
 
 ### `magika`

--- a/docs/reference/format/archive-layout.md
+++ b/docs/reference/format/archive-layout.md
@@ -100,21 +100,33 @@ here is for understanding and for tools that scan a bucket without a manifest.
 
 ## Shard assignment
 
-A chunk's shard is a deterministic function of its ID:
+A chunk's shard is a deterministic function of the chunk, chosen by
+`--shard-strategy`. The default, `round-robin`, uses the chunk's ID:
 
 ```go
-shardID := job.ID % shardCount
+shardID := chunk.ID % shardCount
 ```
 
-Chunks round-robin across shards. With the default 8 shards, chunk 0 → shard 0,
-chunk 1 → shard 1, …, chunk 8 → shard 0, and so on. Each shard is an independent
-S3 key prefix, which is what lets uploads and restores parallelize S3 request
-throughput rather than serializing through one prefix.
+so chunk 0 → shard 0, chunk 1 → shard 1, …, chunk 8 → shard 0 with 8 shards. The
+other strategies (`hash`, `size`, `type`, `directory`) derive the shard from the
+chunk's contents, sizes, or paths instead — see
+[Sharding](/guides/features/sharding). Each shard is an independent S3 key
+prefix, which is what lets uploads and restores parallelize S3 request throughput
+rather than serializing through one prefix.
 
-The shard count is chosen adaptively (4–32) from the workload's file count, size,
-and the machine's resources, or set manually with `--shard-count`. The value
-used for an upload is recorded in the manifest's `shard_count` field, and every
-shard is enumerated in the `shards` array. See
+::: warning Readers must not recompute assignment
+The strategy is an **upload-time** choice and is not recorded in the manifest.
+Every chunk's actual shard is recorded in its `ChunkEntry` (and in the `shards`
+array), so readers must take the shard from the manifest rather than recomputing
+it. A reader that assumes `chunk.ID % shard_count` will address the wrong object
+for any archive written with a non-default strategy.
+:::
+
+CargoShip automatically selects between 4 and 32 shards when `--shard-count` is 0
+(the default), from the workload's file count, size, and the machine's resources;
+if automatic selection fails it falls back to 8. The value used for an upload is
+recorded in the manifest's `shard_count` field, and every shard is enumerated in
+the `shards` array. See
 [Why sharding matters](/intro/how-it-works#why-sharding-matters).
 
 ## Per-object S3 metadata

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -35,9 +35,9 @@ commit, or DVC stage ([`cargoship restore`](/guides/restoring)). Contrast with
 
 **Shard** — An S3 key prefix (`shard-0`, `shard-1`, …) that chunks are distributed
 across to parallelize S3 request throughput. The number of shards — the **shard
-count** — is chosen [adaptively](/guides/features/sharding) or set with
-`--shard-count`; distribution is controlled by `--shard-strategy` (hash, size,
-type, directory).
+count** — is chosen [adaptively](/guides/features/sharding) (4–32) or set with
+`--shard-count`; distribution is controlled by `--shard-strategy` (round-robin,
+hash, size, type, directory).
 
 **Storage class / tier** — The S3 storage class an object is written with
 (STANDARD, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE, …). CargoShip can assign

--- a/docs/start/first-upload.md
+++ b/docs/start/first-upload.md
@@ -44,7 +44,7 @@ Nothing is written to local disk in between; data streams straight to S3.
 |------|------------------|
 | `--region us-east-1` | Match your bucket's region (or set `AWS_REGION`). |
 | `--storage-class INTELLIGENT_TIERING` | Let S3 tier cold data automatically. |
-| `--compression-level 9` | Trade CPU for smaller objects on compressible data. |
+| `--compression-level 9` | Pin every chunk to one level, replacing [content-aware selection](/guides/features/compression). |
 | `--shard-count 16` | Override the [adaptive shard count](/guides/features/sharding). |
 | `--project my-study` | Tag spend for [budgets & cost reports](/guides/cost/budgets). |
 | `--quiet` | Suppress the progress display (good for scripts/logs). |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,11 +5,33 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
+
+// validShardStrategies is the accepted set for cargohold.shard_strategy.
+//
+// #316: this mirrors pipeline.ShardStrategies(). It is duplicated rather than
+// imported because pkg/pipeline already imports pkg/config, so the dependency
+// can only go one way. TestShardStrategiesMatchConfig in pkg/pipeline asserts
+// the two stay identical — before #316 this list omitted "round-robin", so a
+// config file naming the actual default strategy was rejected.
+var validShardStrategies = map[string]bool{
+	"round-robin": true,
+	"hash":        true,
+	"size":        true,
+	"type":        true,
+	"directory":   true,
+}
+
+// ValidShardStrategies returns the accepted cargohold.shard_strategy values in
+// a stable order, for error messages and for cross-package parity checks.
+func ValidShardStrategies() []string {
+	return []string{"round-robin", "hash", "size", "type", "directory"}
+}
 
 // Config represents the complete CargoShip configuration
 type Config struct {
@@ -340,15 +362,9 @@ func (m *Manager) validateConfig() error {
 		return fmt.Errorf("cargohold.shard_count must be between 1 and 100")
 	}
 
-	validShardStrategies := map[string]bool{
-		"hash":      true,
-		"size":      true,
-		"type":      true,
-		"directory": true,
-	}
-
 	if !validShardStrategies[m.config.CargoHold.ShardStrategy] {
-		return fmt.Errorf("invalid cargohold.shard_strategy: %s (valid: hash, size, type, directory)", m.config.CargoHold.ShardStrategy)
+		return fmt.Errorf("invalid cargohold.shard_strategy: %s (valid: %s)",
+			m.config.CargoHold.ShardStrategy, strings.Join(ValidShardStrategies(), ", "))
 	}
 
 	if m.config.CargoHold.CompressionLevel < 1 || m.config.CargoHold.CompressionLevel > 22 {

--- a/pkg/observability/tracing/provider.go
+++ b/pkg/observability/tracing/provider.go
@@ -11,12 +11,18 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+
+	"github.com/scttfrdmn/cargoship/internal/version"
 )
 
 // Config holds configuration for OpenTelemetry tracing
 type Config struct {
-	ServiceName    string  // Name of the service (e.g., "cargoship")
-	ServiceVersion string  // Version of the service (e.g., "v0.6.2")
+	ServiceName string // Name of the service (e.g., "cargoship")
+
+	// ServiceVersion labels every emitted span. Empty means "use the binary's
+	// own version" (#318) — a hardcoded literal here silently mislabels traces
+	// for every release after the one it was written in.
+	ServiceVersion string
 	ExporterType   string  // "stdout", "otlp", or "none"
 	Endpoint       string  // Collector endpoint for OTLP (e.g., "localhost:4317")
 	SampleRate     float64 // Sampling rate (0.0 to 1.0, default 1.0 = 100%)
@@ -32,6 +38,12 @@ func NewTracerProvider(ctx context.Context, cfg Config) (*sdktrace.TracerProvide
 	// Default sample rate to 100% if not specified
 	if cfg.SampleRate == 0 {
 		cfg.SampleRate = 1.0
+	}
+
+	// #318: fall back to the single version source rather than emitting an
+	// unlabeled service.version attribute.
+	if cfg.ServiceVersion == "" {
+		cfg.ServiceVersion = "v" + version.Version
 	}
 
 	// Create resource with service information

--- a/pkg/pipeline/archiver.go
+++ b/pkg/pipeline/archiver.go
@@ -55,6 +55,15 @@ func NewEncoderPool(size int, level compression.Level) (*EncoderPool, error) {
 }
 
 // convertToZstdLevel converts compression.Level to zstd.EncoderLevel (Issue #105)
+//
+// The four explicit cases are the content-aware tiers from #105 and are kept
+// verbatim: note that 9 maps to SpeedBestCompression, which is NOT what
+// zstd.EncoderLevelFromZstd(9) returns (it yields SpeedBetterCompression, since
+// its bands are <3 / 3-5 / 6-9 / 10+). Delegating all levels to the library
+// would silently weaken source-code compression, so only levels outside the
+// tier set — reachable via an explicit --compression-level override (#316) —
+// fall through to the library's banding. That is still lossy by nature: zstd
+// exposes just four discrete levels, so e.g. 12 and 22 behave identically.
 func convertToZstdLevel(level compression.Level) zstd.EncoderLevel {
 	switch level {
 	case 1: // LevelFastest - images, video, audio, archives
@@ -66,8 +75,18 @@ func convertToZstdLevel(level compression.Level) zstd.EncoderLevel {
 	case 9: // LevelBest - source code
 		return zstd.SpeedBestCompression
 	default:
-		return zstd.SpeedDefault // Fallback to level 3
+		return zstd.EncoderLevelFromZstd(int(level))
 	}
+}
+
+// EffectiveZstdTier names the zstd tier a numeric compression level actually
+// maps to ("fastest", "default", "better", "best").
+//
+// Callers use this to report the effective setting rather than echoing the
+// requested number: zstd has only four tiers, so accepting 1-22 and printing
+// the raw value back would overstate how much control the number carries.
+func EffectiveZstdTier(level int) string {
+	return convertToZstdLevel(compression.Level(level)).String()
 }
 
 // Get retrieves an encoder from the pool (blocks if none available)
@@ -132,6 +151,7 @@ type ArchiverStage struct {
 	outputs           map[string]chan<- *Job // nil = single-output mode (Phase 2)
 	shardCount        int                    // Number of shards (0 = single-output)
 	shardDistribution map[string]*int64      // map[shardName]jobCount for load balancing analysis
+	shardAssigner     *shardAssigner         // #316: implements --shard-strategy
 
 	// Phase 3.3: Archive padding for uniform compressed chunk sizes
 	padder *chunking.ArchivePadder // Archive padder for adding zero-byte padding
@@ -145,12 +165,24 @@ type ArchiverStage struct {
 	paddingBytesAdded    int64 // Total padding bytes added (Phase 3.3)
 }
 
-// createEncoderPools creates encoder pools for common compression levels (Issue #105)
-func createEncoderPools(poolSize int) (map[compression.Level]*EncoderPool, error) {
+// createEncoderPools creates encoder pools for the content-aware compression
+// levels (Issue #105), plus a pool for an explicit override level (#316).
+//
+// override is 0 when no --compression-level was given. A non-zero override
+// outside the {1,3,6,9} tier set gets its own pool so it is honored exactly;
+// without this it would hit the fallback path in Process and silently compress
+// at level 3 instead — the same accepted-but-ignored bug #316 exists to fix.
+func createEncoderPools(poolSize int, override compression.Level) (map[compression.Level]*EncoderPool, error) {
 	encoderPools := make(map[compression.Level]*EncoderPool)
 	levels := []compression.Level{1, 3, 6, 9} // LevelFastest, LevelFast, documents, LevelBest
+	if override != 0 {
+		levels = append(levels, override)
+	}
 
 	for _, level := range levels {
+		if _, exists := encoderPools[level]; exists {
+			continue // override coincides with a tier level
+		}
 		pool, err := NewEncoderPool(poolSize, level)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create encoder pool for level %d: %w", level, err)
@@ -169,7 +201,8 @@ func NewArchiverStage(config *ArchiverConfig, input <-chan *Job, output chan<- *
 
 	// Issue #105: Create multi-level encoder pools for content-aware compression
 	// Pool size = 2× workers to prevent blocking (8 workers × 2 = 16 encoders per level)
-	encoderPools, err := createEncoderPools(config.Workers * 2)
+	// #316: plus a pool for an explicit --compression-level override, if given.
+	encoderPools, err := createEncoderPools(config.Workers*2, compression.Level(config.CompressionLevel))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create encoder pools: %w", err)
 	}
@@ -191,10 +224,22 @@ func NewArchiverStage(config *ArchiverConfig, input <-chan *Job, output chan<- *
 	// Issue #105: Initialize content-aware compressor
 	contentAwareCompressor := compression.NewContentAwareCompressor(nil) // Uses default config
 
+	// #316: single-output mode still stamps a shard into each S3 key, so it
+	// needs an assigner too. ShardCount 0 means the historical 8-shard default.
+	keyShardCount := config.ShardCount
+	if keyShardCount == 0 {
+		keyShardCount = 8
+	}
+	assigner, err := newShardAssigner(config.ShardStrategy, keyShardCount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create shard assigner: %w", err)
+	}
+
 	return &ArchiverStage{
 		config:                 config,
 		input:                  input,
 		output:                 output,
+		shardAssigner:          assigner,
 		compressionDetector:    NewCompressionDetector(),
 		encoderPools:           encoderPools,
 		contentAwareCompressor: contentAwareCompressor,
@@ -222,7 +267,8 @@ func NewArchiverStageWithSharding(config *ArchiverConfig, input <-chan *Job, out
 
 	// Issue #105: Create multi-level encoder pools for content-aware compression
 	// Pool size = 2× workers to prevent blocking (8 workers × 2 = 16 encoders per level)
-	encoderPools, err := createEncoderPools(config.Workers * 2)
+	// #316: plus a pool for an explicit --compression-level override, if given.
+	encoderPools, err := createEncoderPools(config.Workers*2, compression.Level(config.CompressionLevel))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create encoder pools: %w", err)
 	}
@@ -240,6 +286,12 @@ func NewArchiverStageWithSharding(config *ArchiverConfig, input <-chan *Job, out
 		shardDist[shardName] = &count
 	}
 
+	// #316: build the chunk→shard assigner named by --shard-strategy.
+	assigner, err := newShardAssigner(config.ShardStrategy, shardCount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create shard assigner: %w", err)
+	}
+
 	// Phase 3.3: Initialize archive padder if enabled
 	var padder *chunking.ArchivePadder
 	if config.EnablePadding {
@@ -255,6 +307,7 @@ func NewArchiverStageWithSharding(config *ArchiverConfig, input <-chan *Job, out
 		outputs:                outputs,
 		shardCount:             shardCount,
 		shardDistribution:      shardDist,
+		shardAssigner:          assigner,
 		compressionDetector:    NewCompressionDetector(),
 		encoderPools:           encoderPools,
 		contentAwareCompressor: contentAwareCompressor,
@@ -280,8 +333,10 @@ func (s *ArchiverStage) selectOutput(job *Job) chan<- *Job {
 		return s.output
 	}
 
-	// Multi-output mode (Phase 3.2): shard by chunk ID using fast modulo
-	shardID := job.Chunk.ID % s.shardCount
+	// Multi-output mode (Phase 3.2): assign per --shard-strategy (#316).
+	// Before #316 this was always chunk.ID % shardCount; that behavior is now
+	// the round-robin strategy, which remains the default.
+	shardID := s.shardAssigner.assign(&job.Chunk)
 	shardName := fmt.Sprintf("shard-%d", shardID)
 
 	// Track shard distribution for load balancing analysis
@@ -461,10 +516,19 @@ func (s *ArchiverStage) Process(ctx context.Context, job *Job) error {
 	var encoderPool *EncoderPool
 	var compressionLevel compression.Level
 	if useCompression {
-		compressionLevel = s.analyzeChunkContentTypes(job.Chunk.Files)
+		// #316: an explicit --compression-level pins every chunk and skips
+		// content analysis; 0 keeps the automatic per-chunk behavior (#105).
+		if s.config.CompressionLevel != 0 {
+			compressionLevel = compression.Level(s.config.CompressionLevel)
+		} else {
+			compressionLevel = s.analyzeChunkContentTypes(job.Chunk.Files)
+		}
 
-		// Select encoder pool based on content-aware compression level
-		// Fallback to level 3 (default) if specific pool doesn't exist
+		// Select encoder pool based on the chosen compression level.
+		// createEncoderPools pre-builds the content-aware tiers plus the
+		// override level, so a miss here means an internal inconsistency
+		// rather than an unsupported user value; fall back to level 3 so
+		// archiving still succeeds.
 		pool, exists := s.encoderPools[compressionLevel]
 		if !exists {
 			compressionLevel = 3 // LevelDefault fallback
@@ -595,11 +659,12 @@ func (s *ArchiverStage) Process(ctx context.Context, job *Job) error {
 	// Generate S3 key with upload-ID/shard structure for multi-prefix optimization (Phase 3)
 	// Format: uploads/{upload-id}/shard-{shard_id}/chunk-{chunk_id}.tar.zst
 	// This distributes S3 request load across multiple prefixes (8× request rate capacity)
-	shardCount := s.config.ShardCount
-	if shardCount == 0 {
-		shardCount = 8 // Default: 8 shards
-	}
-	shardID := job.ID % shardCount
+	//
+	// #316: the shard is chosen here, once, by the --shard-strategy assigner, and
+	// then reused for the S3 key, job.ShardID, and selectOutput's channel pick.
+	// Previously the key used job.ID % shardCount while selectOutput separately
+	// computed job.Chunk.ID % shardCount, so the two could disagree.
+	shardID := s.shardAssigner.assign(&job.Chunk)
 	uploadID := s.config.UploadID
 	if uploadID == "" {
 		uploadID = "default" // Fallback for tests without upload ID

--- a/pkg/pipeline/archiver_test.go
+++ b/pkg/pipeline/archiver_test.go
@@ -267,7 +267,7 @@ func TestArchiverStage_AnalyzeChunkContentTypesWithMagika(t *testing.T) {
 // TestCreateEncoderPools tests multi-level encoder pool creation (Issue #105)
 func TestCreateEncoderPools(t *testing.T) {
 	poolSize := 4
-	pools, err := createEncoderPools(poolSize)
+	pools, err := createEncoderPools(poolSize, 0)
 	require.NoError(t, err)
 	require.NotNil(t, pools)
 
@@ -285,6 +285,39 @@ func TestCreateEncoderPools(t *testing.T) {
 	for _, pool := range pools {
 		_ = pool.Close()
 	}
+}
+
+// TestCreateEncoderPoolsWithOverride verifies an explicit --compression-level
+// outside the content-aware tier set gets its own pool (#316). Without this the
+// override would miss the map and Process would silently fall back to level 3 —
+// the accepted-but-ignored behavior #316 exists to remove.
+func TestCreateEncoderPoolsWithOverride(t *testing.T) {
+	t.Run("out-of-tier override gets a pool", func(t *testing.T) {
+		pools, err := createEncoderPools(2, 19)
+		require.NoError(t, err)
+		defer func() {
+			for _, pool := range pools {
+				_ = pool.Close()
+			}
+		}()
+
+		pool, exists := pools[19]
+		require.True(t, exists, "level 19 override must have its own pool, not fall back to 3")
+		assert.Equal(t, compression.Level(19), pool.level)
+		assert.Len(t, pools, 5, "4 content-aware tiers + 1 override")
+	})
+
+	t.Run("override coinciding with a tier does not duplicate", func(t *testing.T) {
+		pools, err := createEncoderPools(2, 9)
+		require.NoError(t, err)
+		defer func() {
+			for _, pool := range pools {
+				_ = pool.Close()
+			}
+		}()
+
+		assert.Len(t, pools, 4, "level 9 is already a tier; no extra pool")
+	})
 }
 
 // TestConvertToZstdLevel tests compression level conversion (Issue #105)
@@ -616,5 +649,190 @@ func TestArchiverStage_Process_NoTruncation(t *testing.T) {
 	require.Len(t, got, nFiles, "all files must be present in the archive")
 	for path, size := range want {
 		assert.Equal(t, size, got[path], "file %q should be full length", path)
+	}
+}
+
+// archiveOnce runs one chunk of source-code-like text through Process and
+// returns the compressed archive bytes plus the level the archiver recorded.
+func archiveOnce(t *testing.T, level int, files []chunking.File, totalSize int64) ([]byte, string) {
+	t.Helper()
+
+	config := &ArchiverConfig{Workers: 1, CompressionType: "zstd", CompressionLevel: level}
+	input := make(chan *Job, 1)
+	output := make(chan *Job, 1)
+	stage, err := NewArchiverStage(config, input, output)
+	require.NoError(t, err)
+	defer func() { _ = stage.Stop() }()
+
+	job := &Job{ID: 0, Chunk: chunking.Chunk{ID: 0, Files: files, TotalSize: totalSize}}
+	require.NoError(t, stage.Process(context.Background(), job))
+
+	out := <-output
+	require.NotNil(t, out.Archive)
+	raw, err := io.ReadAll(out.Archive)
+	require.NoError(t, err)
+	_ = out.Archive.Close()
+
+	return raw, out.Metadata["compression_level"]
+}
+
+// codeFiles writes compressible text files that content-aware detection
+// classifies as source code (level 9).
+func codeFiles(t *testing.T, n int) ([]chunking.File, int64) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Semi-repetitive text: compressible enough that level differences show up
+	// in output size, but not so uniform that every level produces the same
+	// tiny result.
+	var body []byte
+	for i := 0; i < 4000; i++ {
+		body = append(body, []byte(fmt.Sprintf("func handler%d(w http.ResponseWriter, r *http.Request) { log.Printf(\"%d\") }\n", i, i))...)
+	}
+
+	var files []chunking.File
+	var total int64
+	for i := 0; i < n; i++ {
+		path := fmt.Sprintf("%s/src%d.go", dir, i)
+		require.NoError(t, os.WriteFile(path, body, 0644))
+		files = append(files, chunking.File{Path: path, Size: int64(len(body))})
+		total += int64(len(body))
+	}
+	return files, total
+}
+
+// TestArchiverStage_CompressionLevelOverride is the behavioral test for #316:
+// --compression-level must change what the archiver actually does. Before the
+// fix ArchiverConfig.CompressionLevel was never read, so all three subtests
+// below produced byte-identical output at the content-aware level.
+func TestArchiverStage_CompressionLevelOverride(t *testing.T) {
+	files, total := codeFiles(t, 3)
+
+	fastest, fastestLevel := archiveOnce(t, 1, files, total)
+	best, bestLevel := archiveOnce(t, 9, files, total)
+
+	assert.Equal(t, "1", fastestLevel, "override must be recorded in job metadata")
+	assert.Equal(t, "9", bestLevel)
+	assert.NotEqual(t, fastest, best,
+		"level 1 and level 9 must produce different compressed output")
+	assert.Less(t, len(best), len(fastest),
+		"level 9 must compress source code better than level 1")
+}
+
+// TestArchiverStage_CompressionLevelOutOfPoolOverride covers the trap inside the
+// fix: levels outside the pre-built {1,3,6,9} pools used to fall through to
+// level 3, which would have silently recreated the no-op bug for exactly the
+// values users reach for (--compression-level 19 for cold archival).
+func TestArchiverStage_CompressionLevelOutOfPoolOverride(t *testing.T) {
+	files, total := codeFiles(t, 2)
+
+	_, level19 := archiveOnce(t, 19, files, total)
+	assert.Equal(t, "19", level19,
+		"an out-of-pool override must be honored, not silently downgraded to 3")
+
+	// 19 and 3 land in different zstd tiers, so the bytes must differ too.
+	out19, _ := archiveOnce(t, 19, files, total)
+	out3, _ := archiveOnce(t, 3, files, total)
+	assert.NotEqual(t, out3, out19,
+		"level 19 must not compress identically to the level-3 fallback")
+}
+
+// TestArchiverStage_CompressionLevelAutomaticByDefault guards the other
+// direction: the override must not become a regression that flattens
+// content-aware selection (#105/#30) for users who never pass the flag.
+func TestArchiverStage_CompressionLevelAutomaticByDefault(t *testing.T) {
+	dir := t.TempDir()
+
+	codeBody := []byte("package main\nfunc main() { println(\"hello\") }\n")
+	codePath := dir + "/main.go"
+	require.NoError(t, os.WriteFile(codePath, codeBody, 0644))
+
+	// A .jpg is detected as an image: content-aware picks level 1 for it and
+	// level 9 for source code, so with CompressionLevel 0 the two chunks must
+	// record different levels.
+	imgBody := make([]byte, len(codeBody))
+	imgPath := dir + "/photo.jpg"
+	require.NoError(t, os.WriteFile(imgPath, imgBody, 0644))
+
+	_, codeLevel := archiveOnce(t, 0,
+		[]chunking.File{{Path: codePath, Size: int64(len(codeBody))}}, int64(len(codeBody)))
+	_, imgLevel := archiveOnce(t, 0,
+		[]chunking.File{{Path: imgPath, Size: int64(len(imgBody))}}, int64(len(imgBody)))
+
+	assert.NotEqual(t, codeLevel, imgLevel,
+		"with no override, level must still vary by chunk content (#105)")
+	assert.Equal(t, "9", codeLevel, "source code should still select level 9")
+}
+
+// TestEffectiveZstdTier documents that the advertised 1-22 range collapses onto
+// four zstd tiers, which is why the CLI reports the effective tier rather than
+// echoing the number back.
+func TestEffectiveZstdTier(t *testing.T) {
+	tests := map[int]string{
+		1:  "fastest",
+		2:  "fastest",
+		3:  "default",
+		5:  "default",
+		6:  "better",
+		9:  "best", // #105 tier mapping, not zstd's own banding
+		12: "best",
+		19: "best",
+		22: "best",
+	}
+	for level, want := range tests {
+		assert.Equal(t, want, EffectiveZstdTier(level), "level %d", level)
+	}
+}
+
+// TestArchiverStage_ShardStrategyAffectsS3Key ties the strategy to the observable
+// output: the shard appears in the S3 key and in job.ShardID, and the manifest
+// records ShardID so restore never recomputes assignment.
+func TestArchiverStage_ShardStrategyAffectsS3Key(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/a.txt"
+	require.NoError(t, os.WriteFile(path, []byte("hello"), 0644))
+	files := []chunking.File{{Path: path, Size: 5}}
+
+	run := func(strategy string, chunkID int) (int, string) {
+		config := &ArchiverConfig{
+			Workers: 1, CompressionType: "zstd",
+			ShardCount: 8, ShardStrategy: strategy, UploadID: "test",
+		}
+		input := make(chan *Job, 1)
+		output := make(chan *Job, 1)
+		stage, err := NewArchiverStage(config, input, output)
+		require.NoError(t, err)
+		defer func() { _ = stage.Stop() }()
+
+		job := &Job{ID: chunkID, Chunk: chunking.Chunk{ID: chunkID, Files: files, TotalSize: 5}}
+		require.NoError(t, stage.Process(context.Background(), job))
+		out := <-output
+		_, _ = io.Copy(io.Discard, out.Archive)
+		_ = out.Archive.Close()
+		return out.ShardID, out.S3Key
+	}
+
+	// Round-robin is the historical behavior: the chunk ID picks the shard.
+	for _, id := range []int{0, 1, 2, 3} {
+		shard, key := run(ShardStrategyRoundRobin, id)
+		assert.Equal(t, id, shard, "round-robin: chunk %d of 8 shards → shard %d", id, id)
+		assert.Contains(t, key, fmt.Sprintf("shard-%d/", id),
+			"S3 key and ShardID must agree — they were computed separately before #316")
+	}
+
+	// Hash assigns by content, so four different chunk IDs holding identical
+	// files must all land on ONE shard. Before #316 every strategy resolved to
+	// chunkID %% shardCount, which spreads these across shards 0-3 — so this
+	// assertion is what distinguishes a real hash from the round-robin alias.
+	var hashShards []int
+	for _, id := range []int{0, 1, 2, 3} {
+		shard, key := run(ShardStrategyHash, id)
+		assert.Contains(t, key, fmt.Sprintf("shard-%d/", shard),
+			"S3 key must carry the shard the assigner chose")
+		hashShards = append(hashShards, shard)
+	}
+	for _, got := range hashShards[1:] {
+		assert.Equal(t, hashShards[0], got,
+			"identical content must hash to one shard regardless of chunk ID; got %v", hashShards)
 	}
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -495,6 +495,10 @@ func (p *Pipeline) startStages(ctx context.Context, rootPath string) error {
 		BufferSize:      64 * 1024, // 64KB
 		UploadID:        p.config.UploadID,
 		ShardCount:      p.config.ShardCount,
+		// #316: honor --compression-level and --shard-strategy. Both were
+		// accepted by the CLI and dropped here before this was wired.
+		CompressionLevel: p.config.CompressionLevel,
+		ShardStrategy:    p.config.ShardStrategy,
 		// Phase 3.3: Archive padding configuration
 		EnablePadding:        p.config.EnableArchivePadding,
 		MaxPaddingRatio:      p.config.MaxPaddingRatio,

--- a/pkg/pipeline/shard_strategy.go
+++ b/pkg/pipeline/shard_strategy.go
@@ -1,0 +1,225 @@
+package pipeline
+
+import (
+	"fmt"
+	"hash/fnv"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/scttfrdmn/cargoship/pkg/chunking"
+	"github.com/scttfrdmn/cargoship/pkg/compression"
+)
+
+// Shard assignment strategies (#316).
+//
+// These name the ways the archiver can map a chunk onto one of the S3 prefix
+// shards it writes to. Before #316 the CLI accepted --shard-strategy and threw
+// the value away: every upload used ShardStrategyRoundRobin regardless, while
+// the flag's own default advertised "hash".
+const (
+	// ShardStrategyRoundRobin distributes by chunk ID. Even shard sizes when
+	// chunks are uniform, and the cheapest option. This is what CargoShip has
+	// always done, and remains the default.
+	ShardStrategyRoundRobin = "round-robin"
+
+	// ShardStrategyHash distributes by a hash of the chunk's file paths.
+	// Assignment is a pure function of chunk content, so the same input tree
+	// lands the same way across runs regardless of scan or completion order.
+	ShardStrategyHash = "hash"
+
+	// ShardStrategySize sends each chunk to whichever shard currently holds
+	// the fewest bytes, evening out shards when chunk sizes vary widely.
+	ShardStrategySize = "size"
+
+	// ShardStrategyType groups chunks by predominant content type, so a shard
+	// tends to hold like-compressing data.
+	ShardStrategyType = "type"
+
+	// ShardStrategyDirectory groups chunks by their common directory prefix,
+	// keeping a source subtree together within a shard.
+	ShardStrategyDirectory = "directory"
+)
+
+// ShardStrategies lists every valid --shard-strategy value, in help-text order.
+func ShardStrategies() []string {
+	return []string{
+		ShardStrategyRoundRobin,
+		ShardStrategyHash,
+		ShardStrategySize,
+		ShardStrategyType,
+		ShardStrategyDirectory,
+	}
+}
+
+// ValidateShardStrategy reports whether name is a known strategy. An empty
+// name is valid and means the default (round-robin).
+func ValidateShardStrategy(name string) error {
+	if name == "" {
+		return nil
+	}
+	for _, s := range ShardStrategies() {
+		if name == s {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown shard strategy %q (valid: %s)", name, strings.Join(ShardStrategies(), ", "))
+}
+
+// shardAssigner maps chunks onto shard indices in [0, shardCount).
+//
+// Assignment only decides which S3 prefix a chunk is uploaded under. It does
+// not affect restore: the manifest records each chunk's ShardID, and restore
+// reads that rather than recomputing an assignment. Changing strategy can
+// therefore never make an existing archive unreadable.
+type shardAssigner struct {
+	strategy   string
+	shardCount int
+
+	// mu guards shardBytes, which the size strategy both reads and writes.
+	// Selection happens on every archiver worker goroutine, so least-loaded
+	// needs the read and the update to be one atomic step.
+	mu         sync.Mutex
+	shardBytes []int64
+}
+
+// newShardAssigner builds an assigner for the given strategy. An empty
+// strategy means round-robin. shardCount must be positive.
+func newShardAssigner(strategy string, shardCount int) (*shardAssigner, error) {
+	if shardCount <= 0 {
+		return nil, fmt.Errorf("shard count must be positive, got %d", shardCount)
+	}
+	if strategy == "" {
+		strategy = ShardStrategyRoundRobin
+	}
+	if err := ValidateShardStrategy(strategy); err != nil {
+		return nil, err
+	}
+	return &shardAssigner{
+		strategy:   strategy,
+		shardCount: shardCount,
+		shardBytes: make([]int64, shardCount),
+	}, nil
+}
+
+// assign returns the shard index for a chunk.
+func (a *shardAssigner) assign(chunk *chunking.Chunk) int {
+	switch a.strategy {
+	case ShardStrategyHash:
+		return a.modulo(hashFileIdentity(chunk.Files))
+	case ShardStrategySize:
+		return a.leastLoaded(chunk.TotalSize)
+	case ShardStrategyType:
+		return a.modulo(hashString(string(predominantContentType(chunk.Files))))
+	case ShardStrategyDirectory:
+		return a.modulo(hashString(commonDirPrefix(chunk.Files)))
+	default: // ShardStrategyRoundRobin
+		// chunk.ID can be negative only if a caller hand-builds a Chunk;
+		// modulo normalizes rather than panicking on a negative index.
+		return a.modulo(uint64(uint32(chunk.ID)))
+	}
+}
+
+// modulo reduces a hash to a shard index.
+func (a *shardAssigner) modulo(h uint64) int {
+	return int(h % uint64(a.shardCount))
+}
+
+// leastLoaded returns the shard holding the fewest bytes and charges size to
+// it. Ties go to the lowest index, so an all-equal start behaves like
+// round-robin.
+//
+// Unlike the hash strategies this is order-dependent: which shard a given
+// chunk lands on depends on what has already been assigned. That is inherent
+// to load balancing, and harmless because the manifest records the resulting
+// ShardID per chunk.
+func (a *shardAssigner) leastLoaded(size int64) int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	best := 0
+	for i := 1; i < a.shardCount; i++ {
+		if a.shardBytes[i] < a.shardBytes[best] {
+			best = i
+		}
+	}
+	a.shardBytes[best] += size
+	return best
+}
+
+// hashFileIdentity hashes a chunk's file paths and sizes, sorted so the result
+// does not depend on the order the scanner produced them in.
+func hashFileIdentity(files []chunking.File) uint64 {
+	if len(files) == 0 {
+		return 0
+	}
+	keys := make([]string, 0, len(files))
+	for _, f := range files {
+		keys = append(keys, fmt.Sprintf("%s:%d", f.Path, f.Size))
+	}
+	sort.Strings(keys)
+
+	h := fnv.New64a()
+	for _, k := range keys {
+		_, _ = h.Write([]byte(k))
+		_, _ = h.Write([]byte{0}) // separator: "ab"+"c" must not collide with "a"+"bc"
+	}
+	return h.Sum64()
+}
+
+// hashString hashes a grouping key with FNV-1a.
+func hashString(s string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum64()
+}
+
+// predominantContentType returns the content type accounting for the most
+// bytes in a chunk, using Magika metadata when present (#30) and falling back
+// to extension-based detection. This mirrors analyzeChunkContentTypes, which
+// answers the same question for compression level.
+func predominantContentType(files []chunking.File) compression.ContentType {
+	sizes := make(map[compression.ContentType]int64, len(files))
+	for _, f := range files {
+		sizes[compression.DetectContentTypeWithMetadata(f.Path, f.Metadata)] += f.Size
+	}
+
+	var predominant compression.ContentType
+	var maxSize int64 = -1
+	for ct, size := range sizes {
+		// Break ties by name so map iteration order can't change the result.
+		if size > maxSize || (size == maxSize && ct < predominant) {
+			maxSize = size
+			predominant = ct
+		}
+	}
+	return predominant
+}
+
+// commonDirPrefix returns the longest directory prefix shared by every file in
+// a chunk, or "" when they share nothing. Comparison is per path segment:
+// "/a/bc" and "/a/bd" share "/a", not "/a/b".
+func commonDirPrefix(files []chunking.File) string {
+	if len(files) == 0 {
+		return ""
+	}
+
+	prefix := strings.Split(filepath.ToSlash(filepath.Dir(files[0].Path)), "/")
+	for _, f := range files[1:] {
+		segs := strings.Split(filepath.ToSlash(filepath.Dir(f.Path)), "/")
+		if len(segs) < len(prefix) {
+			prefix = prefix[:len(segs)]
+		}
+		for i := range prefix {
+			if prefix[i] != segs[i] {
+				prefix = prefix[:i]
+				break
+			}
+		}
+		if len(prefix) == 0 {
+			return ""
+		}
+	}
+	return strings.Join(prefix, "/")
+}

--- a/pkg/pipeline/shard_strategy_test.go
+++ b/pkg/pipeline/shard_strategy_test.go
@@ -1,0 +1,280 @@
+package pipeline
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/cargoship/pkg/chunking"
+	"github.com/scttfrdmn/cargoship/pkg/config"
+)
+
+// TestShardStrategiesMatchConfig pins the two lists together. pkg/config can't
+// import pkg/pipeline (the dependency runs the other way), so the accepted set
+// is duplicated there; this is what keeps the copy honest. Before #316 the
+// config copy omitted "round-robin" — the flag's real default — so a config file
+// naming it was rejected by `cargoship config --validate`.
+func TestShardStrategiesMatchConfig(t *testing.T) {
+	assert.Equal(t, ShardStrategies(), config.ValidShardStrategies(),
+		"pkg/config's shard-strategy list has drifted from pkg/pipeline's")
+
+	for _, s := range config.ValidShardStrategies() {
+		assert.NoError(t, ValidateShardStrategy(s),
+			"config accepts %q but the pipeline rejects it", s)
+	}
+}
+
+// These tests are deliberately behavioral: each one distinguishes strategies by
+// the assignments they produce, so they fail against the pre-#316 code where
+// every strategy resolved to chunkID % shardCount. Presence/default assertions
+// (the shape of the old cmd tests) passed while the flags did nothing, which is
+// how this shipped in the first place.
+
+func chunk(id int, totalSize int64, paths ...string) *chunking.Chunk {
+	files := make([]chunking.File, 0, len(paths))
+	// Spread totalSize evenly so per-file sizes stay consistent with TotalSize.
+	var per int64
+	if len(paths) > 0 {
+		per = totalSize / int64(len(paths))
+	}
+	for _, p := range paths {
+		files = append(files, chunking.File{Path: p, Size: per})
+	}
+	return &chunking.Chunk{ID: id, Files: files, TotalSize: totalSize, FileCount: len(files)}
+}
+
+func TestNewShardAssigner(t *testing.T) {
+	t.Run("empty strategy defaults to round-robin", func(t *testing.T) {
+		a, err := newShardAssigner("", 4)
+		require.NoError(t, err)
+		assert.Equal(t, ShardStrategyRoundRobin, a.strategy)
+	})
+
+	t.Run("rejects unknown strategy", func(t *testing.T) {
+		_, err := newShardAssigner("magic", 4)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown shard strategy")
+	})
+
+	t.Run("rejects non-positive shard count", func(t *testing.T) {
+		_, err := newShardAssigner(ShardStrategyHash, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("accepts every advertised strategy", func(t *testing.T) {
+		for _, s := range ShardStrategies() {
+			_, err := newShardAssigner(s, 4)
+			assert.NoError(t, err, "strategy %q is advertised in --help but rejected", s)
+		}
+	})
+}
+
+func TestValidateShardStrategy(t *testing.T) {
+	assert.NoError(t, ValidateShardStrategy(""), "empty means default")
+	for _, s := range ShardStrategies() {
+		assert.NoError(t, ValidateShardStrategy(s))
+	}
+	err := ValidateShardStrategy("nope")
+	require.Error(t, err)
+	// The message must list the alternatives; a bare "invalid" is what sent
+	// users to the docs to find a strategy list that was itself wrong.
+	assert.Contains(t, err.Error(), ShardStrategyRoundRobin)
+	assert.Contains(t, err.Error(), ShardStrategyDirectory)
+}
+
+// TestShardAssignerRoundRobin pins the historical behavior so a future strategy
+// change can't silently redistribute existing users' uploads.
+func TestShardAssignerRoundRobin(t *testing.T) {
+	a, err := newShardAssigner(ShardStrategyRoundRobin, 4)
+	require.NoError(t, err)
+
+	for id := 0; id < 12; id++ {
+		assert.Equal(t, id%4, a.assign(chunk(id, 100, "a.txt")),
+			"round-robin must remain chunkID %% shardCount")
+	}
+}
+
+// TestShardAssignerHashDiffersFromRoundRobin is the core regression test: the
+// flag's advertised default was "hash" while the implementation was round-robin.
+// If hash ever collapses back to chunkID %% shardCount, this fails.
+func TestShardAssignerHashDiffersFromRoundRobin(t *testing.T) {
+	const shards = 8
+	hash, err := newShardAssigner(ShardStrategyHash, shards)
+	require.NoError(t, err)
+	rr, err := newShardAssigner(ShardStrategyRoundRobin, shards)
+	require.NoError(t, err)
+
+	// Same chunk IDs, distinct contents.
+	differences := 0
+	for id := 0; id < 32; id++ {
+		c := chunk(id, 1000, fmt.Sprintf("dir/file-%d.txt", id))
+		if hash.assign(c) != rr.assign(c) {
+			differences++
+		}
+	}
+	assert.Greater(t, differences, 0,
+		"hash must not be an alias for round-robin — that mismatch is #316")
+}
+
+func TestShardAssignerHashIsContentStable(t *testing.T) {
+	const shards = 8
+
+	t.Run("same content, different chunk ID, same shard", func(t *testing.T) {
+		a, err := newShardAssigner(ShardStrategyHash, shards)
+		require.NoError(t, err)
+		first := a.assign(chunk(1, 500, "x/a.txt", "x/b.txt"))
+		second := a.assign(chunk(99, 500, "x/a.txt", "x/b.txt"))
+		assert.Equal(t, first, second, "hash must depend on content, not chunk ID")
+	})
+
+	t.Run("file order does not change the shard", func(t *testing.T) {
+		a, err := newShardAssigner(ShardStrategyHash, shards)
+		require.NoError(t, err)
+		forward := a.assign(chunk(1, 600, "a.txt", "b.txt", "c.txt"))
+		reverse := a.assign(chunk(1, 600, "c.txt", "b.txt", "a.txt"))
+		assert.Equal(t, forward, reverse,
+			"scan order must not affect assignment, or two runs of the same upload diverge")
+	})
+
+	t.Run("empty chunk is handled", func(t *testing.T) {
+		a, err := newShardAssigner(ShardStrategyHash, shards)
+		require.NoError(t, err)
+		assert.Equal(t, 0, a.assign(chunk(0, 0)))
+	})
+}
+
+// TestShardAssignerSizeBalances uses a deliberately uneven workload: one large
+// chunk followed by many small ones. Round-robin spreads by count and leaves the
+// large chunk's shard heaviest; size-based must even out the bytes.
+func TestShardAssignerSizeBalances(t *testing.T) {
+	const shards = 4
+	sizes := []int64{1000, 10, 10, 10, 10, 10, 10, 10}
+
+	size, err := newShardAssigner(ShardStrategySize, shards)
+	require.NoError(t, err)
+	rr, err := newShardAssigner(ShardStrategyRoundRobin, shards)
+	require.NoError(t, err)
+
+	sizeLoad := make([]int64, shards)
+	rrLoad := make([]int64, shards)
+	for id, s := range sizes {
+		c := chunk(id, s, fmt.Sprintf("f%d.bin", id))
+		sizeLoad[size.assign(c)] += s
+		rrLoad[rr.assign(c)] += s
+	}
+
+	assert.Equal(t, sizeLoad, size.shardBytes, "internal accounting must match observed load")
+
+	spread := func(load []int64) int64 {
+		min, max := load[0], load[0]
+		for _, v := range load[1:] {
+			if v < min {
+				min = v
+			}
+			if v > max {
+				max = v
+			}
+		}
+		return max - min
+	}
+	// Size-based can't beat a single dominant chunk, but it must put every
+	// small chunk on the other shards rather than continuing to round-robin
+	// onto the heavy one.
+	assert.Less(t, spread(sizeLoad), spread(rrLoad),
+		"least-loaded must produce a tighter byte spread than round-robin")
+	assert.Equal(t, int64(0), sizeLoad[0]-1000,
+		"the 1000-byte chunk lands alone on shard 0, and nothing else joins it")
+}
+
+func TestShardAssignerSizeTiesGoLowest(t *testing.T) {
+	a, err := newShardAssigner(ShardStrategySize, 3)
+	require.NoError(t, err)
+	// All shards start empty, so equal chunks behave like round-robin.
+	assert.Equal(t, 0, a.assign(chunk(0, 10, "a")))
+	assert.Equal(t, 1, a.assign(chunk(1, 10, "b")))
+	assert.Equal(t, 2, a.assign(chunk(2, 10, "c")))
+	assert.Equal(t, 0, a.assign(chunk(3, 10, "d")))
+}
+
+// TestShardAssignerTypeGroups checks that chunks sharing a predominant content
+// type co-locate, and that a different type can land elsewhere.
+func TestShardAssignerTypeGroups(t *testing.T) {
+	a, err := newShardAssigner(ShardStrategyType, 8)
+	require.NoError(t, err)
+
+	goA := a.assign(chunk(0, 100, "src/one.go"))
+	goB := a.assign(chunk(7, 100, "other/two.go"))
+	assert.Equal(t, goA, goB, "same predominant content type must share a shard")
+
+	// Predominance is by bytes, so a chunk whose bulk is Go code groups with
+	// Go even when it contains a stray file of another type.
+	mixed := &chunking.Chunk{
+		ID: 3,
+		Files: []chunking.File{
+			{Path: "src/big.go", Size: 10_000},
+			{Path: "img/tiny.jpg", Size: 10},
+		},
+		TotalSize: 10_010,
+	}
+	assert.Equal(t, goA, a.assign(mixed), "predominance must be weighted by size")
+}
+
+func TestShardAssignerDirectoryGroups(t *testing.T) {
+	a, err := newShardAssigner(ShardStrategyDirectory, 8)
+	require.NoError(t, err)
+
+	first := a.assign(chunk(0, 100, "/data/project-a/x.bin", "/data/project-a/y.bin"))
+	second := a.assign(chunk(5, 100, "/data/project-a/z.bin"))
+	assert.Equal(t, first, second, "chunks under one directory must share a shard")
+}
+
+func TestCommonDirPrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{"single file", []string{"/a/b/c.txt"}, "/a/b"},
+		{"same dir", []string{"/a/b/c.txt", "/a/b/d.txt"}, "/a/b"},
+		{"diverging subdirs", []string{"/a/b/c.txt", "/a/e/f.txt"}, "/a"},
+		{
+			// Segment-wise comparison: "bc" and "bd" share no segment, so the
+			// answer is "/a" and not the string prefix "/a/b".
+			"similar sibling names are not a shared prefix",
+			[]string{"/a/bc/x.txt", "/a/bd/y.txt"},
+			"/a",
+		},
+		{"nested under shared root", []string{"/a/b/c.txt", "/a/b/d/e.txt"}, "/a/b"},
+		{"no shared root", []string{"/x/1.txt", "/y/2.txt"}, ""},
+		{"empty", nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := make([]chunking.File, 0, len(tt.paths))
+			for _, p := range tt.paths {
+				files = append(files, chunking.File{Path: p, Size: 1})
+			}
+			assert.Equal(t, tt.want, commonDirPrefix(files))
+		})
+	}
+}
+
+// TestShardAssignerStaysInRange guards the modulo arithmetic for every strategy,
+// including a negative chunk ID (which would panic an unguarded array index).
+func TestShardAssignerStaysInRange(t *testing.T) {
+	for _, strategy := range ShardStrategies() {
+		for _, shards := range []int{1, 3, 8, 32} {
+			a, err := newShardAssigner(strategy, shards)
+			require.NoError(t, err)
+
+			for _, id := range []int{-7, -1, 0, 1, 5, 1 << 20} {
+				got := a.assign(chunk(id, 128, fmt.Sprintf("p/%d.dat", id)))
+				assert.GreaterOrEqual(t, got, 0, "%s/%d shards, id %d", strategy, shards, id)
+				assert.Less(t, got, shards, "%s/%d shards, id %d", strategy, shards, id)
+			}
+		}
+	}
+}

--- a/pkg/pipeline/shard_strategy_test.go
+++ b/pkg/pipeline/shard_strategy_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/scttfrdmn/cargoship/pkg/chunking"
 	"github.com/scttfrdmn/cargoship/pkg/config"
+	"github.com/scttfrdmn/cargoship/pkg/manifest"
 )
 
 // TestShardStrategiesMatchConfig pins the two lists together. pkg/config can't
@@ -277,4 +278,54 @@ func TestShardAssignerStaysInRange(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestShardStrategyDoesNotAffectRestore pins the invariant that makes changing
+// the shard strategy safe for existing archives: readers take each chunk's shard
+// and key from the manifest, and nothing recomputes assignment from the chunk ID.
+//
+// This matters because the strategy is an upload-time choice that is NOT recorded
+// in the manifest. If any reader recomputed `chunk.ID % shard_count`, it would
+// address the wrong S3 object for every archive written with a non-default
+// strategy — turning a tuning flag into a data-loss bug.
+func TestShardStrategyDoesNotAffectRestore(t *testing.T) {
+	const shards = 8
+	files := []chunking.File{{Path: "/data/a.bin", Size: 100}}
+
+	// Two strategies that disagree about where chunk 3 belongs.
+	rr, err := newShardAssigner(ShardStrategyRoundRobin, shards)
+	require.NoError(t, err)
+	dir, err := newShardAssigner(ShardStrategyDirectory, shards)
+	require.NoError(t, err)
+
+	c := &chunking.Chunk{ID: 3, Files: files, TotalSize: 100}
+	rrShard := rr.assign(c)
+	dirShard := dir.assign(c)
+
+	// Whatever each strategy chose, the recorded shard is what a reader uses.
+	// Simulate the two manifests a reader could be handed.
+	for name, shard := range map[string]int{"round-robin": rrShard, "directory": dirShard} {
+		t.Run(name, func(t *testing.T) {
+			recorded := manifest.ChunkEntry{
+				ID:      3,
+				ShardID: shard,
+				S3Key:   fmt.Sprintf("uploads/u1/shard-%d/chunk-3.tar.zst", shard),
+			}
+			// A reader must resolve to the recorded key, not one derived from the
+			// chunk ID. With round-robin, chunk 3 → shard 3; if the recorded shard
+			// differs, deriving it would produce a key for an object that does not
+			// exist.
+			assert.Equal(t,
+				fmt.Sprintf("uploads/u1/shard-%d/chunk-3.tar.zst", recorded.ShardID),
+				manifest.ResolveObjectKey("", "bucket", recorded.S3Key),
+				"restore must follow the manifest's recorded shard")
+			assert.Contains(t, recorded.S3Key, fmt.Sprintf("shard-%d/", recorded.ShardID),
+				"the recorded key and recorded ShardID must agree")
+		})
+	}
+
+	// And the guard that gives the above its teeth: the strategies really do
+	// disagree here, so a reader that recomputed would be wrong for one of them.
+	assert.NotEqual(t, rrShard, dirShard,
+		"fixture must be one where the strategies disagree, or this test proves nothing")
 }

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -225,7 +225,12 @@ type PipelineConfig struct {
 
 	// #316: ShardStrategy chooses how the archiver assigns chunks to S3 prefix
 	// shards: "round-robin", "hash", "size", "type", or "directory".
-	// Empty means "round-robin". Only meaningful with EnableArchiverSharding.
+	// Empty means "round-robin".
+	//
+	// This applies in every mode, not just EnableArchiverSharding: the archiver
+	// bakes the chosen shard into each chunk's S3 key, and the router only
+	// re-reads it from there. With EnableArchiverSharding it additionally picks
+	// the output channel.
 	ShardStrategy string
 
 	// Phase 3.3: Compressed-aware chunking with adaptive sizing and padding

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -218,6 +218,16 @@ type PipelineConfig struct {
 	// Phase 3.2: Archiver-level sharding (eliminates router bottleneck)
 	EnableArchiverSharding bool // If true, archiver shards directly to per-prefix channels (no router)
 
+	// #316: CompressionLevel is an explicit override of content-aware compression.
+	// 0 (the default) keeps per-chunk automatic selection (#105/#30); any other
+	// value pins every chunk to that level and skips content analysis entirely.
+	CompressionLevel int
+
+	// #316: ShardStrategy chooses how the archiver assigns chunks to S3 prefix
+	// shards: "round-robin", "hash", "size", "type", or "directory".
+	// Empty means "round-robin". Only meaningful with EnableArchiverSharding.
+	ShardStrategy string
+
 	// Phase 3.3: Compressed-aware chunking with adaptive sizing and padding
 	EnableCompressedAwareChunking bool    // Enable compression-aware chunking (default: true)
 	EnableArchivePadding          bool    // Enable padding to reach target sizes (default: true)
@@ -377,14 +387,26 @@ type ScannerConfig struct {
 
 // ArchiverConfig configures the archiver stage
 type ArchiverConfig struct {
-	Workers          int
+	Workers int
+
+	// CompressionLevel overrides content-aware per-chunk compression (#316).
+	// 0 means automatic: analyze each chunk's predominant content type and pick
+	// a level from it (#105/#30). Any other value pins every chunk to that
+	// level and skips the analysis. Note that Go's zstd exposes only four
+	// discrete levels, so many int values collapse onto the same behavior —
+	// see EffectiveCompressionLevel.
 	CompressionLevel int
-	CompressionType  string // "gzip", "zstd", "bzip2"
-	BufferSize       int
+
+	CompressionType string // "gzip", "zstd", "bzip2"
+	BufferSize      int
 
 	// Multi-prefix optimization (Phase 3)
 	UploadID   string // Unique identifier for this upload session (format: {timestamp}-{random})
 	ShardCount int    // Number of S3 prefix shards for parallel uploads (default: 8)
+
+	// ShardStrategy selects the chunk→shard assignment function (#316).
+	// One of "round-robin" (default), "hash", "size", "type", "directory".
+	ShardStrategy string
 
 	// Phase 3.3: Archive padding for uniform compressed chunk sizes
 	EnablePadding        bool    // Enable zero-byte padding to reach target compressed sizes

--- a/scripts/test-quality-check.sh
+++ b/scripts/test-quality-check.sh
@@ -73,11 +73,20 @@ check_test_categories() {
         fi
     fi
     
-    # Files with LocalStack or external service dependencies should have integration tags
-    if grep -q "LocalStack\|localstack\|4566\|docker" "$file"; then
-        if ! head -5 "$file" | grep -q "//go:build integration"; then
-            log_warning "$file: Integration test missing '//go:build integration' tag"
-            issues=$((issues + 1))
+    # Tests that depend on the S3 emulator should be excluded from the default
+    # build. Previously this grepped for LocalStack/port 4566/docker — none of
+    # which any test has mentioned since integration tests moved to the
+    # in-process Substrate emulator, so the check could never fire.
+    #
+    # integration/e2e/benchmark tags all exclude a file from the default build. A
+    # runtime t.Skip() on an opt-in env var also counts: real-AWS tests are
+    # required to self-skip rather than hide behind a tag.
+    if grep -q "emulator\." "$file"; then
+        if ! head -5 "$file" | grep -qE "//go:build (integration|e2e|benchmark)"; then
+            if ! grep -q "t\.Skip" "$file"; then
+                log_warning "$file: Integration test needs a build tag (integration/e2e/benchmark) or a runtime t.Skip() guard"
+                issues=$((issues + 1))
+            fi
         fi
     fi
     

--- a/scripts/validate-setup.sh
+++ b/scripts/validate-setup.sh
@@ -191,7 +191,7 @@ check_network() {
     log_info "Checking network connectivity..."
     
     if ! ping -c 1 8.8.8.8 &> /dev/null; then
-        log_warning "No internet connectivity - LocalStack only mode"
+        log_warning "No internet connectivity - offline mode (emulator-backed tests only; real-AWS tests will skip)"
         return 0
     fi
     


### PR DESCRIPTION
## Why

An external review flagged this as the project's most important public-quality
problem, and the scope turned out wider than reported: `upload` accepted **five**
flags with no behavioral effect (`sync` two). `cmd/cargoship/cmd/upload.go` said
so outright:

```go
// Note: Compression level and shard strategy are not yet implemented in the pipeline
```

A rejected flag is an inconvenience. An accepted flag that silently does nothing
means a user who ran `--compression-level 19` for cold archival believes they got
it and did not — and the published guides actively teach these flags, so
following the documentation produced silent non-compliance.

## Root cause: a fourth abandoned duplicate

`NewShardCoordinator` → `NewShardPipeline` → `NewShardProgressRenderer` has **no
production caller** (verified with `deadcode`). That subsystem is the *only* code
that honored `CompressionLevel`, and `ShardProgressRenderer` is exactly the
per-shard progress + pause/resume that `--interactive` advertises.

This is the same duplicate-drift mechanism as #308 and #311: a second copy stops
being called, stops being reviewed, and silently misses everything the live copy
gets. It stayed invisible because `pkg/pipeline` was outside the dead-code
audit's filter. **This PR adds it.**

## What changed

| Flag | Before | After |
|---|---|---|
| `--compression-level` | dropped | explicit override; out-of-tier levels honored |
| `--shard-strategy` | dropped; defaulted to `hash` while behaving as round-robin | all values implemented; default corrected to `round-robin` |
| `--direct-upload-threshold-mb` | never read | read |
| `--direct-upload-workers` | never read | read |
| `--interactive` | accepted, inert | hidden (see #325) |

Three decisions worth calling out:

1. **The compression-level default is deliberately not forwarded.** The flag
   defaults to 3, so naively passing it through would have pinned every chunk to
   level 3 and switched content-aware compression *off* for everyone who never
   touched the flag. `cmd.Flags().Changed()` distinguishes an explicit `3` from
   an absent flag; `TestArchiverStage_CompressionLevelAutomaticByDefault` guards
   it.
2. **Out-of-tier levels get their own encoder pool.** The pre-existing
   `!exists → level 3` fallback would have silently downgraded
   `--compression-level 19` — exactly the value a cold-archival user reaches for,
   and exactly the bug this PR exists to fix.
3. **The default became `round-robin`, not `hash`.** `hash` now genuinely hashes,
   but flipping the *default* to it would silently redistribute every existing
   user's shard layout. Round-robin is what the archiver has always actually
   done.

Also collapsed **two independent shard computations** into one: the S3 key used
`job.ID % shardCount` while `selectOutput` separately computed
`job.Chunk.ID % shardCount`. They could disagree.

## Restore safety

Changing shard strategy **cannot break existing archives**: each chunk's
`ShardID` is recorded in the manifest and restore follows the manifest rather
than recomputing assignment. The archive-layout spec previously implied readers
*could* recompute it — that's now a warning, since a reader assuming
`chunk.ID % shard_count` addresses the wrong object for any non-default-strategy
archive.

## Verification

Behavioral, not presence-based — the old tests asserted only flag presence and
defaults, which is precisely how this shipped. Each new test was confirmed to
**fail against the pre-fix code** (per the plan: *"asserting coverage without
watching a test fail against the old code is how #308/#311 stayed invisible"*):

```
--- FAIL: TestCreateEncoderPoolsWithOverride/out-of-tier_override_gets_a_pool
--- FAIL: TestArchiverStage_CompressionLevelOverride
--- FAIL: TestArchiverStage_CompressionLevelOutOfPoolOverride
--- FAIL: TestArchiverStage_ShardStrategyAffectsS3Key
        identical content must hash to one shard regardless of chunk ID; got [0 1 2 3]
```

That last line is the old code spreading identical content across four shards —
i.e. round-robin wearing the `hash` label.

Local gate: `gofmt -l` clean, `go vet` clean, `staticcheck` clean on touched
packages, `go test -short ./...` green, pre-commit hook green (quality A+ 91.5,
coverage 57.1% vs 56% floor), `gen-cli.sh` regenerated and committed.

## Also in scope

- **#318** — tracing `ServiceVersion` was hardcoded `v0.6.2`, mislabeling every
  span from every release since. Now reads `internal/version` (#260's single
  source) and defaults to it when unset.
- **#319** — ROADMAP body claimed the current release was v0.13.2 and described
  already-shipped work as upcoming. Version numbers now appear once at the top
  and nowhere in the body, so the body can't drift.
- **#324** — the shard-count default was stated four ways ("8 shards",
  "10 shards", "4–32 adaptive", plus an undocumented fallback of 8). Converged
  across README, help text, and 8 docs pages.
- **`cargoship config --validate` rejected `round-robin`** — `pkg/config` had a
  fifth hardcoded strategy list. It can't import `pkg/pipeline` (the dependency
  runs the other way), so `TestShardStrategiesMatchConfig` pins the two lists
  together instead.

Fixes #316
Fixes #318
Fixes #319
Fixes #324