### PR TITLE
fix(test): repair the performance and benchmark build tags, then guard them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,31 @@ jobs:
   # identical `go test ./... -short` plus a coverage profile — a separate "Test"
   # job would be pure duplication, so it's intentionally omitted.
 
+  build-tags:
+    name: Build Tags Compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      # Compile-checks every custom build tag in the tree. The `performance` and
+      # `benchmark` suites need real AWS to RUN, so nothing here runs them — but
+      # nothing compiled them either, and both had been broken on main for an
+      # unknown length of time (#329). Compiling is the part that regresses.
+      - name: Check all build tags compile
+        run: bash scripts/ci/check-build-tags.sh
+
   e2e-quickstart:
     name: Quick Start E2E (emulator)
     runs-on: ubuntu-latest

--- a/pkg/aws/s3/real_aws_helpers_test.go
+++ b/pkg/aws/s3/real_aws_helpers_test.go
@@ -1,0 +1,76 @@
+//go:build integration || performance
+
+// Bucket/object helpers shared by the real-AWS suites in this package.
+//
+// The build tag is an OR on purpose. These helpers were originally defined in
+// real_aws_integration_test.go (`//go:build integration`) but called from
+// stress_test.go and extreme_test.go (`//go:build performance`). Those tags are
+// never set together, so the callers could never see the callees and the
+// performance-tagged files did not compile — for as long as nothing built them
+// (#329). Anything used across both suites belongs here, not in one of them.
+
+package s3
+
+import (
+	"context"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// transpTestRegion is the region ensureTestBucket creates buckets in. It is
+// shared because both suites create buckets; the bucket NAMES are per-suite and
+// stay with their own files (an unused var here trips staticcheck under
+// whichever tag doesn't reference it).
+var transpTestRegion = firstNonEmpty(os.Getenv("AWS_REGION"), "us-west-2")
+
+// firstNonEmpty returns the first non-empty string, or "" if there is none.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// ensureTestBucket creates bucket if it does not already exist.
+func ensureTestBucket(ctx context.Context, s3Client *s3.Client, bucket string) error {
+	_, err := s3Client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	})
+
+	if err == nil {
+		return nil
+	}
+
+	_, err = s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{
+			LocationConstraint: types.BucketLocationConstraint(transpTestRegion),
+		},
+	})
+
+	return err
+}
+
+// cleanupTestObjects deletes every object under prefix, best-effort.
+func cleanupTestObjects(ctx context.Context, s3Client *s3.Client, bucket, prefix string) {
+	result, err := s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String(prefix),
+	})
+
+	if err != nil {
+		return
+	}
+
+	for _, obj := range result.Contents {
+		_, _ = s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    obj.Key,
+		})
+	}
+}

--- a/pkg/aws/s3/real_aws_integration_test.go
+++ b/pkg/aws/s3/real_aws_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -26,22 +25,10 @@ import (
 
 const transpTestPrefix = "transporter-test"
 
-// Region and bucket are resolved from the standard env knobs so the suite runs
-// both locally (AWS_PROFILE=aws, defaults below) and in CI (creds from the
-// default chain, bucket from CARGOSHIP_TEST_BUCKET).
-var (
-	transpTestRegion = firstNonEmpty(os.Getenv("AWS_REGION"), "us-west-2")
-	transpTestBucket = firstNonEmpty(os.Getenv("CARGOSHIP_TEST_BUCKET"), "cargoship-integration-test")
-)
-
-func firstNonEmpty(vals ...string) string {
-	for _, v := range vals {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
-}
+// transpTestRegion, ensureTestBucket, and cleanupTestObjects live in
+// real_aws_helpers_test.go, tagged `integration || performance` so the
+// performance-tagged suites in this package can reach them too (#329).
+var transpTestBucket = firstNonEmpty(os.Getenv("CARGOSHIP_TEST_BUCKET"), "cargoship-integration-test")
 
 // TestCargoShipTransporterIntegration tests all CargoShip transporters with real AWS S3.
 //
@@ -759,44 +746,5 @@ func testMultipleConcurrentUploads(t *testing.T, ctx context.Context, s3Client *
 	for i := 0; i < numUploads; i++ {
 		testKey := fmt.Sprintf("%s/concurrent-test-%d-%d.txt", transpTestPrefix, startTime.Unix(), i)
 		transporter.DeleteObject(ctx, testKey)
-	}
-}
-
-// Helper functions
-
-func ensureTestBucket(ctx context.Context, s3Client *s3.Client, bucket string) error {
-	_, err := s3Client.HeadBucket(ctx, &s3.HeadBucketInput{
-		Bucket: aws.String(bucket),
-	})
-
-	if err == nil {
-		return nil
-	}
-
-	_, err = s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
-		Bucket: aws.String(bucket),
-		CreateBucketConfiguration: &types.CreateBucketConfiguration{
-			LocationConstraint: types.BucketLocationConstraint(transpTestRegion),
-		},
-	})
-
-	return err
-}
-
-func cleanupTestObjects(ctx context.Context, s3Client *s3.Client, bucket, prefix string) {
-	result, err := s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: aws.String(bucket),
-		Prefix: aws.String(prefix),
-	})
-
-	if err != nil {
-		return
-	}
-
-	for _, obj := range result.Contents {
-		s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
-			Bucket: aws.String(bucket),
-			Key:    obj.Key,
-		})
 	}
 }

--- a/pkg/pipeline/benchmark_test.go
+++ b/pkg/pipeline/benchmark_test.go
@@ -592,10 +592,12 @@ func BenchmarkPipeline_LargeFiles_100_56GB(b *testing.B) {
 		// Cleanup AWS SDK HTTP connections (Issue #65)
 		// Close idle connections to prevent goroutine leaks in goleak tests
 		// This is only necessary when running benchmarks with -cpuprofile flag
-		if config.S3Client != nil {
+		// Read Options() off the concrete client rather than config.S3Client,
+		// which is an interface{} field and has no methods.
+		if s3Client != nil {
 			// Access the underlying HTTP client from the AWS SDK client
 			// The S3 client wraps an HTTP client that maintains persistent connections
-			if httpClient, ok := config.S3Client.Options().HTTPClient.(*http.Client); ok {
+			if httpClient, ok := s3Client.Options().HTTPClient.(*http.Client); ok {
 				httpClient.CloseIdleConnections()
 				b.Logf("Closed AWS SDK HTTP idle connections")
 			}

--- a/scripts/ci/check-build-tags.sh
+++ b/scripts/ci/check-build-tags.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Compile-check every custom build tag in the repository.
+#
+# Why this exists (#329): two tagged test files — pkg/aws/s3/stress_test.go
+# (`performance`) and pkg/pipeline/benchmark_test.go (`benchmark`) — had been
+# broken on main for an unknown length of time. One called a helper that lived
+# behind a different, mutually exclusive tag; the other called a method on a
+# field whose type had since widened to interface{}. Neither was noticed because
+# no CI lane set either tag, and absence of a signal reads exactly like success.
+#
+# These suites need real AWS credentials to *run*, so this does not run them. It
+# only proves they still COMPILE, which is the part that was regressing.
+#
+# The tag list is DERIVED from the tree rather than hardcoded. A new tag is
+# therefore covered the moment it appears — a hardcoded list would rot the same
+# way the files did.
+#
+# Usage: scripts/ci/check-build-tags.sh
+# Exit 0 = every tag compiles; exit 1 = at least one does not.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+# Tags handled by the toolchain itself (GOOS/GOARCH and friends). Setting these
+# via -tags is meaningless-to-harmful, and cross-platform files are already
+# compile-checked by the normal build on their own platform.
+is_platform_tag() {
+  case "$1" in
+    linux|darwin|windows|freebsd|netbsd|openbsd|dragonfly|solaris|aix|plan9|android|ios) return 0 ;;
+    js|wasm|wasip1|unix|cgo|race|msan|asan|purego|gc|gccgo) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Collect identifiers from every //go:build line in tracked Go source. The
+# expression grammar allows && || ! and parens; splitting on those leaves bare
+# tag names. Negated tags (e.g. `!integration`) yield the same identifier, which
+# is what we want — a file excluded by a tag is built when the tag is unset, and
+# the unset case is covered by the untagged build below.
+mapfile -t tags < <(
+  git grep -h '^//go:build ' -- '*.go' \
+    | sed 's|^//go:build ||' \
+    | tr '()!' '   ' \
+    | sed 's/&&/ /g; s/||/ /g' \
+    | tr -s '[:space:]' '\n' \
+    | grep -E '^[a-z][a-z0-9_.]*$' \
+    | sort -u
+)
+
+custom=()
+for t in "${tags[@]}"; do
+  is_platform_tag "$t" || custom+=("$t")
+done
+
+if [ "${#custom[@]}" -eq 0 ]; then
+  echo "no custom build tags found — nothing to check"
+  exit 0
+fi
+
+echo "custom build tags discovered: ${custom[*]}"
+echo
+
+fail=0
+
+# Baseline: the default build. Cheap, and it means a failure below is
+# unambiguously tag-specific rather than a broken tree.
+echo "→ go vet ./...  (no tags)"
+if ! out="$(go vet ./... 2>&1)"; then
+  echo "::error::go vet failed with no build tags set"
+  echo "$out"
+  fail=1
+fi
+
+for t in "${custom[@]}"; do
+  echo "→ go vet -tags $t ./..."
+  if ! out="$(go vet -tags "$t" ./... 2>&1)"; then
+    echo "::error::build tag '$t' does not compile; tagged files are not built by any"
+    echo "::error::other lane, so this rot is invisible until something sets the tag."
+    echo "$out"
+    fail=1
+  fi
+done
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "✅ build tags: default build plus ${#custom[@]} custom tag(s) all compile."
+fi
+exit $fail


### PR DESCRIPTION
Closes #329.

## What was broken

Two tagged test suites did not compile on `main`, and had not for an unknown
length of time. Reproduced before changing anything:

```
$ go vet -tags performance ./...
vet: pkg/aws/s3/stress_test.go:684:9: undefined: ensureTestBucket

$ go vet -tags benchmark ./...
vet: pkg/pipeline/benchmark_test.go:598:41: config.S3Client.Options undefined
     (type interface{} has no field or method Options)
```

Different causes, same reason nobody noticed: **no CI lane sets either tag**, and
absence of a signal reads exactly like success.

## The fixes

**`performance` — a helper across a tag boundary.** `stress_test.go` and
`extreme_test.go` (`//go:build performance`) called `ensureTestBucket` and
`cleanupTestObjects`, defined only in `real_aws_integration_test.go`
(`//go:build integration`). Those tags are never set together, so the callers
could never see the callees.

Moved the shared helpers into a new `real_aws_helpers_test.go` tagged
`integration || performance` — an expression *satisfiable from either suite*,
rather than duplicating the helpers into both files. The bucket *names* stayed
behind with their own suites on purpose: a shared name is unused under whichever
tag doesn't reference it, and staticcheck flags that (`U1000`). Only
`transpTestRegion`, which both need for `CreateBucket`, is shared.

**`benchmark` — an interface widened underneath it.** `config.S3Client` is an
`interface{}` field, so the concrete `*s3.Client`'s `Options()` isn't reachable.
The concrete client was already in scope as a local at line 477, so the call now
reads `Options()` off that. One line.

## The guard

Repairing the files fixes today, not tomorrow. `scripts/ci/check-build-tags.sh`
runs `go vet -tags <t> ./...` for every custom tag, wired into `test.yml` as
**Build Tags Compile**.

The tag list is **derived from the `//go:build` lines in the tree**, not
hardcoded — a hardcoded list would rot exactly the way these files did. Platform
tags (`linux`, `darwin`, `js`, …) are excluded since the toolchain handles those
and passing them via `-tags` is meaningless.

Deriving it surfaced a tag the issue didn't mention: **`benchmarks`** (plural, in
`tests/benchmarks/dvc/`), distinct from `benchmark` and equally unbuilt by CI. It
does compile. There is also a `!integration` file, covered by the untagged
baseline the script runs first.

These suites need real AWS credentials to **run**, so the check does not run
them. Compiling is the part that was regressing.

## Verification

Held #321's standard — the guard was confirmed to fail against the pre-fix tree,
not merely read and judged adequate. Stashing both fixes and re-running it:

```
→ go vet -tags benchmark ./...
::error::build tag 'benchmark' does not compile; ...
vet: pkg/pipeline/benchmark_test.go:598:41: config.S3Client.Options undefined
→ go vet -tags performance ./...
::error::build tag 'performance' does not compile; ...
vet: pkg/aws/s3/stress_test.go:684:9: undefined: ensureTestBucket
EXIT=1
```

Both original errors, verbatim. After the fixes it reports all 5 tags compiling
and exits 0.

Also: `go test -short ./...` fully green; `gofmt` clean; `shellcheck` clean on the
new script; `staticcheck` finding count **unchanged at 15** (all pre-existing, none
in touched files) — checked by running it with and without the change; and
`staticcheck -tags <t>` clean on every touched file under all five tags.

## Note

Test files only plus one CI job — **no production code changed.**

This is the build-tag analogue of the #308/#311/#325 duplicate-drift pattern:
code that nothing compiles stops tracking reality, and stays silent about it. The
derived tag list is what makes this guard different from a checklist.

One leftover the hook flagged as non-blocking, not addressed here: the test-quality
script warns that `pkg/pipeline/benchmark_test.go` is "missing `//go:build performance`"
— it has `//go:build benchmark`. That heuristic doesn't know about the second tag.
Worth a follow-up if the warning becomes blocking as threatened.