### PR TITLE
fix(restore): fetch objects from the bucket the manifest was read from, not the one baked inside it (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A copied, replicated, or renamed archive read from its original location.**
+  Every restore and verify path resolved objects against the bucket recorded
+  *inside* the manifest at upload time, never the bucket the manifest was just
+  read out of — so `cargoship restore s3://archive-copy/…` loaded the manifest
+  from `archive-copy` and then fetched every chunk from the original bucket,
+  silently, having been handed a bucket it ignored. The 404 is the benign case:
+  the dangerous one is a `verify --deep` that reports the copy as intact while
+  never touching a byte of it, which is the one thing an integrity check must not
+  do. `SelectiveExtractor` and `DeepVerifier` now take a `SetBucket` override, and
+  every command wires the bucket it parsed from the user's URL. Omitting the
+  override keeps the manifest's own bucket, so embedders are unaffected. `browse`
+  also picked up the #336 exit-code fix, which it had missed. (#335)
 - **Restoring any prefixed chunked archive by exact path failed outright** with
   `glacier pre-flight check failed: ... HeadObject ... 404`. Manifests record
   `S3Key` relative to `manifest.Prefix`, and the download path resolved it

--- a/cmd/cargoship/cmd/browse.go
+++ b/cmd/cargoship/cmd/browse.go
@@ -120,7 +120,11 @@ Examples:
 			}
 
 			maxCacheBytes := cacheGB * 1024 * 1024 * 1024
-			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes)
+			// SetBucket: fetch from the bucket this manifest was just read from,
+			// not the one recorded inside it. Without it the Glacier pre-flight
+			// below checks `bucket` while the download goes somewhere else — the
+			// same split that made #334 undetectable. (#335)
+			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes).SetBucket(bucket)
 
 			// Glacier pre-flight check on the chunks needed for selected files.
 			restoreTier := s3pkg.RestoreTier(tier)
@@ -168,7 +172,13 @@ Examples:
 				return fmt.Errorf("restore failed: %w", err)
 			}
 
-			fmt.Printf("✅ Restore complete!\n")
+			// Same exit-code contract as `restore` (#336): BatchRestore counts
+			// per-file failures and continues, so err == nil on total failure.
+			if stats.Restored > 0 {
+				fmt.Printf("✅ Restore complete!\n")
+			} else {
+				fmt.Printf("❌ Restore failed: no files were restored\n")
+			}
 			fmt.Printf("   Files restored:    %d\n", stats.Restored)
 			if stats.Failed > 0 {
 				fmt.Printf("   Files failed:      %d\n", stats.Failed)
@@ -178,7 +188,7 @@ Examples:
 				fmt.Printf("   Retrieval cost:    $%.4f USD\n", report.EstimatedCostUSD)
 			}
 			fmt.Printf("   Output directory:  %s\n", destDir)
-			return nil
+			return restoreOutcomeError(stats)
 		},
 	}
 

--- a/cmd/cargoship/cmd/download.go
+++ b/cmd/cargoship/cmd/download.go
@@ -218,6 +218,7 @@ Examples:
 				targets[i] = file.Path
 			}
 			extractor := manifest.NewSelectiveExtractor(m, s3Client, 0).
+				SetBucket(bucket). // where the manifest actually came from (#335)
 				SetVerify(!noVerify).
 				SetFlatten(flatten)
 			stats, err := extractor.BatchRestore(ctx, targets, outputDir)

--- a/cmd/cargoship/cmd/restore.go
+++ b/cmd/cargoship/cmd/restore.go
@@ -112,7 +112,13 @@ Examples:
 			fmt.Printf("✅ Manifest loaded: %d files, %d chunks\n\n", m.TotalFiles, m.TotalChunks)
 
 			maxCacheBytes := cacheGB * 1024 * 1024 * 1024
-			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes).SetVerify(!noVerify).SetFlatten(flatten)
+			// SetBucket: fetch from the bucket the manifest was just read from,
+			// not the stale name recorded inside it, so a copied or replicated
+			// archive restores from where it actually is (#335).
+			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes).
+				SetBucket(bucket).
+				SetVerify(!noVerify).
+				SetFlatten(flatten)
 
 			// Resolve target paths/keys.
 			var targetPaths []string

--- a/cmd/cargoship/cmd/restore_jobs.go
+++ b/cmd/cargoship/cmd/restore_jobs.go
@@ -239,7 +239,9 @@ The job must be in 'ready' status (run 'restore jobs check' first if unsure).`,
 			}
 
 			maxCacheBytes := cacheGB * 1024 * 1024 * 1024
-			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes)
+			// SetBucket: fetch from the bucket in the job's own S3 URL, not the
+			// one recorded in the manifest (#335).
+			se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes).SetBucket(bucket)
 
 			fmt.Printf("🚀 Restoring files to %s…\n", job.OutputDir)
 

--- a/cmd/cargoship/cmd/shell.go
+++ b/cmd/cargoship/cmd/shell.go
@@ -111,7 +111,9 @@ func runArchiveShell(ctx context.Context, s3URL, region string, cacheGB int64) e
 	fmt.Printf("✅ Manifest loaded: %d files, %d chunks\n\n", m.TotalFiles, m.TotalChunks)
 
 	maxCacheBytes := cacheGB * 1024 * 1024 * 1024
-	se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes)
+	// SetBucket: fetch from where the manifest was read, not the bucket name
+	// baked into it at upload time (#335).
+	se := manifest.NewSelectiveExtractor(m, s3Client, maxCacheBytes).SetBucket(bucket)
 	vfs := archivefs.New(m)
 
 	sh := &archiveShell{

--- a/cmd/cargoship/cmd/verify.go
+++ b/cmd/cargoship/cmd/verify.go
@@ -194,7 +194,7 @@ Exit Codes:
 				// recompute checksums to confirm the DATA matches the manifest,
 				// not just that the manifest is internally consistent.
 				if deep {
-					if err := runDeepVerify(ctx, s3Client, m, verbose); err != nil {
+					if err := runDeepVerify(ctx, s3Client, m, bucket, verbose); err != nil {
 						os.Exit(1)
 					}
 					return nil
@@ -263,7 +263,11 @@ Exit Codes:
 // runDeepVerify re-downloads each chunk object, recomputes its checksum, and
 // compares it to the manifest. It prints a per-chunk report and returns an
 // error if any chunk is corrupted, missing, or unverifiable (#271).
-func runDeepVerify(ctx context.Context, s3Client manifest.S3Downloader, m *manifest.Manifest, verbose bool) error {
+// bucket is where the manifest was actually read from; chunk objects are fetched
+// there rather than from the name recorded inside the manifest. A deep verify
+// that silently read the ORIGINAL bucket would report a copied archive as intact
+// without touching a byte of it (#335).
+func runDeepVerify(ctx context.Context, s3Client manifest.S3Downloader, m *manifest.Manifest, bucket string, verbose bool) error {
 	fmt.Printf("🔬 Deep verification: re-downloading and checksumming stored data...\n")
 	if m.ChecksumAlgorithm == "" {
 		fmt.Printf("⚠️  This manifest predates checksum capture (no algorithm recorded).\n")
@@ -272,7 +276,7 @@ func runDeepVerify(ctx context.Context, s3Client manifest.S3Downloader, m *manif
 		fmt.Printf("   Algorithm: %s | Chunks: %d\n\n", m.ChecksumAlgorithm, len(m.Chunks))
 	}
 
-	verifier := manifest.NewDeepVerifier(m, s3Client)
+	verifier := manifest.NewDeepVerifier(m, s3Client).SetBucket(bucket)
 	result, err := verifier.VerifyChunks(ctx)
 	if err != nil {
 		fmt.Printf("❌ Deep verification aborted: %v\n", err)

--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -153,6 +153,16 @@ type SelectiveExtractor struct {
 	// default dataset-relative layout (#287). Useful for targeted single-file
 	// restores. Set with SetFlatten(true).
 	flatten bool
+
+	// bucket overrides the bucket objects are fetched from. Empty means use
+	// manifest.Bucket, which is the historical behavior.
+	//
+	// The manifest records the bucket it was written to, so an archive copied or
+	// replicated elsewhere carried a stale name and every fetch went to the
+	// ORIGINAL bucket — silently, since the caller had already been asked for a
+	// bucket in the S3 URL and had no reason to think it was ignored (#335). Set
+	// with SetBucket to the bucket the manifest was actually read from.
+	bucket string
 }
 
 // NewSelectiveExtractor creates a SelectiveExtractor. maxCacheSize sets the
@@ -174,6 +184,28 @@ func NewSelectiveExtractor(manifest *Manifest, s3Client S3Downloader, maxCacheSi
 func (se *SelectiveExtractor) SetVerify(v bool) *SelectiveExtractor {
 	se.verify = v
 	return se
+}
+
+// SetBucket overrides the bucket objects are fetched from, for callers that know
+// where the archive actually lives — normally the bucket the manifest was just
+// read from. Passing "" keeps the manifest's own recorded bucket.
+//
+// Without this, a copied, replicated, or renamed archive fetches from the bucket
+// baked in at upload time: the restore either 404s or, worse, succeeds against a
+// stale original that the user believed they had moved away from (#335).
+// Returns the receiver for chaining.
+func (se *SelectiveExtractor) SetBucket(bucket string) *SelectiveExtractor {
+	se.bucket = bucket
+	return se
+}
+
+// objectBucket returns the bucket to fetch from: the explicit override when set,
+// otherwise the manifest's recorded bucket.
+func (se *SelectiveExtractor) objectBucket() string {
+	if se.bucket != "" {
+		return se.bucket
+	}
+	return se.manifest.Bucket
 }
 
 // SetFlatten toggles flat restore layout (destDir/<basename> per file) instead
@@ -533,7 +565,7 @@ func (se *SelectiveExtractor) downloadChunk(ctx context.Context, s3Key string) (
 	// as an object key verbatim. ResolveObjectKey maps all shapes to the real
 	// object key relative to the bucket.
 	out, err := se.s3Client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(se.manifest.Bucket),
+		Bucket: aws.String(se.objectBucket()),
 		Key:    aws.String(se.resolveKey(s3Key)),
 	})
 	if err != nil {

--- a/pkg/manifest/batch_restore_test.go
+++ b/pkg/manifest/batch_restore_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1073,4 +1075,89 @@ func TestBatchRestore_ZeroModTimeLeavesFileAlone(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, fi.ModTime().IsZero(), "should keep the write time, not stamp year 1")
 	assert.True(t, fi.ModTime().Year() > 2000, "got %s", fi.ModTime())
+}
+
+// ---------------------------------------------------------------------------
+// #335: objects were fetched from the bucket recorded IN the manifest, never
+// from the bucket the manifest was read out of. An archive copied, replicated,
+// or renamed therefore fetched from its original location — silently, since the
+// caller had supplied a bucket in the S3 URL and had no reason to think it was
+// ignored. Worst case is not the 404: it is a restore or a deep verify that
+// SUCCEEDS against the stale original the user believed they had moved away
+// from, certifying a copy nobody read.
+// ---------------------------------------------------------------------------
+
+// buildMovedArchive returns a prefixed manifest whose recorded Bucket is stale,
+// plus a client that serves the objects ONLY from the bucket the archive was
+// actually moved to.
+func buildMovedArchive(t *testing.T) (*Manifest, *mockS3Client, string) {
+	t.Helper()
+	const newBucket = "archive-copy"
+
+	m := buildPrefixedManifest()
+	m.Bucket = "original-bucket" // stale: where it was first uploaded
+
+	client := &mockS3Client{chunks: make(map[string][]byte), onlyBucket: newBucket}
+	for _, chunk := range m.Chunks {
+		var files []FileEntry
+		for _, fe := range m.Files {
+			if fe.ChunkID == chunk.ID {
+				files = append(files, fe)
+			}
+		}
+		client.chunks[ResolveObjectKey(m.Prefix, m.Bucket, chunk.S3Key)] = buildZstdTar(t, files)
+	}
+	return m, client, newBucket
+}
+
+func TestBatchRestore_FetchesFromOverriddenBucket(t *testing.T) {
+	m, client, newBucket := buildMovedArchive(t)
+
+	se := NewSelectiveExtractor(m, client, 0).SetBucket(newBucket)
+	stats, err := se.BatchRestore(context.Background(), []string{"data/file-000.bin"}, t.TempDir())
+	require.NoError(t, err)
+	require.Zero(t, stats.Failed, "restore must read from the bucket it was pointed at")
+	assert.Equal(t, int64(1), stats.Restored)
+
+	assert.Equal(t, []string{newBucket}, client.requestedBuckets(),
+		"objects must come from the bucket the manifest was read from, not the stale name inside it")
+}
+
+// TestBatchRestore_UnsetBucketKeepsManifestBucket pins the default. Callers that
+// never call SetBucket must behave exactly as before — the override is opt-in, so
+// it cannot change what existing embedders do.
+func TestBatchRestore_UnsetBucketKeepsManifestBucket(t *testing.T) {
+	m, client, _ := buildMovedArchive(t)
+	client.onlyBucket = m.Bucket // serve only from the manifest's own bucket
+
+	se := NewSelectiveExtractor(m, client, 0)
+	stats, err := se.BatchRestore(context.Background(), []string{"data/file-000.bin"}, t.TempDir())
+	require.NoError(t, err)
+	require.Zero(t, stats.Failed)
+
+	assert.Equal(t, []string{m.Bucket}, client.requestedBuckets(),
+		"with no override the manifest's recorded bucket must still be used")
+}
+
+// TestDeepVerify_DoesNotCertifyABucketItNeverRead is the assertion that matters
+// most. A deep verify is a claim about specific bytes in a specific place; if it
+// reads the original bucket while the user asked about a copy, it certifies data
+// it never touched. That is the one thing an integrity check must not do.
+func TestDeepVerify_DoesNotCertifyABucketItNeverRead(t *testing.T) {
+	m, client, newBucket := buildMovedArchive(t)
+	m.ChecksumAlgorithm = ChecksumAlgorithmSHA256
+	for i := range m.Chunks {
+		key := ResolveObjectKey(m.Prefix, m.Bucket, m.Chunks[i].S3Key)
+		sum := sha256.Sum256(client.chunks[key])
+		m.Chunks[i].Checksum = hex.EncodeToString(sum[:])
+	}
+
+	dv := NewDeepVerifier(m, client).SetBucket(newBucket)
+	result, err := dv.VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.True(t, result.Passed(),
+		"deep verify must read the bucket it was pointed at (ok=%d missing=%d mismatched=%d)",
+		result.OK, result.Missing, result.Mismatched)
+	assert.Equal(t, []string{newBucket}, client.requestedBuckets(),
+		"deep verify must not certify bytes it read from a different bucket")
 }

--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -71,11 +71,37 @@ func (r *DeepVerifyResult) Passed() bool {
 type DeepVerifier struct {
 	manifest *Manifest
 	s3Client S3Downloader
+
+	// bucket overrides the bucket objects are fetched from; empty means use
+	// manifest.Bucket. See SetBucket (#335).
+	bucket string
 }
 
 // NewDeepVerifier creates a deep verifier for a manifest.
 func NewDeepVerifier(m *Manifest, s3Client S3Downloader) *DeepVerifier {
 	return &DeepVerifier{manifest: m, s3Client: s3Client}
+}
+
+// SetBucket overrides the bucket chunk objects are fetched from — normally the
+// bucket the manifest was just read from. Passing "" keeps the manifest's own
+// recorded bucket. Returns the receiver for chaining.
+//
+// This matters more for verification than for restore: a deep verify against a
+// copied archive that silently read the ORIGINAL bucket would report the copy as
+// intact while never having touched a byte of it, which is the one thing an
+// integrity check must not do (#335).
+func (dv *DeepVerifier) SetBucket(bucket string) *DeepVerifier {
+	dv.bucket = bucket
+	return dv
+}
+
+// objectBucket returns the bucket to fetch from: the explicit override when set,
+// otherwise the manifest's recorded bucket.
+func (dv *DeepVerifier) objectBucket() string {
+	if dv.bucket != "" {
+		return dv.bucket
+	}
+	return dv.manifest.Bucket
 }
 
 // VerifyChunks re-downloads every chunk object, recomputes its SHA-256, and
@@ -221,7 +247,7 @@ func (dv *DeepVerifier) verifyChunk(ctx context.Context, chunk *ChunkEntry) Chun
 	}
 
 	output, err := dv.s3Client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(dv.manifest.Bucket),
+		Bucket: aws.String(dv.objectBucket()),
 		Key:    aws.String(dv.objectKey(chunk.S3Key)),
 	})
 	if err != nil {
@@ -393,7 +419,7 @@ func (dv *DeepVerifier) chunkByID(id int) *ChunkEntry {
 // can detect files that never appeared.
 func (dv *DeepVerifier) verifyChunkFiles(ctx context.Context, chunk *ChunkEntry, expected map[fileKey]string, seen map[fileKey]bool) ([]FileVerifyResult, error) {
 	output, err := dv.s3Client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(dv.manifest.Bucket),
+		Bucket: aws.String(dv.objectBucket()),
 		Key:    aws.String(dv.objectKey(chunk.S3Key)),
 	})
 	if err != nil {

--- a/pkg/manifest/helpers_test.go
+++ b/pkg/manifest/helpers_test.go
@@ -21,17 +21,34 @@ import (
 
 // mockS3Client serves object bytes from an in-memory map, keyed by S3 key. It
 // records the keys it was asked for so tests can assert WHICH object was
-// fetched, not merely that the fetch succeeded (#334).
+// fetched, not merely that the fetch succeeded (#334), and the buckets so they
+// can assert WHERE it was fetched from (#335).
+//
+// When onlyBucket is set, a request for any other bucket fails the way a real
+// missing/foreign bucket would — that is what lets a test prove the fetch went
+// to the intended bucket rather than the one recorded in the manifest.
 type mockS3Client struct {
-	chunks    map[string][]byte // S3 key -> compressed tar data
-	mu        sync.Mutex
-	requested []string
+	chunks     map[string][]byte // S3 key -> compressed tar data
+	onlyBucket string            // when set, requests to other buckets fail
+	mu         sync.Mutex
+	requested  []string
+	buckets    []string
 }
 
 func (m *mockS3Client) GetObject(ctx context.Context, input *s3.GetObjectInput, opts ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	bucket := ""
+	if input.Bucket != nil {
+		bucket = *input.Bucket
+	}
+
 	m.mu.Lock()
 	m.requested = append(m.requested, *input.Key)
+	m.buckets = append(m.buckets, bucket)
 	m.mu.Unlock()
+
+	if m.onlyBucket != "" && bucket != m.onlyBucket {
+		return nil, fmt.Errorf("NoSuchBucket: %s", bucket)
+	}
 
 	data, ok := m.chunks[*input.Key]
 	if !ok {
@@ -41,6 +58,21 @@ func (m *mockS3Client) GetObject(ctx context.Context, input *s3.GetObjectInput, 
 	return &s3.GetObjectOutput{
 		Body: io.NopCloser(bytes.NewReader(data)),
 	}, nil
+}
+
+// requestedBuckets returns the deduplicated set of buckets GetObject addressed.
+func (m *mockS3Client) requestedBuckets() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	seen := make(map[string]struct{}, len(m.buckets))
+	var out []string
+	for _, b := range m.buckets {
+		if _, ok := seen[b]; !ok {
+			seen[b] = struct{}{}
+			out = append(out, b)
+		}
+	}
+	return out
 }
 
 // requestedKeys returns the deduplicated set of keys GetObject was called with.

--- a/tests/e2e/moved_archive_test.go
+++ b/tests/e2e/moved_archive_test.go
@@ -1,0 +1,175 @@
+//go:build e2e
+
+// End-to-end regression for #335: restoring and verifying an archive that has
+// been COPIED to a different bucket.
+//
+// Every restore path resolved objects against the bucket recorded inside the
+// manifest at upload time, never the bucket the manifest was just read out of.
+// So `cargoship restore s3://archive-copy/...` loaded the manifest from
+// archive-copy and then fetched every chunk from the original bucket. The caller
+// had supplied a bucket and had no indication it was ignored.
+//
+// The 404 is the benign case. The dangerous one is a restore or a deep verify
+// that SUCCEEDS against the stale original — certifying a copy nobody read,
+// which is exactly the claim a `verify --deep` is supposed to make about
+// specific bytes in a specific place.
+//
+// Copying to a new bucket and DELETING the original is what makes this
+// unambiguous: with the original gone, any operation that still succeeds must
+// have read the copy.
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// TestMovedArchive_RestoresAndVerifiesFromTheBucketItWasGiven is the #335
+// regression. Chunked layout with a prefix, because the chunk objects are what
+// get addressed by bucket — a direct-layout archive stores files as plain
+// objects and would not exercise the chunk fetch path.
+func TestMovedArchive_RestoresAndVerifiesFromTheBucketItWasGiven(t *testing.T) {
+	const (
+		origBucket = "moved-archive-origin"
+		copyBucket = "moved-archive-copy"
+		prefix     = "archives"
+	)
+	for _, b := range []string{origBucket, copyBucket} {
+		if err := createBucket(substrateURL, b); err != nil {
+			t.Fatalf("create bucket %s: %v", b, err)
+		}
+	}
+
+	// Chunked layout needs an average file size that defeats the direct-upload
+	// heuristic. Patterned so it compresses small and the test stays fast.
+	src := t.TempDir()
+	big := make([]byte, 6*1024*1024)
+	for i := range big {
+		big[i] = byte(i % 251)
+	}
+	for _, name := range []string{"moved-a.bin", "moved-b.bin"} {
+		if err := os.WriteFile(filepath.Join(src, name), big, 0o644); err != nil {
+			t.Fatalf("write source: %v", err)
+		}
+	}
+
+	uploadDest := "s3://" + origBucket + "/" + prefix
+	out := runCargoship(t, "upload", src, uploadDest, "--region", "us-east-1")
+	uploadID := extractUploadID(t, out)
+
+	// Copy every object to the second bucket under identical keys, then delete
+	// the original. Anything that still works from here read the copy.
+	keys := copyAllObjects(t, origBucket, copyBucket)
+	if len(keys) == 0 {
+		t.Fatal("upload produced no objects to copy")
+	}
+	deleteAllObjects(t, origBucket, keys)
+
+	copyURL := "s3://" + copyBucket + "/" + prefix + "/uploads/" + uploadID
+
+	// 1. verify --deep against the copy must read the copy. Before the fix it
+	// fetched from the (now empty) original and reported every chunk missing.
+	runCargoship(t, "verify", copyURL, "--deep", "--region", "us-east-1")
+
+	// 2. Restore by the exact manifest path, the same combination #334 covers,
+	// so the Glacier pre-flight is exercised rather than skipped.
+	restoreDir := t.TempDir()
+	runCargoship(t, "restore", copyURL, restoreDir,
+		"--region", "us-east-1", "--file", filepath.Join(src, "moved-a.bin"))
+
+	got, err := os.ReadFile(findFileByBase(t, restoreDir, "moved-a.bin"))
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if len(got) != len(big) {
+		t.Fatalf("restored size %d, want %d", len(got), len(big))
+	}
+	for i := range got {
+		if got[i] != big[i] {
+			t.Fatalf("restored content differs at byte %d: got %d want %d", i, got[i], big[i])
+		}
+	}
+}
+
+// copyAllObjects copies every object from src to dst under identical keys and
+// returns the keys copied.
+func copyAllObjects(t *testing.T, srcBucket, dstBucket string) []string {
+	t.Helper()
+	ctx := context.Background()
+	client := fixtureS3Client()
+
+	var keys []string
+	var token *string
+	for {
+		page, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(srcBucket),
+			ContinuationToken: token,
+		})
+		if err != nil {
+			t.Fatalf("list %s: %v", srcBucket, err)
+		}
+		for _, obj := range page.Contents {
+			key := aws.ToString(obj.Key)
+			body, getErr := client.GetObject(ctx, &s3.GetObjectInput{
+				Bucket: aws.String(srcBucket),
+				Key:    aws.String(key),
+			})
+			if getErr != nil {
+				t.Fatalf("get %s: %v", key, getErr)
+			}
+			data := readAllAndClose(t, body)
+			if _, putErr := client.PutObject(ctx, &s3.PutObjectInput{
+				Bucket: aws.String(dstBucket),
+				Key:    aws.String(key),
+				Body:   bytes.NewReader(data),
+			}); putErr != nil {
+				t.Fatalf("put %s: %v", key, putErr)
+			}
+			keys = append(keys, key)
+		}
+		if page.IsTruncated == nil || !*page.IsTruncated {
+			break
+		}
+		token = page.NextContinuationToken
+	}
+	return keys
+}
+
+// deleteAllObjects removes the given keys from bucket, so that a later success
+// can only have come from somewhere else.
+func deleteAllObjects(t *testing.T, bucket string, keys []string) {
+	t.Helper()
+	ctx := context.Background()
+	client := fixtureS3Client()
+	for _, key := range keys {
+		if _, err := client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		}); err != nil {
+			t.Fatalf("delete %s/%s: %v", bucket, key, err)
+		}
+	}
+
+	// Confirm the original really is empty. If the emulator ignored the deletes,
+	// the whole test would pass vacuously — a fetch from the original bucket
+	// would still succeed and prove nothing.
+	page, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Fatalf("list %s after delete: %v", bucket, err)
+	}
+	if len(page.Contents) != 0 {
+		var remaining []string
+		for _, o := range page.Contents {
+			remaining = append(remaining, aws.ToString(o.Key))
+		}
+		t.Fatalf("origin bucket still holds %d object(s) (%s); the test could pass without reading the copy",
+			len(page.Contents), strings.Join(remaining, ", "))
+	}
+}


### PR DESCRIPTION
Fixes #335. The last of the four defects the #322 cross-version work surfaced; #334/#336/#337 landed in #338.

## The defect

Every restore and verify path resolved objects against `manifest.Bucket` — the bucket recorded at upload time — never the bucket the manifest was actually read out of. So:

```
cargoship restore s3://archive-copy/archives/uploads/… ./out
```

loaded the manifest from `archive-copy`, then fetched every chunk from the **original** bucket. The caller had supplied a bucket in the S3 URL and had no indication it was ignored.

The 404 is the benign outcome. The dangerous one is a restore or a `verify --deep` that **succeeds** against the stale original: a deep verify is a claim about specific bytes in a specific place, so certifying a copy nobody read is the one thing an integrity check must not do.

Found while building the #322 fixture harness — it initially replayed captured object trees into fresh buckets and all ten fixtures failed. Reproduced on `main` independently of any fixture.

## The fix

`SelectiveExtractor` and `DeepVerifier` take a `SetBucket` override; `restore`, `browse`, `download`, `shell`, `restore jobs` and `verify` each pass the bucket they already parsed from the user's URL.

The override is **opt-in** — omitting it keeps `manifest.Bucket` — so existing embedders are unaffected. That's pinned by `TestBatchRestore_UnsetBucketKeepsManifestBucket` rather than left as an assumption.

One thing that looks like an oversight and isn't: `resolveKey` still passes `manifest.Bucket` to `ResolveObjectKey`. That argument strips the bucket name a **key was recorded with**, which is the *old* name. Passing the new bucket there would fail to strip it.

Also fixes `browse`'s copy of #336: it printed an unconditional `✅ Restore complete!` and returned nil regardless of `stats.Failed`. Same reasoning as `restore` — the exit code has to agree with the numbers printed beside it.

## Verification

The unit tests only prove the new method is absent pre-fix (a build failure), which is not evidence the old *behavior* was wrong. So the real check is `tests/e2e/moved_archive_test.go`, which drives the actual CLI against an archive copied to a second bucket **with the original deleted**. With the origin gone, any success must have read the copy.

The delete helper then asserts the origin really is empty — otherwise, if the emulator ignored the deletes, the test would pass vacuously, which is the exact failure mode that made #334 invisible for so long.

Pre-fix, stash-verified with `-count=1`:

```
🔬 Deep verification: re-downloading and checksumming stored data...
   ✗ chunk 0 MISSING: uploads/…/shard-0/chunk-0.tar.zst (… 404 … NoSuchKey)
📊 Deep Verify: 0 OK, 0 corrupted, 1 missing, 0 unverifiable (of 1 chunks)
📊 File Verify: 0 OK, 0 corrupted, 4 missing, 0 unverifiable (of 2 files)
❌ Deep verification FAIL
```

Gate: `gofmt` clean, `go vet ./...` and `go vet -tags e2e ./...` clean, `go test -short ./...` green, full e2e green, `scripts/ci/check-build-tags.sh` green (all 5 custom tags compile).

## Milestone status

This closes out v0.19.0 — Assurance Depth. #320, #321, #322, #329 and #334/#336/#337 are merged; only #323 (external security review) remains, and it sits in **Future Work** blocked on budget/vendor.