### PR TITLE
test: pin the v0.16/v0.17 defects with fixtures verified against pre-fix code

### DIFF
--- a/internal/audit/tarloop_test.go
+++ b/internal/audit/tarloop_test.go
@@ -1,0 +1,98 @@
+// Package audit holds repository-structure tests: invariants about the shape of
+// the codebase that no single package can assert about itself.
+package audit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// tarLoopAllowlist is every non-test site that constructs a tar.Reader, with the
+// reason each is safe. Adding a site without updating this list fails the test.
+//
+// Why an inventory rather than a behavioral test: #311 was a *duplicate*
+// extraction loop. `download` grew its own tar loop that joined the untrusted
+// header name straight onto the output directory — the third live copy of the
+// #282 traversal. No test of the shared extractor could have caught it, because
+// the vulnerable code never called the shared extractor. What made it invisible
+// was that a new loop could appear without anyone re-asking the containment
+// question.
+//
+// So the invariant is: a tar-reading site is either (a) the shared extractor
+// that sanitizes, (b) a reader that never writes to disk and therefore cannot
+// traverse, or (c) newly added and unreviewed — which is what this test reports.
+var tarLoopAllowlist = map[string]string{
+	"pkg/manifest/batch_restore.go":              "the shared SelectiveExtractor; sanitizes header names and asserts containment (see TestBatchRestore_ChunkedTraversalIsContained)",
+	"pkg/extraction/extractor.go":                "checks containment in extractFile, and validates symlink targets in createSymlink",
+	"pkg/manifest/deep_verify.go":                "hashes entries in memory via io.CopyN; never writes to disk",
+	"pkg/pipeline/rebalance.go":                  "reads entries into memory for re-chunking; never writes to disk",
+	"examples/library-usage/03-manifest/main.go": "example program, not shipped in the binary; reads entries in memory",
+}
+
+// TestTarReaderSitesAreReviewed pins the set of files that read tar archives.
+//
+// A new entry is not necessarily a bug — but it does mean a reviewer must decide
+// whether that loop writes to disk and, if so, whether it contains its output.
+// #311 shipped because that question was never asked for a fourth copy.
+func TestTarReaderSitesAreReviewed(t *testing.T) {
+	root := repoRoot(t)
+
+	// git grep so the search respects .gitignore and only covers tracked source.
+	cmd := exec.Command("git", "grep", "-l", "tar.NewReader", "--", "*.go")
+	cmd.Dir = root
+	out, err := cmd.Output()
+	require.NoError(t, err, "git grep for tar.NewReader failed")
+
+	var unreviewed []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		file := strings.TrimSpace(line)
+		if file == "" || strings.HasSuffix(file, "_test.go") {
+			continue // tests construct tar readers to build fixtures
+		}
+		if _, ok := tarLoopAllowlist[file]; !ok {
+			unreviewed = append(unreviewed, file)
+		}
+	}
+	sort.Strings(unreviewed)
+
+	require.Empty(t, unreviewed,
+		"new tar.NewReader site(s) not in tarLoopAllowlist: %v\n\n"+
+			"A tar loop that joins an untrusted header.Name onto an output directory is a "+
+			"path traversal (#282, #311). Either route the extraction through "+
+			"manifest.SelectiveExtractor, or -- if this loop reads into memory and never "+
+			"writes to disk -- add it to tarLoopAllowlist with that reason.",
+		unreviewed)
+}
+
+// TestTarLoopAllowlistHasNoStaleEntries keeps the allowlist honest in the other
+// direction: an entry for a file that no longer reads tar (or no longer exists)
+// is dead documentation that makes the guard look broader than it is.
+func TestTarLoopAllowlistHasNoStaleEntries(t *testing.T) {
+	root := repoRoot(t)
+
+	for file, reason := range tarLoopAllowlist {
+		require.NotEmpty(t, reason, "%s: allowlist entries must state why the site is safe", file)
+
+		path := filepath.Join(root, file)
+		data, err := os.ReadFile(path) // #nosec G304 -- path comes from the in-repo allowlist
+		require.NoError(t, err, "allowlisted file %s does not exist; remove the entry", file)
+		require.Contains(t, string(data), "tar.NewReader",
+			"allowlisted file %s no longer reads tar archives; remove the entry", file)
+	}
+}
+
+// repoRoot returns the repository root, resolved from git rather than a relative
+// path so the test does not silently pass from an unexpected directory.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	require.NoError(t, err, "not in a git repository")
+	return strings.TrimSpace(string(out))
+}

--- a/pkg/manifest/schema_validate_test.go
+++ b/pkg/manifest/schema_validate_test.go
@@ -132,6 +132,57 @@ func TestValidateAgainstSchema_OptionalNullBlocks(t *testing.T) {
 	assert.Empty(t, violations, "nullable optional blocks should validate: %v", violations)
 }
 
+// TestValidateAgainstSchema_EmptyCollectionsAreArrays is the named regression
+// test for the nil-slice defect FuzzValidateAgainstSchema found (#302/#303).
+//
+// The schema declares files, chunks, and shards required with type "array", but
+// encoding/json renders a nil slice as `null`. An upload that produced no chunks
+// (e.g. everything routed to the direct path) therefore wrote a manifest in a
+// shape the format's own published schema rejects — a document CargoShip emitted
+// and a conforming third-party reader would refuse. `ToJSON` normalizes the nil
+// slices to empty arrays; this pins that.
+//
+// The fuzz target checks this as a differential invariant over generated input;
+// this states it as a readable case, so the guarantee is legible in the test
+// suite rather than implicit in a corpus file.
+func TestValidateAgainstSchema_EmptyCollectionsAreArrays(t *testing.T) {
+	// A manifest with every collection left nil — the shape a no-chunk upload
+	// produces. Built directly rather than through Builder, which pre-populates.
+	m := &Manifest{
+		Version:           ManifestVersion,
+		UploadID:          "20260802-empty",
+		SourcePath:        "/tmp/src",
+		Bucket:            "example-bucket",
+		Prefix:            "backups",
+		Region:            "us-east-1",
+		CreatedAt:         time.Unix(1_700_000_000, 0).UTC(),
+		ChecksumAlgorithm: ChecksumAlgorithmSHA256,
+	}
+	require.Nil(t, m.Files, "precondition: Files is nil")
+	require.Nil(t, m.Chunks, "precondition: Chunks is nil")
+	require.Nil(t, m.Shards, "precondition: Shards is nil")
+
+	data, err := m.ToJSON()
+	require.NoError(t, err)
+
+	// The wire form must carry arrays, never null. Asserted on the raw JSON: a
+	// round trip through Manifest would hide the difference, since both `null`
+	// and `[]` unmarshal to a slice that reads as empty.
+	var obj map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &obj))
+	for _, field := range []string{"files", "chunks", "shards"} {
+		raw, ok := obj[field]
+		require.True(t, ok, "%q must be present, not omitted", field)
+		assert.Equal(t, "[]", string(raw), "%q must serialize as an empty array, not null", field)
+	}
+
+	violations, err := ValidateAgainstSchema(data)
+	require.NoError(t, err)
+	assert.Empty(t, violations,
+		"a manifest with no files/chunks/shards must still satisfy the published schema: %s",
+		violationsJoined(violations))
+}
+
 func violationsJoined(v []string) string {
 	out := ""
 	for _, s := range v {


### PR DESCRIPTION
Closes #321.

The ask was a committed fixture per defect, **each confirmed to fail against the pre-fix code**. I audited all nine. Seven were already pinned; this adds the two that weren't, and verifies every one by actually reverting the fix and watching the test fail — not by reading the test and judging it adequate.

## Audit results

| Defect | Fixture | Verified pre-fix |
|---|---|---|
| #275 last-file truncation | `TestArchiverStage_Process_NoTruncation` | ✅ `unexpected EOF` on `file4.dat` — the last file |
| `://` inside a key | table case | ✅ key collapsed to bare prefix |
| `prefix//key` | table case | ✅ yielded `pfx//uploads/...` |
| Non-idempotent resolution | table case | ✅ lost a path segment on 2nd pass |
| Leading-slash URLs | table case | ✅ (vs. intermediate — see below) |
| Nil-slice manifests | **added** | ✅ 3 schema violations |
| #311 chunked traversal | **added** (structural) | ✅ flags the exact vulnerable file |
| Verify-on-restore | `Direct_`/`Chunked_DetectsCorruption` | already behavioral, both paths |
| #287 dataset-relative layout | `TestBatchRestore_SourceRelativeLayout` | already behavioral |

For #275 I restored the old single-defer close order (`pw` closed before the encoder's final flush) and the test failed on the **last** file — the reported symptom precisely, not just "a failure."

The four `ResolveObjectKey` cases were checked against a reconstruction of the pre-fix function. The leading-slash-URL case is the one honest exception: it passes the naive version and only fails once `isURLScheme` exists but the leading-slash trim doesn't run first, so I verified it against that intermediate state. It pins an *interaction* between two fixes, which is worth saying out loud rather than claiming a clean pre-fix failure.

## The two additions

**1. Nil-slice manifests** — the invariant lived only in the `FuzzValidateAgainstSchema` differential, which is exactly the "readable rather than implicit in a binary corpus" gap #321 describes. `TestValidateAgainstSchema_EmptyCollectionsAreArrays` builds the shape a no-chunk upload produces and asserts on the **raw JSON**. That detail matters: a round trip through `Manifest` hides the bug entirely, since `null` and `[]` both unmarshal to a slice that reads as empty. Reverting `ToJSON`'s normalization fails it with all three violations.

**2. A structural guard for #311** — the other eight defects get behavioral fixtures because they were bugs in live code. #311 was a *duplicate extraction loop*: `download` grew its own tar loop that joined the untrusted header name onto the output directory. **No test of the shared extractor could have caught it, because the vulnerable code never called the shared extractor.** The existing `TestBatchRestore_ChunkedTraversalIsContained` cannot fail pre-fix for that reason — it tests the safe path, and the bug was in a fourth copy.

What made #311 invisible was that a new tar loop could appear without anyone re-asking the containment question. So `internal/audit/tarloop_test.go` inventories every non-test `tar.NewReader` site with the reason each is safe, and fails on an unlisted one. **Verified against `f913acb^`** — the actual pre-fix tree — where it flags `cmd/cargoship/cmd/download.go`, the exact file that carried the traversal. A second test rejects stale entries so the allowlist can't overstate its coverage.

While auditing I confirmed the other three tar loops cannot traverse: `pkg/extraction` checks containment in `extractFile` and validates symlink targets in `createSymlink`; `deep_verify` and `rebalance` read into memory and never write to disk.

## Gate

`gofmt`, `go vet`, `staticcheck`, `golangci-lint` (0 issues), `go test -short ./...`, pre-commit hook green (quality 91.4 / A+). No production code changed — tests only.