### PR TITLE
fix(security): refuse to write through symlinks in restore/extract (#341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `CARGOSHIP_CONTROLLER_URL`, `CARGOSHIP_WATCH_PATHS` and
     `CARGOSHIP_DESTINATION` variables, which were read only by `cargoship-launch`.
 
+### Fixed
+
+- **`restore` and `extract` no longer write through a symlink in the destination**
+  (#341). Both checked containment lexically — `filepath.Join` then a
+  `strings.HasPrefix` against the destination — which stops a hostile *path*
+  (`../evil`, fixed in #282) but cannot see a hostile *destination*. If the
+  destination directory already contained `cache -> /elsewhere`, the entry
+  `cache/config.txt` passed every check and the OS followed the link, writing
+  outside the destination and truncating whatever it found. (CWE-59)
+  - Every write now goes through an `os.Root` opened on the destination, so each
+    path component is re-validated at open time. This replaces the check-then-write
+    `os.Lstat` walk originally planned: that pattern is racy by construction — it
+    can confirm a parent is a real directory and have it swapped for a symlink
+    before the write lands. `os.Root` closes the race rather than narrowing it, and
+    is portable across every target goreleaser builds.
+  - `os.Root` alone was not sufficient. It refuses a symlink leaving the root, but
+    one pointing to another path *inside* it is still followed, so
+    `dest/cache -> real` silently diverted `cache/config.txt` into `real/`. Parent
+    components are now walked one at a time and any symlink refused, so a restored
+    path means what it says. In `pkg/extraction` that also closes a two-entry
+    archive attack needing no pre-existing state: plant `link -> real` (a legal
+    relative symlink), then write `link/payload.txt`.
+  - A refused file is counted in `RestoreStats.Failed`, which the CLI already turns
+    into a non-zero exit (#336) — so a withheld file cannot read as a clean restore.
+  - **The test gap is the finding.** `pkg/manifest` had traversal tests but not one
+    symlink test, which is why this survived #282. Added: symlinked parent,
+    symlinked leaf, and in-root symlinked parent, across both storage layouts;
+    the `pkg/extraction` equivalents plus the planted-symlink case; and an
+    end-to-end test driving the real binary, which asserts the exit code as well
+    as containment. Each was watched failing against the pre-fix tree. Controls
+    that pin the ordinary path — a pre-existing *real* directory in the
+    destination must stay writable — accompany each, so a fix that simply refused
+    everything could not pass.
+
 ## [0.19.0] - 2026-08-03
 
 **Assurance depth.** An external review scored the project 8.9/10 and asked for

--- a/pkg/extraction/extractor.go
+++ b/pkg/extraction/extractor.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -135,8 +136,20 @@ func (e *Extractor) Extract(ctx context.Context) (*ExtractionStats, error) {
 	// Create tar reader
 	tarReader := tar.NewReader(reader)
 
+	// #341: every filesystem write below goes through this root, so a symlinked
+	// component inside OutputDir — pre-existing, or planted by an earlier entry in
+	// this same archive — is refused rather than followed.
+	if err := os.MkdirAll(e.config.OutputDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+	root, err := os.OpenRoot(e.config.OutputDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open output directory: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+
 	// Extract files from tar archive
-	if err := e.extractFiles(ctx, tarReader); err != nil {
+	if err := e.extractFiles(ctx, tarReader, root); err != nil {
 		return nil, fmt.Errorf("extraction failed: %w", err)
 	}
 
@@ -169,8 +182,9 @@ func (e *Extractor) closeReader(r io.Reader) {
 	}
 }
 
-// extractFiles extracts all files from the tar archive
-func (e *Extractor) extractFiles(ctx context.Context, tarReader *tar.Reader) error {
+// extractFiles extracts all files from the tar archive. All writes are performed
+// relative to root, which confines them to OutputDir. (#341)
+func (e *Extractor) extractFiles(ctx context.Context, tarReader *tar.Reader, root *os.Root) error {
 	for {
 		// Check context cancellation
 		select {
@@ -190,7 +204,7 @@ func (e *Extractor) extractFiles(ctx context.Context, tarReader *tar.Reader) err
 		}
 
 		// Extract the file
-		if err := e.extractFile(tarReader, header); err != nil {
+		if err := e.extractFile(tarReader, header, root); err != nil {
 			e.stats.ErrorCount++
 			return fmt.Errorf("failed to extract %s: %w", header.Name, err)
 		}
@@ -202,8 +216,15 @@ func (e *Extractor) extractFiles(ctx context.Context, tarReader *tar.Reader) err
 	return nil
 }
 
-// extractFile extracts a single file from the tar archive
-func (e *Extractor) extractFile(tarReader *tar.Reader, header *tar.Header) error {
+// extractFile extracts a single file from the tar archive.
+//
+// Containment is enforced in two layers. The lexical check below rejects an
+// obviously hostile archive entry ("../evil") with a clear diagnostic naming the
+// entry. The root passed to the creators is what actually guarantees containment:
+// it re-validates every path component at open time, so a symlink in OutputDir
+// cannot redirect a write out of it. The lexical check alone cannot see symlinks,
+// which is the defect in #341.
+func (e *Extractor) extractFile(tarReader *tar.Reader, header *tar.Header, root *os.Root) error {
 	// Construct output path
 	outputPath := filepath.Join(e.config.OutputDir, header.Name) // #nosec G305 -- containment is verified immediately below
 
@@ -212,52 +233,127 @@ func (e *Extractor) extractFile(tarReader *tar.Reader, header *tar.Header) error
 		return fmt.Errorf("invalid path: %s (possible path traversal)", header.Name)
 	}
 
+	relPath, err := e.relOutputPath(outputPath)
+	if err != nil {
+		return err
+	}
+
 	// Handle different file types
 	switch header.Typeflag {
 	case tar.TypeDir:
-		return e.createDirectory(outputPath, header)
+		return e.createDirectory(root, relPath, header)
 	case tar.TypeReg:
-		return e.createRegularFile(tarReader, outputPath, header)
+		return e.createRegularFile(tarReader, root, relPath, header)
 	case tar.TypeSymlink:
-		return e.createSymlink(outputPath, header)
+		return e.createSymlink(root, relPath, outputPath, header)
 	default:
 		// Skip unsupported file types (devices, FIFOs, etc.)
 		return nil
 	}
 }
 
+// relOutputPath converts an absolute output path into a slash-separated path
+// relative to OutputDir, for use with the *os.Root methods.
+func (e *Extractor) relOutputPath(outputPath string) (string, error) {
+	rel, err := filepath.Rel(e.config.OutputDir, outputPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to relativize %q against output directory: %w", outputPath, err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid path: %s (escapes output directory)", outputPath)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+// mkdirParentsContained creates the parent directories of relPath inside root.
+func mkdirParentsContained(root *os.Root, relPath string) error {
+	return mkdirContained(root, path.Dir(relPath), 0755)
+}
+
+// mkdirContained creates dir and each missing parent inside root, refusing to
+// traverse a symlinked component.
+//
+// root.MkdirAll is not sufficient on its own: os.Root blocks a symlink that
+// leaves the root, but a symlink pointing to another path *inside* it is still
+// followed. An archive can exploit that in two entries — plant "link" -> "real"
+// (a legal relative symlink), then write "link/payload.txt" — and both entries
+// pass every lexical check individually. Walking component by component and
+// rejecting any symlink closes that, so an extracted path means what it says.
+func mkdirContained(root *os.Root, dir string, perm os.FileMode) error {
+	if dir == "." || dir == "/" || dir == "" {
+		return nil
+	}
+	var cur string
+	for _, comp := range strings.Split(dir, "/") {
+		if comp == "" || comp == "." {
+			continue
+		}
+		if cur == "" {
+			cur = comp
+		} else {
+			cur += "/" + comp
+		}
+
+		fi, err := root.Lstat(cur)
+		if err == nil {
+			if fi.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to write under %s: path component is a symlink", cur)
+			}
+			if !fi.IsDir() {
+				return fmt.Errorf("refusing to write under %s: path component is not a directory", cur)
+			}
+			continue
+		}
+		if err := root.Mkdir(cur, perm); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create directory %s: %w", cur, err)
+		}
+	}
+	return nil
+}
+
 // createDirectory creates a directory from tar header
-func (e *Extractor) createDirectory(path string, header *tar.Header) error {
+func (e *Extractor) createDirectory(root *os.Root, relPath string, header *tar.Header) error {
 	// Create directory with permissions
 	mode := os.FileMode(0755)
 	if e.config.PreservePermissions {
 		mode = header.FileInfo().Mode()
 	}
 
-	if err := os.MkdirAll(path, mode); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
+	// mode comes from a tar header and carries type bits that Mkdir rejects; keep
+	// only the permission bits.
+	if err := mkdirContained(root, relPath, mode.Perm()); err != nil {
+		return err
 	}
 
 	return nil
 }
 
 // createRegularFile creates a regular file from tar archive
-func (e *Extractor) createRegularFile(tarReader *tar.Reader, path string, header *tar.Header) error {
-	// Check if file exists
+func (e *Extractor) createRegularFile(tarReader *tar.Reader, root *os.Root, relPath string, header *tar.Header) error {
+	// Check if file exists. Lstat, not Stat: a dangling symlink at this path is
+	// still an existing entry, and Stat would follow it. (#341)
 	if !e.config.OverwriteExisting {
-		if _, err := os.Stat(path); err == nil {
+		if _, err := root.Lstat(relPath); err == nil {
 			e.stats.SkippedFiles++
 			return nil // Skip existing file
 		}
 	}
 
 	// Create parent directories
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return fmt.Errorf("failed to create parent directory: %w", err)
+	if err := mkdirParentsContained(root, relPath); err != nil {
+		return err
+	}
+
+	// Refuse to write through a symlink at the leaf. root already blocks a link
+	// pointing outside OutputDir; this also rejects one pointing back inside it,
+	// because an extraction should write the path the archive named rather than
+	// wherever a link happens to lead. (#341)
+	if fi, err := root.Lstat(relPath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to extract %s: destination path is a symlink", relPath)
 	}
 
 	// Create file
-	outFile, err := os.Create(path)
+	outFile, err := root.Create(relPath)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
@@ -285,31 +381,32 @@ func (e *Extractor) createRegularFile(tarReader *tar.Reader, path string, header
 
 // createSymlink creates a symbolic link from tar header.
 // The symlink target is validated to prevent path traversal via crafted archives (CWE-22).
-func (e *Extractor) createSymlink(path string, header *tar.Header) error {
+// outputPath is the absolute form of relPath, used only for target resolution.
+func (e *Extractor) createSymlink(root *os.Root, relPath, outputPath string, header *tar.Header) error {
 	// Validate symlink target: reject absolute paths and any ".." components.
 	if filepath.IsAbs(header.Linkname) || strings.Contains(header.Linkname, "..") {
 		return fmt.Errorf("invalid symlink target %q: must be relative and must not contain '..'", header.Linkname)
 	}
 
 	// Resolve what the symlink would point to and ensure it stays inside OutputDir.
-	resolvedTarget := filepath.Join(filepath.Dir(path), header.Linkname) // #nosec G305 -- containment is verified immediately below
+	resolvedTarget := filepath.Join(filepath.Dir(outputPath), header.Linkname) // #nosec G305 -- containment is verified immediately below
 	outputDir := filepath.Clean(e.config.OutputDir) + string(os.PathSeparator)
 	if !strings.HasPrefix(filepath.Clean(resolvedTarget)+string(os.PathSeparator), outputDir) {
 		return fmt.Errorf("symlink target %q escapes extraction directory", header.Linkname)
 	}
 
 	// Create parent directories
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return fmt.Errorf("failed to create parent directory: %w", err)
+	if err := mkdirParentsContained(root, relPath); err != nil {
+		return err
 	}
 
 	// Remove existing symlink if overwrite is enabled
 	if e.config.OverwriteExisting {
-		_ = os.Remove(path)
+		_ = root.Remove(relPath)
 	}
 
 	// Create symlink
-	if err := os.Symlink(header.Linkname, path); err != nil {
+	if err := root.Symlink(header.Linkname, relPath); err != nil {
 		return fmt.Errorf("failed to create symlink: %w", err)
 	}
 

--- a/pkg/extraction/extractor_test.go
+++ b/pkg/extraction/extractor_test.go
@@ -906,3 +906,469 @@ func TestExtractor_GetStats(t *testing.T) {
 			statsAfter.BytesExtracted, statsFromGetter.BytesExtracted)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Symlinked-destination containment (#341)
+//
+// The existing traversal test above covers a hostile *archive* ("../evil"). The
+// tests below cover a hostile *destination*: OutputDir already contains a
+// symlink, planted by an earlier extraction or by anything else with write
+// access to that directory. filepath.Join + HasPrefix is a lexical check and
+// cannot see it, so pre-fix the OS happily followed the link and wrote outside
+// OutputDir. (CWE-59)
+// ---------------------------------------------------------------------------
+
+// symlinkedOutputDir returns an OutputDir containing linkName -> an outside
+// directory, plus that outside directory, for asserting nothing escapes.
+func symlinkedOutputDir(t *testing.T, linkName string) (string, string) {
+	t.Helper()
+	base := t.TempDir()
+	out := filepath.Join(base, "out")
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatalf("failed to create output dir: %v", err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(out, linkName)); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+	return out, outside
+}
+
+// TestExtractor_SymlinkedParentDirRefused proves a pre-existing symlinked parent
+// directory in OutputDir is refused rather than followed.
+func TestExtractor_SymlinkedParentDirRefused(t *testing.T) {
+	out, outside := symlinkedOutputDir(t, "cache")
+
+	extractor, err := NewExtractor(&ExtractorConfig{
+		S3Client:  &mockS3Client{body: createTestTarGz(t, map[string]string{"cache/config.txt": "attacker content"})},
+		Bucket:    "test-bucket",
+		Key:       "archive.tar.gz",
+		OutputDir: out,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create extractor: %v", err)
+	}
+
+	_, err = extractor.Extract(context.Background())
+
+	escaped := filepath.Join(outside, "config.txt")
+	if _, statErr := os.Lstat(escaped); statErr == nil {
+		t.Fatalf("extraction escaped OutputDir: wrote through a symlinked parent to %s", escaped)
+	}
+	if err == nil {
+		t.Fatal("expected extraction to fail on a symlinked parent directory, got nil")
+	}
+}
+
+// TestExtractor_SymlinkedLeafRefused covers the leaf case: OutputDir already
+// holds a symlink AT the path being extracted, so writing through it truncates
+// a file outside OutputDir.
+func TestExtractor_SymlinkedLeafRefused(t *testing.T) {
+	base := t.TempDir()
+	out := filepath.Join(base, "out")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatalf("failed to create output dir: %v", err)
+	}
+	victim := filepath.Join(base, "victim.txt")
+	if err := os.WriteFile(victim, []byte("original"), 0o644); err != nil {
+		t.Fatalf("failed to create victim file: %v", err)
+	}
+	if err := os.Symlink(victim, filepath.Join(out, "file1.txt")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	extractor, err := NewExtractor(&ExtractorConfig{
+		S3Client:          &mockS3Client{body: createTestTarGz(t, map[string]string{"file1.txt": "attacker content"})},
+		Bucket:            "test-bucket",
+		Key:               "archive.tar.gz",
+		OutputDir:         out,
+		OverwriteExisting: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create extractor: %v", err)
+	}
+
+	_, err = extractor.Extract(context.Background())
+
+	got, readErr := os.ReadFile(victim)
+	if readErr != nil {
+		t.Fatalf("failed to read victim file: %v", readErr)
+	}
+	if string(got) != "original" {
+		t.Errorf("extraction overwrote a file outside OutputDir through a symlinked leaf: got %q", got)
+	}
+	if err == nil {
+		t.Fatal("expected extraction to fail on a symlinked leaf, got nil")
+	}
+}
+
+// TestExtractor_PlantedSymlinkNotFollowed is the two-entry version, and the one
+// that needs no pre-existing hostile state: entry 1 is a legitimate relative
+// symlink (which the archive is allowed to contain), entry 2 writes *through*
+// it. Both entries pass the lexical check individually.
+func TestExtractor_PlantedSymlinkNotFollowed(t *testing.T) {
+	base := t.TempDir()
+	out := filepath.Join(base, "out")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatalf("failed to create output dir: %v", err)
+	}
+	victimDir := filepath.Join(out, "real")
+	if err := os.MkdirAll(victimDir, 0o755); err != nil {
+		t.Fatalf("failed to create real dir: %v", err)
+	}
+
+	// link -> real (relative, inside OutputDir: accepted by createSymlink), then
+	// write link/payload.txt. A restore should write the path it was given.
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: "link", Typeflag: tar.TypeSymlink, Linkname: "real", Mode: 0777,
+	}); err != nil {
+		t.Fatalf("failed to write symlink header: %v", err)
+	}
+	content := "written through a symlink"
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: "link/payload.txt", Mode: 0644, Size: int64(len(content)),
+	}); err != nil {
+		t.Fatalf("failed to write file header: %v", err)
+	}
+	if _, err := tarWriter.Write([]byte(content)); err != nil {
+		t.Fatalf("failed to write content: %v", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+
+	extractor, err := NewExtractor(&ExtractorConfig{
+		S3Client:  &mockS3Client{body: io.NopCloser(bytes.NewReader(buf.Bytes()))},
+		Bucket:    "test-bucket",
+		Key:       "archive.tar.gz",
+		OutputDir: out,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create extractor: %v", err)
+	}
+
+	_, err = extractor.Extract(context.Background())
+
+	if _, statErr := os.Lstat(filepath.Join(victimDir, "payload.txt")); statErr == nil {
+		t.Error("extraction wrote through a planted symlink into real/")
+	}
+	if err == nil {
+		t.Fatal("expected extraction to fail writing through a planted symlink, got nil")
+	}
+}
+
+// TestExtractor_RealDirInOutputStillWorks is the control: an ordinary
+// pre-existing directory in OutputDir must stay writable. Without this, a fix
+// that refuses every existing parent would look correct.
+func TestExtractor_RealDirInOutputStillWorks(t *testing.T) {
+	out := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(out, "cache"), 0o755); err != nil {
+		t.Fatalf("failed to create cache dir: %v", err)
+	}
+
+	extractor, err := NewExtractor(&ExtractorConfig{
+		S3Client:  &mockS3Client{body: createTestTarGz(t, map[string]string{"cache/config.txt": "ordinary content"})},
+		Bucket:    "test-bucket",
+		Key:       "archive.tar.gz",
+		OutputDir: out,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create extractor: %v", err)
+	}
+
+	stats, err := extractor.Extract(context.Background())
+	if err != nil {
+		t.Fatalf("ordinary extraction into an existing real directory failed: %v", err)
+	}
+	if stats.FilesExtracted != 1 {
+		t.Errorf("expected 1 file extracted, got %d", stats.FilesExtracted)
+	}
+	got, err := os.ReadFile(filepath.Join(out, "cache", "config.txt"))
+	if err != nil {
+		t.Fatalf("failed to read extracted file: %v", err)
+	}
+	if string(got) != "ordinary content" {
+		t.Errorf("extracted content mismatch: got %q", got)
+	}
+}
+
+// TestExtractor_NonDirectoryParentRefused covers the other half of the parent
+// walk: a component that exists but is a regular file. Pre-fix os.MkdirAll would
+// have failed with a bare ENOTDIR from deep inside the call; the walk names the
+// offending component.
+func TestExtractor_NonDirectoryParentRefused(t *testing.T) {
+	out := t.TempDir()
+	// "cache" exists as a file, but the archive wants to treat it as a directory.
+	if err := os.WriteFile(filepath.Join(out, "cache"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("failed to create blocking file: %v", err)
+	}
+
+	extractor, err := NewExtractor(&ExtractorConfig{
+		S3Client:  &mockS3Client{body: createTestTarGz(t, map[string]string{"cache/config.txt": "payload"})},
+		Bucket:    "test-bucket",
+		Key:       "archive.tar.gz",
+		OutputDir: out,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create extractor: %v", err)
+	}
+
+	_, err = extractor.Extract(context.Background())
+	if err == nil {
+		t.Fatal("expected extraction to fail when a parent component is a regular file, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Errorf("expected a 'not a directory' diagnostic naming the component, got: %v", err)
+	}
+}
+
+// TestExtractor_SymlinkOverExistingRefused pins the skip path with Lstat rather
+// than Stat: a *dangling* symlink at the target path is an existing entry, and
+// Stat would follow it and report "not found", causing the extractor to write
+// through the link. With OverwriteExisting off, it must be skipped.
+func TestExtractor_DanglingSymlinkSkippedNotFollowed(t *testing.T) {
+	base := t.TempDir()
+	out := filepath.Join(base, "out")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatalf("failed to create output dir: %v", err)
+	}
+	// Points at a file that does not exist yet, inside the base but outside out.
+	victim := filepath.Join(base, "victim.txt")
+	if err := os.Symlink(victim, filepath.Join(out, "file1.txt")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	extractor, err := NewExtractor(&ExtractorConfig{
+		S3Client:          &mockS3Client{body: createTestTarGz(t, map[string]string{"file1.txt": "attacker content"})},
+		Bucket:            "test-bucket",
+		Key:               "archive.tar.gz",
+		OutputDir:         out,
+		OverwriteExisting: false,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create extractor: %v", err)
+	}
+
+	stats, err := extractor.Extract(context.Background())
+	if err != nil {
+		t.Fatalf("extraction should skip the existing entry, not fail: %v", err)
+	}
+	if stats.SkippedFiles != 1 {
+		t.Errorf("expected 1 skipped file, got %d", stats.SkippedFiles)
+	}
+	if _, statErr := os.Lstat(victim); statErr == nil {
+		t.Error("extraction created the dangling symlink's target outside OutputDir")
+	}
+}
+
+// TestExtractor_SymlinkOverwriteReplacesLink pins the overwrite branch of
+// createSymlink: an existing entry at the path is removed first, so the new link
+// is created rather than failing with EEXIST.
+func TestExtractor_SymlinkOverwriteReplacesLink(t *testing.T) {
+	out := t.TempDir()
+	if err := os.WriteFile(filepath.Join(out, "target.txt"), []byte("target"), 0o644); err != nil {
+		t.Fatalf("failed to create target: %v", err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(out, "link")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: "link", Typeflag: tar.TypeSymlink, Linkname: "target.txt", Mode: 0777,
+	}); err != nil {
+		t.Fatalf("failed to write symlink header: %v", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+
+	extractor, err := NewExtractor(&ExtractorConfig{
+		S3Client:          &mockS3Client{body: io.NopCloser(bytes.NewReader(buf.Bytes()))},
+		Bucket:            "test-bucket",
+		Key:               "archive.tar.gz",
+		OutputDir:         out,
+		OverwriteExisting: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create extractor: %v", err)
+	}
+
+	if _, err := extractor.Extract(context.Background()); err != nil {
+		t.Fatalf("overwriting an existing symlink should succeed: %v", err)
+	}
+	got, err := os.Readlink(filepath.Join(out, "link"))
+	if err != nil {
+		t.Fatalf("failed to read link: %v", err)
+	}
+	if got != "target.txt" {
+		t.Errorf("expected link -> target.txt, got %q", got)
+	}
+}
+
+// TestExtractor_OutputDirCreatedIfMissing pins that Extract creates OutputDir
+// before opening the root — the extractor accepts a destination that does not
+// exist yet, and os.OpenRoot would fail on it.
+func TestExtractor_OutputDirCreatedIfMissing(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "nested", "does-not-exist")
+
+	extractor, err := NewExtractor(&ExtractorConfig{
+		S3Client:  &mockS3Client{body: createTestTarGz(t, map[string]string{"file1.txt": "payload"})},
+		Bucket:    "test-bucket",
+		Key:       "archive.tar.gz",
+		OutputDir: out,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create extractor: %v", err)
+	}
+
+	if _, err := extractor.Extract(context.Background()); err != nil {
+		t.Fatalf("extraction into a missing output directory failed: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(out, "file1.txt"))
+	if err != nil {
+		t.Fatalf("failed to read extracted file: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Errorf("content mismatch: got %q", got)
+	}
+}
+
+// TestRelOutputPath exercises the root-relative conversion directly. Its
+// escape branch is unreachable through Extract — the lexical check in extractFile
+// rejects those entries first — so it is only reachable here. It exists as a
+// backstop in case that ordering ever changes, and an untested backstop is not
+// one.
+func TestRelOutputPath(t *testing.T) {
+	e := &Extractor{config: &ExtractorConfig{OutputDir: "/out"}}
+
+	tests := []struct {
+		name       string
+		outputPath string
+		want       string
+		wantErr    bool
+	}{
+		{name: "nested entry", outputPath: "/out/a/b/c.txt", want: "a/b/c.txt"},
+		{name: "top-level entry", outputPath: "/out/c.txt", want: "c.txt"},
+		{name: "output dir itself", outputPath: "/out", wantErr: true},
+		{name: "escapes output dir", outputPath: "/elsewhere/c.txt", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := e.relOutputPath(tt.outputPath)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %q, got %q", tt.outputPath, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMkdirContained exercises the parent walk directly, including the no-op
+// cases that a tar archive cannot produce.
+func TestMkdirContained(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open root: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	// No-op inputs must not error.
+	for _, dir := range []string{".", "/", ""} {
+		if err := mkdirContained(root, dir, 0755); err != nil {
+			t.Errorf("mkdirContained(%q) = %v, want nil", dir, err)
+		}
+	}
+
+	// Nested creation, then idempotent re-creation over real directories.
+	for i := 0; i < 2; i++ {
+		if err := mkdirContained(root, "a/b/c", 0755); err != nil {
+			t.Fatalf("mkdirContained(a/b/c) attempt %d: %v", i+1, err)
+		}
+	}
+	fi, err := root.Stat("a/b/c")
+	if err != nil {
+		t.Fatalf("stat a/b/c: %v", err)
+	}
+	if !fi.IsDir() {
+		t.Error("a/b/c is not a directory")
+	}
+}
+
+// TestExtractor_SymlinkTargetEscapes pins the target-validation branches of
+// createSymlink: an absolute target, a "..", and a relative target that stays
+// syntactically clean but resolves outside OutputDir.
+func TestExtractor_SymlinkTargetEscapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		linkname string
+		wantMsg  string
+	}{
+		{name: "absolute target", linkname: "/etc/passwd", wantMsg: "must be relative"},
+		{name: "dotdot target", linkname: "../outside", wantMsg: "must be relative"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			gzWriter := gzip.NewWriter(&buf)
+			tarWriter := tar.NewWriter(gzWriter)
+			if err := tarWriter.WriteHeader(&tar.Header{
+				Name: "link", Typeflag: tar.TypeSymlink, Linkname: tt.linkname, Mode: 0777,
+			}); err != nil {
+				t.Fatalf("failed to write symlink header: %v", err)
+			}
+			if err := tarWriter.Close(); err != nil {
+				t.Fatalf("failed to close tar writer: %v", err)
+			}
+			if err := gzWriter.Close(); err != nil {
+				t.Fatalf("failed to close gzip writer: %v", err)
+			}
+
+			out := t.TempDir()
+			extractor, err := NewExtractor(&ExtractorConfig{
+				S3Client:  &mockS3Client{body: io.NopCloser(bytes.NewReader(buf.Bytes()))},
+				Bucket:    "test-bucket",
+				Key:       "archive.tar.gz",
+				OutputDir: out,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create extractor: %v", err)
+			}
+
+			_, err = extractor.Extract(context.Background())
+			if err == nil {
+				t.Fatalf("expected symlink target %q to be rejected, got nil", tt.linkname)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("expected error containing %q, got: %v", tt.wantMsg, err)
+			}
+			if _, statErr := os.Lstat(filepath.Join(out, "link")); statErr == nil {
+				t.Error("the rejected symlink was created anyway")
+			}
+		})
+	}
+}

--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -286,11 +287,143 @@ func (se *SelectiveExtractor) restorePath(destDir, entryPath string) (string, er
 // the time of the restore. A failure here is deliberately non-fatal: the file
 // content is already correct on disk, and refusing the restore over a timestamp
 // would be worse than an imprecise timestamp. (#311)
-func restoreModTime(path string, modTime time.Time) {
+func restoreModTime(root *os.Root, relPath string, modTime time.Time) {
 	if modTime.IsZero() {
 		return
 	}
-	_ = os.Chtimes(path, modTime, modTime)
+	_ = root.Chtimes(relPath, modTime, modTime)
+}
+
+// destRoot opens destDir as an os.Root, the containment boundary every restore
+// write goes through (#341).
+//
+// restorePath's own check is LEXICAL — it strips volume names, leading slashes
+// and `.`/`..` segments and confirms the joined result is textually under
+// destDir. That closes the crafted-manifest traversal of #282, but neither
+// filepath.Abs nor filepath.Clean resolves symlinks, so a lexically-contained
+// path can still escape the *filesystem* when a component inside destDir is a
+// pre-existing symlink pointing elsewhere (CWE-59). With
+// `destDir/cache -> /etc`, an ordinary entry `cache/passwd` passes containment
+// and the OS follows the link. The hostile input is the destination's shape, not
+// the manifest — a world-writable staging dir, a shared scratch mount, or an
+// unpacked tarball that shipped its own symlinks is enough.
+//
+// os.Root resolves every component with openat(2) relative to a held directory
+// descriptor and refuses any component that leaves the root. That also closes
+// the TOCTOU window a check-then-write approach leaves open: a `Lstat` walk can
+// verify a parent is a real directory and have it replaced with a symlink before
+// the write lands, whereas os.Root re-validates at each open. It is the standard
+// library's answer to exactly this class, and it behaves consistently across all
+// the platforms goreleaser builds (linux, darwin, windows).
+func destRoot(destDir string) (*os.Root, error) {
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return nil, fmt.Errorf("create destination directory: %w", err)
+	}
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		return nil, fmt.Errorf("open destination directory: %w", err)
+	}
+	return root, nil
+}
+
+// destRelPath converts the absolute output path restorePath produced back into a
+// slash-separated path relative to destDir, for use with os.Root's methods
+// (which take root-relative names). restorePath has already guaranteed lexical
+// containment, so a failure here means a caller passed mismatched paths.
+func destRelPath(destDir, outPath string) (string, error) {
+	rel, err := filepath.Rel(destDir, outPath)
+	if err != nil {
+		return "", fmt.Errorf("relativize %q against %q: %w", outPath, destDir, err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("refusing to restore %q: path escapes destination", outPath)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+// prepareParents creates the parent directories of relPath inside root, walking
+// one component at a time and refusing any that already exists as a symlink. An
+// ordinary pre-existing directory is reused as usual.
+//
+// root.MkdirAll would not be enough. os.Root refuses a symlink that leaves the
+// root — the escape this issue is about — but a symlink pointing to another path
+// *inside* destDir is still followed, so `dest/cache -> real` would silently
+// divert `cache/config.txt` into `real/`. That is a correctness failure rather
+// than an escape: a restore must reproduce the paths the manifest recorded.
+func prepareParents(root *os.Root, relPath string) error {
+	dir := path.Dir(relPath)
+	if dir == "." || dir == "/" || dir == "" {
+		return nil
+	}
+	var cur string
+	for _, comp := range strings.Split(dir, "/") {
+		if comp == "" || comp == "." {
+			continue
+		}
+		if cur == "" {
+			cur = comp
+		} else {
+			cur += "/" + comp
+		}
+
+		fi, err := root.Lstat(cur)
+		if err == nil {
+			if fi.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to restore under %s: path component is a symlink", cur)
+			}
+			if !fi.IsDir() {
+				return fmt.Errorf("refusing to restore under %s: path component is not a directory", cur)
+			}
+			continue
+		}
+		if err := root.Mkdir(cur, 0755); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("mkdir %s: %w", cur, err)
+		}
+	}
+	return nil
+}
+
+// createContained opens relPath for writing inside root, refusing to write
+// through a symlink at the leaf.
+//
+// os.Root alone already refuses a leaf symlink that points outside the root —
+// that is the escape this issue is about. The extra Lstat rejects a leaf symlink
+// pointing *inside* the root too, because a restore should write the file it was
+// asked to write rather than through whatever link happens to sit at that path.
+// That second case is a correctness guard, not a containment one, and it carries
+// an unavoidable TOCTOU window (the link could be introduced between the Lstat
+// and the open). The containment guarantee does not depend on it: os.Root
+// re-validates every component at open time, so even if the race is won the
+// write still cannot leave destDir. O_NOFOLLOW would close the window but is not
+// portable — it is absent on Windows, which goreleaser builds.
+//
+// O_TRUNC preserves the existing overwrite behavior for real files.
+func createContained(root *os.Root, relPath string) (*os.File, error) {
+	if fi, err := root.Lstat(relPath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to restore %s: destination path is a symlink", relPath)
+	}
+	f, err := root.OpenFile(relPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", relPath, err)
+	}
+	return f, nil
+}
+
+// writeContained writes data to relPath inside root with the same symlink
+// refusal as createContained.
+func writeContained(root *os.Root, relPath string, data []byte) error {
+	f, err := createContained(root, relPath)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write %s: %w", relPath, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("write %s: %w", relPath, err)
+	}
+	return nil
 }
 
 // relativeEntryPath returns entryPath relative to the manifest's SourcePath (the
@@ -426,9 +559,13 @@ func (se *SelectiveExtractor) BatchRestore(ctx context.Context, targets []string
 		chunkMap[key].files = append(chunkMap[key].files, entry)
 	}
 
-	if err := os.MkdirAll(destDir, 0755); err != nil {
-		return nil, fmt.Errorf("create destination directory: %w", err)
+	// #341: every write below goes through this root, so a symlinked component
+	// inside destDir is refused rather than followed.
+	root, err := destRoot(destDir)
+	if err != nil {
+		return nil, err
 	}
+	defer func() { _ = root.Close() }()
 
 	// Direct-upload manifests have no chunks: each file was stored as its own S3
 	// object (the object at FileEntry.S3Key IS the raw file, not a tar.zst chunk).
@@ -450,7 +587,7 @@ func (se *SelectiveExtractor) BatchRestore(ctx context.Context, targets []string
 
 		if directMode {
 			// One S3 object == one file; write the raw bytes.
-			restored, written, err := se.writeDirectFiles(data, grp.files, destDir)
+			restored, written, err := se.writeDirectFiles(data, grp.files, root, destDir)
 			stats.Restored += int64(restored)
 			stats.Bytes += written
 			if err != nil {
@@ -459,7 +596,7 @@ func (se *SelectiveExtractor) BatchRestore(ctx context.Context, targets []string
 			continue
 		}
 
-		restored, written, err := se.extractFromChunkData(data, grp.files, destDir)
+		restored, written, err := se.extractFromChunkData(data, grp.files, root, destDir)
 		stats.Restored += int64(restored)
 		stats.Bytes += written
 		if err != nil {
@@ -501,7 +638,7 @@ func (se *SelectiveExtractor) resolveEntry(target string) *FileEntry {
 // writeDirectFiles writes direct-upload objects (raw file bytes, one object per
 // file) to destDir. The output path is the file's basename (manifests may store
 // an absolute source path; we never write outside destDir). (Issue #228)
-func (se *SelectiveExtractor) writeDirectFiles(data []byte, files []*FileEntry, destDir string) (int, int64, error) {
+func (se *SelectiveExtractor) writeDirectFiles(data []byte, files []*FileEntry, root *os.Root, destDir string) (int, int64, error) {
 	var restored int
 	var totalBytes int64
 	for _, entry := range files {
@@ -516,13 +653,19 @@ func (se *SelectiveExtractor) writeDirectFiles(data []byte, files []*FileEntry, 
 		if err != nil {
 			return restored, totalBytes, err
 		}
-		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
-			return restored, totalBytes, fmt.Errorf("mkdir for %s: %w", outPath, err)
+		// #341: resolve through the root so a symlinked parent or leaf inside
+		// destDir is refused instead of followed.
+		rel, err := destRelPath(destDir, outPath)
+		if err != nil {
+			return restored, totalBytes, err
 		}
-		if err := os.WriteFile(outPath, data, 0644); err != nil {
-			return restored, totalBytes, fmt.Errorf("write %s: %w", outPath, err)
+		if err := prepareParents(root, rel); err != nil {
+			return restored, totalBytes, err
 		}
-		restoreModTime(outPath, entry.ModTime)
+		if err := writeContained(root, rel, data); err != nil {
+			return restored, totalBytes, err
+		}
+		restoreModTime(root, rel, entry.ModTime)
 		restored++
 		totalBytes += int64(len(data))
 	}
@@ -582,7 +725,7 @@ func (se *SelectiveExtractor) downloadChunk(ctx context.Context, s3Key string) (
 // extractFromChunkData decompresses data (a compressed tar archive) and writes
 // the requested files to destDir. Returns the count of files written and total
 // bytes written.
-func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEntry, destDir string) (int, int64, error) {
+func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEntry, root *os.Root, destDir string) (int, int64, error) {
 	want := make(map[string]*FileEntry, len(files))
 	for _, f := range files {
 		want[f.Path] = f
@@ -632,8 +775,13 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 		if err != nil {
 			return restored, totalBytes, err
 		}
-		if mkErr := os.MkdirAll(filepath.Dir(outPath), 0755); mkErr != nil {
-			return restored, totalBytes, fmt.Errorf("mkdir for %s: %w", outPath, mkErr)
+		// #341: same root-relative, symlink-refusing write as the direct path.
+		rel, err := destRelPath(destDir, outPath)
+		if err != nil {
+			return restored, totalBytes, err
+		}
+		if mkErr := prepareParents(root, rel); mkErr != nil {
+			return restored, totalBytes, mkErr
 		}
 
 		verifyThis := se.verify && entry.Checksum != "" &&
@@ -653,18 +801,18 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 			if se.checksumMismatch(entry, content) {
 				return restored, totalBytes, fmt.Errorf("checksum mismatch for %s: stored data does not match manifest", entry.Path)
 			}
-			if err := os.WriteFile(outPath, content, 0644); err != nil {
-				return restored, totalBytes, fmt.Errorf("write %s: %w", outPath, err)
+			if err := writeContained(root, rel, content); err != nil {
+				return restored, totalBytes, err
 			}
-			restoreModTime(outPath, entry.ModTime)
+			restoreModTime(root, rel, entry.ModTime)
 			restored++
 			totalBytes += int64(len(content))
 			continue
 		}
 
-		f, err := os.Create(outPath)
+		f, err := createContained(root, rel)
 		if err != nil {
-			return restored, totalBytes, fmt.Errorf("create %s: %w", outPath, err)
+			return restored, totalBytes, err
 		}
 		// #337: CopyN, not Copy. A tar entry cut short mid-stream is
 		// indistinguishable from EOF to io.Copy, which returns nil having
@@ -682,7 +830,7 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 		if err != nil {
 			// Remove the partial file. An absent file is a correct, loud
 			// outcome; a short one that looks complete is not.
-			_ = os.Remove(outPath)
+			_ = root.Remove(rel)
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				return restored, totalBytes, fmt.Errorf(
 					"truncated archive: %s declares %d bytes but the stored chunk ended after %d",
@@ -690,7 +838,7 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 			}
 			return restored, totalBytes, fmt.Errorf("write %s: %w", outPath, err)
 		}
-		restoreModTime(outPath, entry.ModTime)
+		restoreModTime(root, rel, entry.ModTime)
 		restored++
 		totalBytes += written
 	}

--- a/pkg/manifest/batch_restore_test.go
+++ b/pkg/manifest/batch_restore_test.go
@@ -1161,3 +1161,257 @@ func TestDeepVerify_DoesNotCertifyABucketItNeverRead(t *testing.T) {
 	assert.Equal(t, []string{newBucket}, client.requestedBuckets(),
 		"deep verify must not certify bytes it read from a different bucket")
 }
+
+// ---------------------------------------------------------------------------
+// #341: symlinked parents in the destination
+// ---------------------------------------------------------------------------
+
+// The #282 containment check in restorePath is LEXICAL: it strips volume names,
+// leading slashes and `.`/`..` segments, then confirms the joined result is
+// textually under destDir. filepath.Abs and filepath.Clean do not resolve
+// symlinks, so a path that is lexically contained can still be *filesystem*
+// escaping when a component of destDir's interior is a pre-existing symlink to
+// somewhere else (CWE-59). A restore into an attacker-prepared destination —
+// a world-writable staging dir, a shared scratch mount, an unpacked tarball
+// that shipped its own symlinks — writes through the link.
+//
+// These tests operate on the destination side, not the manifest side. The
+// manifest paths below are entirely ordinary; the hostile input is the
+// destination's shape.
+
+// symlinkTestDest builds a destination directory in which `linkName` is a
+// symlink pointing at an outside directory, and returns (destDir, outsideDir).
+func symlinkTestDest(t *testing.T, linkName string) (string, string) {
+	t.Helper()
+	base := t.TempDir()
+	dest := filepath.Join(base, "dest")
+	outside := filepath.Join(base, "outside")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+	require.NoError(t, os.MkdirAll(outside, 0o755))
+	if err := os.Symlink(outside, filepath.Join(dest, linkName)); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+	return dest, outside
+}
+
+// assertNoEscape fails when anything was written through the symlink into the
+// outside directory. It is the assertion that matters: bytes landing outside
+// destDir is the finding.
+func assertNoEscape(t *testing.T, outside, name string) {
+	t.Helper()
+	escaped := filepath.Join(outside, name)
+	if _, err := os.Lstat(escaped); err == nil {
+		t.Fatalf("restore escaped the destination: wrote through a symlinked parent to %s", escaped)
+	}
+}
+
+// assertRefused pins the other half of the contract: the refusal must be
+// *reported*, not swallowed. BatchRestore deliberately counts per-file failures
+// and continues instead of returning an error (a partial restore should finish),
+// so the signal is stats.Failed — which the CLI's restoreOutcomeError turns into
+// a nonzero exit code (#336). Silently skipping the file would leave a user
+// believing a restore succeeded when a file was withheld, which is why
+// Failed==1 matters here as much as the containment itself.
+func assertRefused(t *testing.T, stats *RestoreStats, err error) {
+	t.Helper()
+	require.NoError(t, err, "a refused file is a per-file failure, not a fatal error")
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(0), stats.Restored, "nothing should have been restored")
+	assert.Equal(t, int64(1), stats.Failed, "the refused file must be counted as failed")
+}
+
+// TestBatchRestore_SymlinkedParentDirect proves the direct-storage path refuses
+// to write through a symlinked parent directory in the destination.
+func TestBatchRestore_SymlinkedParentDirect(t *testing.T) {
+	dest, outside := symlinkTestDest(t, "cache")
+
+	content := []byte("direct payload")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		SourcePath: "/src",
+		Files:      []FileEntry{{Path: "/src/cache/config.txt", Size: int64(len(content)), S3Key: "k"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": content}}
+
+	stats, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{"config.txt"}, dest)
+
+	assertNoEscape(t, outside, "config.txt")
+	assertRefused(t, stats, err)
+}
+
+// TestBatchRestore_SymlinkedParentChunked is the chunked-storage twin: the two
+// storage layouts have separate write sites (writeDirectFiles vs the tar loop),
+// so a fix applied to only one leaves the other escapable.
+func TestBatchRestore_SymlinkedParentChunked(t *testing.T) {
+	dest, outside := symlinkTestDest(t, "cache")
+
+	content := []byte("chunked payload")
+	srcPath := "/src/cache/config.txt"
+	chunk := makeTarZst(t, map[string][]byte{srcPath: content})
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "zstd", TotalChunks: 1,
+		SourcePath: "/src",
+		Chunks:     []ChunkEntry{{ID: 0, S3Key: "c0", FileCount: 1, FilePaths: []string{srcPath}}},
+		Files:      []FileEntry{{Path: srcPath, Size: int64(len(content)), S3Key: "c0"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"c0": chunk}}
+
+	stats, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{srcPath}, dest)
+
+	assertNoEscape(t, outside, "config.txt")
+	assertRefused(t, stats, err)
+}
+
+// TestBatchRestore_SymlinkedLeafDirect covers the leaf case: the destination
+// already contains a symlink AT the path being restored. Writing through it
+// truncates and overwrites the link target, which is a file outside destDir.
+func TestBatchRestore_SymlinkedLeafDirect(t *testing.T) {
+	base := t.TempDir()
+	dest := filepath.Join(base, "dest")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+	outsideFile := filepath.Join(base, "victim.txt")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("original"), 0o644))
+	if err := os.Symlink(outsideFile, filepath.Join(dest, "config.txt")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	content := []byte("attacker content")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		SourcePath: "/src",
+		Files:      []FileEntry{{Path: "/src/config.txt", Size: int64(len(content)), S3Key: "k"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": content}}
+
+	stats, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{"config.txt"}, dest)
+
+	got, rerr := os.ReadFile(outsideFile)
+	require.NoError(t, rerr)
+	assert.Equal(t, []byte("original"), got,
+		"restore overwrote a file outside destDir through a symlinked leaf")
+	assertRefused(t, stats, err)
+}
+
+// TestBatchRestore_SymlinkedLeafChunked is the chunked twin of the leaf case.
+func TestBatchRestore_SymlinkedLeafChunked(t *testing.T) {
+	base := t.TempDir()
+	dest := filepath.Join(base, "dest")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+	outsideFile := filepath.Join(base, "victim.txt")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("original"), 0o644))
+	if err := os.Symlink(outsideFile, filepath.Join(dest, "config.txt")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	content := []byte("attacker content")
+	srcPath := "/src/config.txt"
+	chunk := makeTarZst(t, map[string][]byte{srcPath: content})
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "zstd", TotalChunks: 1,
+		SourcePath: "/src",
+		Chunks:     []ChunkEntry{{ID: 0, S3Key: "c0", FileCount: 1, FilePaths: []string{srcPath}}},
+		Files:      []FileEntry{{Path: srcPath, Size: int64(len(content)), S3Key: "c0"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"c0": chunk}}
+
+	stats, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{srcPath}, dest)
+
+	got, rerr := os.ReadFile(outsideFile)
+	require.NoError(t, rerr)
+	assert.Equal(t, []byte("original"), got,
+		"restore overwrote a file outside destDir through a symlinked leaf (chunked)")
+	assertRefused(t, stats, err)
+}
+
+// TestBatchRestore_OrdinaryRestoreStillWorks is the control: the containment
+// hardening must not break a normal restore into a clean destination, including
+// creating nested directories that don't exist yet.
+func TestBatchRestore_OrdinaryRestoreStillWorks(t *testing.T) {
+	content := []byte("ordinary content")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		SourcePath: "/src",
+		Files:      []FileEntry{{Path: "/src/a/b/c/report.txt", Size: int64(len(content)), S3Key: "k"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": content}}
+
+	dest := t.TempDir()
+	stats, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{"report.txt"}, dest)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.Restored)
+
+	got, err := os.ReadFile(filepath.Join(dest, "a/b/c/report.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+// TestBatchRestore_RealDirInDestStillWorks pins the distinction that matters:
+// an ordinary (non-symlink) directory that already exists in the destination is
+// fine to write into. A fix that rejected all pre-existing parents would pass
+// the escape tests above while breaking every incremental restore.
+func TestBatchRestore_RealDirInDestStillWorks(t *testing.T) {
+	dest := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dest, "cache"), 0o755))
+
+	content := []byte("into an existing real dir")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		SourcePath: "/src",
+		Files:      []FileEntry{{Path: "/src/cache/config.txt", Size: int64(len(content)), S3Key: "k"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": content}}
+
+	stats, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{"config.txt"}, dest)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.Restored)
+
+	got, err := os.ReadFile(filepath.Join(dest, "cache/config.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+// TestBatchRestore_InRootSymlinkedParent covers the case os.Root does NOT catch
+// on its own: a symlinked parent whose target is *inside* destDir. os.Root only
+// refuses links that leave the root, so this one is still followed — the file
+// lands somewhere other than the path the manifest named. That is a correctness
+// bug rather than an escape, and the same gap the extractor's parent walk closes.
+func TestBatchRestore_InRootSymlinkedParent(t *testing.T) {
+	base := t.TempDir()
+	dest := filepath.Join(base, "dest")
+	real := filepath.Join(dest, "real")
+	require.NoError(t, os.MkdirAll(real, 0o755))
+	// A *relative* target is the point: os.Root rejects an absolute symlink
+	// outright, so an absolute link here would pass for the wrong reason.
+	if err := os.Symlink("real", filepath.Join(dest, "cache")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	content := []byte("payload")
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "b", CompressionType: "none", TotalChunks: 0,
+		SourcePath: "/src",
+		Files:      []FileEntry{{Path: "/src/cache/config.txt", Size: int64(len(content)), S3Key: "k"}},
+	}
+	m.TotalFiles = 1
+	client := &mockS3Client{chunks: map[string][]byte{"k": content}}
+
+	stats, err := NewSelectiveExtractor(m, client, 0).
+		BatchRestore(context.Background(), []string{"config.txt"}, dest)
+
+	if _, statErr := os.Lstat(filepath.Join(real, "config.txt")); statErr == nil {
+		t.Fatal("restore followed an in-root symlinked parent: file landed in real/, not cache/")
+	}
+	assertRefused(t, stats, err)
+}

--- a/tests/e2e/commands_test.go
+++ b/tests/e2e/commands_test.go
@@ -231,3 +231,73 @@ func splitUploadURL(t *testing.T, url string) (bucket, uploadID string) {
 	uploadID = url[idx+len("/uploads/"):]
 	return bucket, uploadID
 }
+
+// TestRestore_RefusesSymlinkedDestination is the binary-level form of #341: the
+// destination directory already contains a symlink pointing outside itself, as
+// could be left by any process with write access there. The restore must refuse
+// and exit non-zero, and nothing may appear at the link target.
+//
+// The unit tests in pkg/manifest pin the write helpers; this pins the contract a
+// user actually experiences, including the exit code — a refusal reported only in
+// stats but exiting 0 would look like a successful restore.
+func TestRestore_RefusesSymlinkedDestination(t *testing.T) {
+	url := uploadTree(t, "symlink-dest-e2e", map[string]string{
+		"cache/config.txt": "original payload\n",
+	})
+
+	base := t.TempDir()
+	dest := filepath.Join(base, "dest")
+	outside := filepath.Join(base, "outside")
+	for _, d := range []string{dest, outside} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.Symlink(outside, filepath.Join(dest, "cache")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	out, err := runCargoshipAllowErr(t, "restore", url, dest, "--file", "config.txt", "--region", "us-east-1")
+
+	if escaped := filepath.Join(outside, "config.txt"); !fileMissing(t, escaped) {
+		t.Fatalf("restore escaped the destination: wrote through a symlink to %s\n%s", escaped, out)
+	}
+	if err == nil {
+		t.Fatalf("restore into a symlinked destination exited 0; it must fail\n%s", out)
+	}
+}
+
+// TestRestore_CleanDestinationStillWorks is the companion control: the same
+// archive into an untouched destination must still round-trip byte-identically,
+// confirming the containment work did not break the ordinary path.
+func TestRestore_CleanDestinationStillWorks(t *testing.T) {
+	want := "original payload\n"
+	url := uploadTree(t, "clean-dest-e2e", map[string]string{
+		"cache/config.txt": want,
+	})
+
+	dest := t.TempDir()
+	runCargoship(t, "restore", url, dest, "--file", "config.txt", "--region", "us-east-1")
+
+	got, err := os.ReadFile(findFileByBase(t, dest, "config.txt"))
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("restored content mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// fileMissing reports whether path does not exist, failing on any other error so
+// a permission problem is not silently read as "nothing escaped".
+func fileMissing(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Lstat(path)
+	if err == nil {
+		return false
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("lstat %s: %v", path, err)
+	}
+	return true
+}


### PR DESCRIPTION
Closes #341 — audit finding **CSH-002**, the only finding from the 2026-08-02 audit that reaches the released CLI.

Stacked on #343 (Phase 1). Base is `fix/340-remove-distributed-surface`, so the diff here is only the symlink work; retarget to `main` once #343 merges.

## The defect

`restore` and `extract` both validated containment **lexically** — `filepath.Join` then `strings.HasPrefix` against the destination. That stops a hostile *path* (`../evil`, fixed in #282) but not a hostile *destination*. Given a pre-existing `dest/cache -> /elsewhere`, the entry `cache/config.txt` passed every check and the OS followed the link, writing outside the destination and truncating whatever it found. CWE-59.

Local escalation, not remotely triggerable — it needs a symlink pre-placed in the restore destination. But restore is the one place CargoShip writes attacker-influenced paths.

## The fix, and why it differs from the plan

Every write now goes through an **`os.Root`** opened on the destination.

The issue and plan called for an `os.Lstat` parent walk. That pattern is **racy by construction**: it can confirm a parent is a real directory and have it swapped for a symlink before the write lands. `os.Root` re-validates every component at open time, so it closes the race rather than narrowing it, and it is portable to every target goreleaser builds. `O_NOFOLLOW` is not — it does not exist on Windows, which is what made the first attempt fail to compile.

**`os.Root` alone was not sufficient**, and the tests are what caught it. It refuses a symlink leaving the root, but one pointing to another path *inside* it is still followed — so `dest/cache -> real` silently diverted `cache/config.txt` into `real/`. Not an escape, but a restore must reproduce the paths the manifest recorded. Parent components are now walked one at a time with any symlink refused.

In `pkg/extraction` that also closes a **two-entry archive attack needing no pre-existing state**: plant `link -> real` (a legal relative symlink), then write `link/payload.txt`. Both entries pass every lexical check individually.

A refused file counts in `RestoreStats.Failed`, which the CLI already converts to a non-zero exit (#336) — so a withheld file cannot read as a clean restore.

## The test gap is the finding

`pkg/manifest` had traversal tests and **not one symlink test**, which is why this survived #282.

| Test | Layer |
|---|---|
| symlinked parent, symlinked leaf, in-root symlinked parent | `pkg/manifest`, direct + chunked |
| same three + planted-symlink, non-directory parent, dangling-symlink skip | `pkg/extraction` |
| `TestRestore_RefusesSymlinkedDestination` | e2e, real binary, asserts exit code |

Every escape test was watched **failing** against the pre-fix tree with `-count=1` — including at binary level, where the pre-fix run wrote `attacker content` outside the destination. Controls accompany each (a pre-existing *real* directory must stay writable), so a fix that simply refused everything could not have passed.

The coverage ratchet then caught `pkg/extraction` at 83% against its 85% floor — the new refusal branches were untested. Covered rather than floor-lowered; that pass also pinned the dangling-symlink skip (`Lstat`, not `Stat` — `Stat` follows the link and reports "not found", so the extractor would write through it).

## Verification

- `go build ./...`, `go vet`, `staticcheck`, `golangci-lint` — clean
- `go test ./...` full, `-tags integration`, `-tags e2e` — all green
- `scripts/ci/check-build-tags.sh` — default plus 5 tag sets compile
- coverage ratchet green; `pkg/extraction` 83% → 86.8%; quality report A+ (91.7)

## Scope note

`pkg/extraction` is reached only via `pkg/migration`, **not** the restore path — the audit conflated the two. Fixed anyway: same defect.