### PR TITLE
docs: qualify "Stable" and link verification reports from the claims

### DIFF
--- a/docs/project/integrity.md
+++ b/docs/project/integrity.md
@@ -104,7 +104,12 @@ The integrity mechanisms are exercised on every change, not just at release:
 - Emulator-based round-trip tests (upload → download → verify) run on every PR,
   credential-free.
 - A real-AWS integration lane runs the same round-trip against a real S3 bucket
-  on merge to main (plus a weekly canary for environmental drift).
+  on **every release tag** — so a published version is always validated against
+  real S3, and the result is published as a
+  [verification report](/project/verification-reports). A weekly canary runs the
+  same lane to catch environmental drift between releases. It deliberately does
+  *not* run per-PR: it needs real credentials and mutates a shared bucket, and
+  the emulator lane above already guards every change.
 - The deep-verify path is tested against **deliberately corrupted** objects —
   the test suite confirms that flipping a byte in storage makes `verify --deep`
   fail loudly. Detecting corruption is the guarantee; the tests prove it detects.
@@ -180,6 +185,14 @@ sha256sum path/to/restored/file
 If step 3's digest matches the `checksum` recorded for that file in the
 manifest, the file is byte-identical to what was uploaded. That check depends on
 nothing but `sha256sum` and a JSON parser — which is the whole point.
+
+And you don't have to take the claim on faith for a given release either. The
+same round trip is run against real S3 before each version ships, and the result
+is published: for **v0.18.0**, 20 files / 61.01 MB round-tripped byte-identical
+across both the direct and chunked paths, with 0 byte-identity failures and 45/45
+integration suites passing —
+[read the report](https://github.com/scttfrdmn/cargoship/releases/download/v0.18.0/v0.18.0-2026-08-02.md)
+or see [all published reports](/project/verification-reports#published-reports).
 
 ## See also
 

--- a/docs/project/maturity.md
+++ b/docs/project/maturity.md
@@ -6,6 +6,25 @@ stable, what is still evolving, and what guarantees you can (and can't) rely on 
 so you can judge it against your own risk tolerance. For the semantic-versioning
 rules behind these levels, see [API stability & versioning](/project/versioning).
 
+## What the levels mean
+
+**Stable** means the interface and archive format are intended for continued use
+and are protected by release-gating verification against real S3. It does not
+imply a commercial support SLA or a long production history.
+
+That distinction is deliberate. Stable paths *have* had consequential defects
+found in them — v0.16.1 and v0.17.0 fixed last-file truncation in compressed
+chunks and a path traversal on the default `download` path. What the label
+promises is not that no bug will be found; it is that the path is covered by the
+release gate, that a fix ships, and that the format keeps its compatibility
+guarantee. Every release's verification evidence is published — see
+[verification reports](/project/verification-reports#published-reports).
+
+**Beta** means functional and used, but the command surface, configuration, or
+wire format may change between minor releases (documented per release).
+**Experimental** means a capability exists in the library but is not wired into
+the CLI, or has not been exercised enough to rely on.
+
 ## Component maturity
 
 | Capability | Status | What that means |
@@ -48,3 +67,9 @@ Reasonable if you: pin a specific release, rely on the **stable** components, ke
 features as opt-in. The archive format's portability — plain `tar.zst` objects
 plus a documented JSON manifest — means your data isn't hostage to the tool even
 if you stop using it.
+
+Judge the claim on the evidence rather than the label:
+[per-release verification reports](/project/verification-reports#published-reports)
+record what round-tripped byte-identical on real S3 for each published version,
+and the [integrity model](/project/integrity) explains how to reproduce it
+yourself.

--- a/docs/project/verification-reports.md
+++ b/docs/project/verification-reports.md
@@ -27,11 +27,31 @@ Crucially, the report is generated from the **exact test run that gated the
 release** — not a separate, later run — so the published numbers cannot drift
 from what actually passed.
 
-## Where to find them
+## Published reports
 
-- **Attached to each [GitHub Release](https://github.com/scttfrdmn/cargoship/releases)**
-  as `vX.Y.Z-YYYY-MM-DD.md`.
-- Also produced by the weekly canary run (as a workflow artifact) to catch
+Every report below is linked directly — you should not have to dig through
+release assets to find the evidence.
+
+| Version | Date | Files | Bytes | Paths | Suites | Result | Report |
+|---------|------|-------|-------|-------|--------|--------|--------|
+| v0.18.0 | 2026-08-02 | 20 | 61.01 MB | direct, chunked | 45 / 0 | ✅ Passed | [`v0.18.0-2026-08-02.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.18.0/v0.18.0-2026-08-02.md) |
+| v0.17.1 | 2026-08-02 | 20 | 61.01 MB | direct, chunked | 45 / 0 | ✅ Passed | [`v0.17.1-2026-08-02.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.17.1/v0.17.1-2026-08-02.md) |
+| v0.17.0 | 2026-08-02 | 20 | 61.01 MB | direct, chunked | 45 / 0 | ✅ Passed | [`v0.17.0-2026-08-02.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.17.0/v0.17.0-2026-08-02.md) |
+| v0.16.1 | 2026-08-02 | 20 | 61.01 MB | direct, chunked | 45 / 0 | ✅ Passed | [`v0.16.1-2026-08-02.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.16.1/v0.16.1-2026-08-02.md) |
+| v0.16.0 | 2026-07-31 | 20 | 61.01 MB | direct, chunked | 45 / 0 | ✅ Passed | [`v0.16.0-2026-07-31.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.16.0/v0.16.0-2026-07-31.md) |
+
+*Files* = round-tripped byte-identical; *Suites* = integration suites
+passed / failed against real S3. Reports begin at v0.16.0, the release that
+introduced the lane; earlier versions have no published report.
+
+The corpus is fixed, so the file and byte counts are expected to be identical
+across releases — what each row attests is that *that build* preserved them. A
+change in those numbers means the corpus changed, not that more was proven.
+
+- Reports are also **attached to each
+  [GitHub Release](https://github.com/scttfrdmn/cargoship/releases)** as
+  `vX.Y.Z-YYYY-MM-DD.md`.
+- The weekly canary produces one too (as a workflow artifact) to catch
   environmental drift between releases, even with no code change.
 
 ## What a report does and does not establish

--- a/scripts/ci/check-doc-versions.sh
+++ b/scripts/ci/check-doc-versions.sh
@@ -109,7 +109,39 @@ for f in "${root_md[@]}"; do
   done < <(grep -oE '\]\([^)]+\)' "$f" | sed -E 's/^\]\(//; s/\)$//')
 done
 
+# --- Check 4: the published-reports table covers every released version --------
+#
+# docs/project/verification-reports.md hand-lists each release's report with a
+# direct asset URL. That table is the evidence the maturity and integrity pages
+# point at, so a release that lands without a row silently weakens the claim.
+# Every CHANGELOG release from FIRST_REPORT_VERSION onward must appear.
+#
+# Only the *presence* of a row is checked, not the metrics — the numbers come
+# from the release run and can't be validated offline.
+
+reports_doc="docs/project/verification-reports.md"
+# The release that introduced the real-AWS verification lane. Versions before
+# this have no published report and are documented as such.
+first_report_version="0.16.0"
+
+if [ -f "$reports_doc" ] && [ -f CHANGELOG.md ]; then
+  # Released versions, newest first, excluding [Unreleased].
+  mapfile -t released < <(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md \
+    | sed -E 's/^## \[//; s/\]$//')
+
+  for v in "${released[@]}"; do
+    # Skip anything older than the first report (string-safe numeric compare).
+    lowest="$(printf '%s\n%s\n' "$v" "$first_report_version" | sort -V | head -1)"
+    [ "$lowest" = "$first_report_version" ] || continue
+
+    if ! grep -qE "^\| v${v//./\\.} " "$reports_doc"; then
+      echo "::error file=$reports_doc::no published-reports row for v$v; add it with the report's direct asset URL (see the table in that file)"
+      fail=1
+    fi
+  done
+fi
+
 if [ "$fail" -eq 0 ]; then
-  echo "✅ doc-consistency: version declarations match ${version_file:+$(tr -d '[:space:]' < "$version_file")}; no denylisted tokens; local links resolve."
+  echo "✅ doc-consistency: version declarations match ${version_file:+$(tr -d '[:space:]' < "$version_file")}; no denylisted tokens; local links resolve; verification-report table covers all releases."
 fi
 exit $fail


### PR DESCRIPTION
Closes #320.

## 1. "Stable" now has a definition

The label read as "battle-tested in production for years." That is not what it meant, and not what the record supports — v0.16.1 and v0.17.0 fixed a last-file truncation in compressed chunks and a live path traversal on the default `download` path, both in paths marked **Stable**.

Rather than downgrade the labels, define the term:

> **Stable** means the interface and archive format are intended for continued use and are protected by release-gating verification against real S3. It does not imply a commercial support SLA or a long production history.

And says plainly what it does *not* promise — not that no bug will be found, but that the path is covered by the release gate, a fix ships, and the format keeps its compatibility guarantee. **Beta** and **Experimental** get definitions too; they were previously only implied by the table's prose.

## 2. The evidence is now one click from the claim

`verification-reports.md` explained what the reports contain and said they're attached to each release — but linked only the releases *index*. A reader wanting proof had to know to open a release and scroll to its assets.

Added a **Published reports** table covering all five (v0.16.0 → v0.18.0) with direct asset URLs, each verified to return HTTP 200. Linked from the two places the claim is actually made:

- `integrity.md`, at the byte-identity section, with v0.18.0's concrete numbers
- `maturity.md`, as the backing for "protected by release verification"

The table also notes that identical file/byte counts across releases are **expected** — the corpus is fixed, so each row attests that *that build* preserved them, not that more was proven. Without that note, five identical rows invite the wrong reading.

## 3. Fixed an overstatement found while doing this

`integrity.md:106` said the real-AWS lane runs "on merge to main." It does not, and deliberately so — `real-aws-integration.yml` runs weekly + on release tags + on dispatch, because it needs real credentials and mutates a shared bucket. The page now states the actual trigger model and the reason. This is the same class of problem #320 is about, so it belonged here.

## 4. The table can't silently go stale

A hand-maintained table keyed to releases will drift, and the drift is invisible — the page just quietly stops covering the newest version. Added **check 4** to `check-doc-versions.sh`: every CHANGELOG release from v0.16.0 (when the lane was introduced) onward must have a row.

Only row *presence* is checked. The metrics come from the release run and can't be validated offline, so asserting them here would be theater.

## Verification

- `check-doc-versions.sh` passes on this tree.
- **Confirmed check 4 fails when a row is removed** (deleted the v0.17.1 row → exit 1 with a pointed error, restored → clean). A doc guard never watched to fail is not a guard.
- All five report URLs return 200.
- `vitepress build` clean — it fails on dead links, so the `#published-reports` anchors resolve.
- `shellcheck` clean on the modified script; `gofmt -l .` empty; pre-commit hook green (quality 91.4 / A+).

No Go code changed.