### PR TITLE
ci(security): digest-pin the Semgrep container image (#359)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,12 +45,20 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      security:
-        patterns:
-          - "*"
-        dependency-type: "all"
-        update-types:
-          - "security"
+      # There was a third group here, `security:`, with `dependency-type: "all"`
+      # and `update-types: ["security"]`. Both values are invalid for a group —
+      # `dependency-type` accepts only production/development, and `update-types`
+      # only major/minor/patch — and **Dependabot rejects the entire file on a
+      # parse error**, so no configured update in any ecosystem here had ever run
+      # (#366). It was introduced with the file in July 2025 and stayed invisible
+      # because Dependabot only re-validates when the file changes; the docker
+      # `directory:` edit in #358 is what finally triggered a re-parse.
+      #
+      # It is not fixable, only removable: `security` is not an update-type.
+      # Security updates are a separate Dependabot mechanism that ignores
+      # `groups:` entirely and always groups per advisory — which is why security
+      # PRs kept arriving from this repo while version updates never did, and why
+      # the group was a no-op in intent as well as in syntax.
 
   # GitHub Actions workflow dependency updates
   - package-ecosystem: "github-actions"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -121,8 +121,26 @@ jobs:
   semgrep:
     name: Semgrep SAST
     runs-on: ubuntu-latest
+    # Digest-pinned, like every action in this repo (#359). This was
+    # `semgrep/semgrep` with no tag at all, i.e. floating `:latest`: whatever the
+    # registry served that morning got to run in the job with the repository
+    # checked out. That is the one image in the repo the runner pulls on our
+    # behalf, so it was also the one supply-chain input the action pinning did not
+    # cover.
+    #
+    # The digest is the multi-arch index digest, so it resolves on both amd64 and
+    # arm64 runners. The version in the comment is documentation, not a
+    # constraint — verified: pulling `semgrep/semgrep:1.100.0@sha256:bdf7013b…`
+    # runs 1.171.0, because Docker resolves the digest and ignores the tag. Hence
+    # the comment form used for actions rather than a `:tag@sha256:` that would
+    # imply the tag is enforced.
+    #
+    # This pins the *engine*, not the ruleset: `--config=auto` below fetches rules
+    # from the Semgrep registry at scan time, so findings can still change between
+    # runs without this line moving. Dependabot's docker ecosystem is scoped to
+    # /docker and does not watch workflow files, so bumping this is manual.
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep@sha256:bdf7013b2c3634a487671158da77c554f531742326b543a9464d2adf6c433ac8 # 1.171.0
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # Enforcing: fails the build on findings. Triaged false-positives are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No behaviour change: the pinned digest is what `:latest` resolved to when it
     was taken, and the engine scans cleanly from it.
 
+- **Dependabot's config had been invalid since July 2025, so no configured
+  dependency update had ever run.** An invalid `security:` group (`dependency-type:
+  "all"`, `update-types: ["security"]` — neither is legal for a group) made
+  Dependabot **reject the entire file**, and it rejects all of it or none of it.
+  None of the three declared ecosystems (`gomod`, `github-actions`, `docker`) ever
+  produced a version-update PR. (#366)
+  - Found while fixing #358: changing the docker `directory:` caused Dependabot to
+    re-parse the file for the first time in a year. It only validates on change, so
+    a config that had never worked was indistinguishable from one that did.
+  - Security PRs kept arriving throughout, which is what disguised it — those come
+    from a **separate mechanism** that works with an unparseable config and ignores
+    `groups:` entirely. Every Dependabot PR this repo has received was a security
+    update, in ecosystems and directories the config does not even declare. **No
+    `github-actions` PR has ever existed**, which is consistent with the Node 20
+    action debt in #305/#307 having to be cleared by hand and with the floating
+    `semgrep/semgrep` image never being flagged.
+  - Removed rather than corrected: `security` is not an update-type, so the group
+    was a no-op in intent as well as in syntax.
+
 ## [0.21.0] - 2026-08-03
 
 **Dead Surface & Provenance.** Removes the last abandoned duplicate in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     so it watched nothing; it now points at `/docker`. That is part of why Alpine
     3.18 survived, and it is what makes digest pinning sustainable rather than
     freezing.
+- **The Semgrep SAST job ran a floating container image; it is now
+  digest-pinned.** From the external security re-review of v0.21.0 (CSH-022,
+  Low). `security.yml` declared `image: semgrep/semgrep` with no tag at all —
+  i.e. `:latest` — so whatever the registry served that morning ran in a job with
+  the repository checked out. Every *action* in this repo is already SHA-pinned;
+  this was the one image the runner pulled on our behalf, and therefore the one
+  supply-chain input that pinning did not cover. (#359)
+  - Pinned to the **multi-arch index digest** so it resolves on amd64 and arm64
+    runners, with the version in a trailing comment, matching the convention used
+    for actions. The comment is documentation and not a constraint: verified that
+    `semgrep/semgrep:1.100.0@sha256:bdf7013b…` runs **1.171.0**, because Docker
+    resolves the digest and ignores the tag. A `:tag@sha256:` form would have
+    implied the tag was enforced when it is not.
+  - **This pins the engine, not the ruleset.** `--config=auto` fetches rules from
+    the Semgrep registry at scan time, so findings can still change between runs
+    without the pin moving. Worth stating rather than claiming a reproducibility
+    the change does not deliver.
+  - No behaviour change: the pinned digest is what `:latest` resolved to when it
+    was taken, and the engine scans cleanly from it.
 
 ## [0.21.0] - 2026-08-03
 


### PR DESCRIPTION
Closes #359. From the external security re-review of v0.21.0 (**CSH-022, Low**).

`security.yml` declared `image: semgrep/semgrep` with **no tag at all** — i.e. `:latest` — so whatever the registry served that morning ran in a job with the repository checked out. Every *action* in this repo is already SHA-pinned; this was the one image the runner pulls on our behalf, and therefore the one supply-chain input the action pinning did not cover.

## The tag in `tag@digest` is decorative — so I did not use that form

The obvious fix is `semgrep/semgrep:1.171.0@sha256:…`. I tested whether the tag is actually enforced:

```
$ docker run --rm semgrep/semgrep:1.100.0@sha256:bdf7013b… semgrep --version
1.171.0
```

A deliberately **wrong** version tag with the right digest runs 1.171.0. Docker resolves the digest and ignores the tag entirely. So `:tag@sha256:` would imply the tag is a constraint when it is not — a future editor bumping only the tag would change nothing while believing they had. The honest form is the one this repo already uses for actions: **digest, with the version in a trailing comment as documentation.**

Pinned to the **multi-arch index digest**, not a per-platform one, so it resolves on both amd64 and arm64 runners.

## Scope, stated plainly: this pins the engine, not the ruleset

`--config=auto` fetches rules from the Semgrep registry at scan time. Findings can still change between runs without this line moving. Pinning the image removes the "arbitrary new container in a checked-out job" exposure; it does not make the scan reproducible, and the comment says so rather than overclaiming.

Also noted in the comment: Dependabot's docker ecosystem is scoped to `/docker` (see #358) and does not watch workflow files, so bumping this is manual.

## Verification

- digest-only ref pulls, and `semgrep --version` inside it reports **1.171.0**
- **negative control:** a fabricated digest is *refused* (`failed to resolve reference … not found`), not silently ignored
- the pinned digest is byte-identical to what `:latest` resolved to when taken, so **behaviour is unchanged**
- the engine scans cleanly from the pinned image: 131 rules, 0 findings
- `semgrep/semgrep` is the only `container:`/`image:` in any workflow — checked by pattern across `.github/workflows/`, so there is no second instance of this defect

---

## Also fixes #366 — found by this PR's own red check

The `.github/dependabot.yml` check-run went **red** here, and chasing it turned up a defect neither #358 nor #359 introduced: the config has failed schema validation since July 2025, and **Dependabot rejects the whole file on a parse error**. So none of the three declared ecosystems (`gomod`, `github-actions`, `docker`) has ever produced a version-update PR.

What disguised it is that Dependabot PRs *did* keep arriving — from a **separate** security-update mechanism that works with an unparseable config and ignores `groups:` entirely. Every Dependabot PR this repo has received was a security update, mostly in ecosystems the config does not even declare. **No `github-actions` PR has ever existed** — consistent with the Node 20 action debt in #305/#307 being cleared by hand, and with this PR's floating `semgrep/semgrep` image never being flagged by automation.

Removed rather than corrected: `security` is not an update-type, so the group was a no-op in intent as well as in syntax. Fixed here rather than separately because it blocks this PR's checks. Details in #366.
