### PR TITLE
fix(security): verify the gitleaks download; gate the SECURITY.md support table (#342)

### DIFF
--- a/.github/workflows/doc-consistency.yml
+++ b/.github/workflows/doc-consistency.yml
@@ -10,6 +10,9 @@ on:
       - 'ROADMAP.md'
       - 'CLAUDE.md'
       - 'docs/**'
+      # The canonical version source: a release bump touching only this file would
+      # otherwise skip this workflow at exactly the moment the doc tables go stale.
+      - 'internal/version/version.txt'
       - 'scripts/ci/check-doc-versions.sh'
       - '.github/workflows/doc-consistency.yml'
   pull_request:
@@ -21,6 +24,9 @@ on:
       - 'ROADMAP.md'
       - 'CLAUDE.md'
       - 'docs/**'
+      # The canonical version source: a release bump touching only this file would
+      # otherwise skip this workflow at exactly the moment the doc tables go stale.
+      - 'internal/version/version.txt'
       - 'scripts/ci/check-doc-versions.sh'
       - '.github/workflows/doc-consistency.yml'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -78,11 +78,21 @@ jobs:
       # Run the gitleaks BINARY directly (MIT-licensed, free for orgs). The
       # gitleaks-action wrapper requires a paid license for GitHub organizations,
       # which we don't use. `detect` scans full history; non-zero exit on leaks.
+      # The tarball SHA-256 is pinned and verified BEFORE extraction. Piping curl
+      # straight into tar, as this step used to, executes whatever the URL serves
+      # — a compromised release asset or a MITM would run in CI with repo access.
+      # Update both VER and SHA256 together; the value comes from the release's
+      # own gitleaks_${VER}_checksums.txt.
       - name: Install gitleaks
         run: |
+          set -euo pipefail
           VER=8.21.2
-          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_linux_x64.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
+          SHA256=5bc41815076e6ed6ef8fbecc9d9b75bcae31f39029ceb55da08086315316e3ba
+          curl -sSLo gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_linux_x64.tar.gz"
+          echo "${SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz -C /usr/local/bin gitleaks
+          rm -f gitleaks.tar.gz
           gitleaks version
       - name: gitleaks detect
         run: gitleaks detect --source . --redact --verbose --exit-code 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The gitleaks binary is now checksum-verified before it runs** (#342). The
+  secret-scanning job piped `curl` straight into `tar`, executing whatever the URL
+  served — a tampered release asset or a MITM would have run in CI with repository
+  access, inside the job whose purpose is to catch leaked secrets. The tarball's
+  SHA-256 is now pinned and checked before extraction, keeping the deliberate
+  choice of the MIT-licensed binary over the wrapper action, which requires a paid
+  license for organizations. The pinned digest was cross-checked against the
+  release's own published `checksums.txt` rather than a single local download.
+  Auditing the rest of CI found no other unverified download.
+
+### Fixed
+
+- **`SECURITY.md` no longer advertises a version that has not shipped for six
+  releases** (#342). Its supported-versions table claimed `0.13.x` while 0.19.0
+  was current, telling users a version they were not running was the supported one
+  — in the one table in the repo where being wrong is itself a security problem.
+  Corrected to `0.19.x`, and `scripts/ci/check-doc-versions.sh` now gates it as a
+  fifth check, so it cannot drift again. The check targets the *minor* line, so a
+  patch release does not require editing the file.
+  - The doc-consistency workflow's path filter did not include
+    `internal/version/version.txt`, so a release that bumped only the canonical
+    version would have skipped this gate at exactly the moment the tables went
+    stale. Added.
+
 ## [0.19.0] - 2026-08-03
 
 **Assurance depth.** An external review scored the project 8.9/10 and asked for

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ backported.
 
 | Version | Supported |
 | ------- | --------- |
-| 0.13.x  | :white_check_mark: |
-| < 0.13  | :x: |
+| 0.19.x  | :white_check_mark: |
+| < 0.19  | :x: |
 
 Always run the [latest release](https://github.com/scttfrdmn/cargoship/releases/latest).
 

--- a/scripts/ci/check-doc-versions.sh
+++ b/scripts/ci/check-doc-versions.sh
@@ -141,7 +141,30 @@ if [ -f "$reports_doc" ] && [ -f CHANGELOG.md ]; then
   done
 fi
 
+# --- Check 5: SECURITY.md's supported-versions table tracks the current line ---
+#
+# The table names the minor line that receives security fixes. It drifted silently
+# across six releases (it advertised 0.13.x while 0.19.0 shipped), telling users
+# their supported version was unsupported and vice versa — the one table in the
+# repo where being wrong is itself a security problem. (#342)
+#
+# Deliberately checks the MINOR line, not the patch: 0.19.1 is still "0.19.x", so
+# a patch release must not require editing this file.
+
+if [ -f SECURITY.md ] && [ -n "${ver:-}" ]; then
+  minor="${ver%.*}" # 0.19.0 -> 0.19
+  want_supported="| ${minor}.x  | :white_check_mark: |"
+  want_unsupported="| < ${minor}  | :x: |"
+
+  for needle in "$want_supported" "$want_unsupported"; do
+    if ! grep -qF "$needle" SECURITY.md; then
+      echo "::error file=SECURITY.md::supported-versions table is stale; expected a row \"$needle\" (current line ${minor}.x, from $version_file = $ver)"
+      fail=1
+    fi
+  done
+fi
+
 if [ "$fail" -eq 0 ]; then
-  echo "✅ doc-consistency: version declarations match ${version_file:+$(tr -d '[:space:]' < "$version_file")}; no denylisted tokens; local links resolve; verification-report table covers all releases."
+  echo "✅ doc-consistency: version declarations match ${version_file:+$(tr -d '[:space:]' < "$version_file")}; no denylisted tokens; local links resolve; verification-report table covers all releases; SECURITY.md supported line current."
 fi
 exit $fail


### PR DESCRIPTION
Closes #342 — audit findings **CSH-007** and **CSH-008**. Independent of #343/#344; branches off `main`.

## CSH-007 — unverified binary download in CI

The secret-scanning job piped `curl` straight into `tar`:

```yaml
curl -sSL "https://.../gitleaks_${VER}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
```

That executes whatever the URL serves. A tampered release asset or a MITM would have run in CI with repository access — inside the very job whose purpose is to catch leaked secrets.

The tarball SHA-256 is now pinned and verified **before** extraction, with `set -euo pipefail` so a failed download cannot fall through to `tar`. This keeps the deliberate choice of the MIT-licensed binary over the `gitleaks-action` wrapper, which requires a paid license for GitHub organizations.

Verified rather than assumed:
- the pinned digest was cross-checked against the release's own published `gitleaks_8.21.2_checksums.txt`, not just a single local download
- the step logic was dry-run both ways — a good tarball extracts and reports `gitleaks.tar.gz: OK`; a tampered one exits 1 at the checksum, before `tar` is reached
- grepped the rest of `.github/workflows/` and `scripts/` for the same pattern: **no other unverified download** (the remaining `curl` hits are health checks)

## CSH-008 — SECURITY.md advertised a line that had not shipped in six releases

The supported-versions table claimed `0.13.x` while 0.19.0 was current, so it told users a version they were not running was the supported one, and that the one they *were* running was not. That is the one table in the repo where being wrong is itself a security problem.

Corrected to `0.19.x` / `< 0.19`, and `scripts/ci/check-doc-versions.sh` now gates it as a fifth check against `internal/version/version.txt`. The check targets the **minor** line, so a patch release does not require editing the file.

Verified by restoring the stale table and watching the check fail:

```
::error file=SECURITY.md::supported-versions table is stale; expected a row
  "| 0.19.x  | :white_check_mark: |" (current line 0.19.x, from internal/version/version.txt = 0.19.0)
```

### The likely reason it drifted for six releases

The doc-consistency workflow's path filter did not include `internal/version/version.txt` — so a release that bumped only the canonical version would **skip this gate entirely**, at exactly the moment the doc tables go stale. Added to both the `push` and `pull_request` filters, otherwise the new check would have the same blind spot as the old ones.

## Verification

- `check-doc-versions.sh` green; watched failing on the reintroduced stale table
- both workflow files parse as YAML
- gitleaks step logic dry-run, pass and tamper paths
- pre-commit hook green: 0 lint issues, ratchet OK, quality A+ (91.4)