### PR TITLE
fix(release): verify the release as a draft, before publishing it (#360)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,15 @@ on:
 # The token is scoped to this job, expires in minutes, and grants no repository
 # write access of its own. It is declared here rather than at job level because
 # this workflow has exactly one job.
+# `packages: write` used to be here and is gone (#360): nothing in this release
+# publishes to a package registry. `.goreleaser.yml` has no dockers:/kos:/nfpms:
+# stanza (the dockers: block is commented out), and brews:/scoops: push to
+# separate repositories with their own PATs rather than GITHUB_TOKEN. Least
+# privilege matters more than usual right here, because the block above argues for
+# *widening* permissions with id-token: write — an argument that is only as strong
+# as the claim that everything else in this list is justified.
 permissions:
   contents: write
-  packages: write
   id-token: write
 
 jobs:
@@ -59,46 +65,123 @@ jobs:
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
-      - name: Run GoReleaser
+      # `--draft` (#360). The release is assembled but NOT public until the
+      # verification step below passes, so a broken provenance chain cannot reach
+      # users at all — previously the verify step ran after publication and could
+      # only report a bad release retroactively, which is a strange property for a
+      # check whose purpose is to prevent shipping unverifiable artifacts.
+      #
+      # Passed as a flag rather than `release.draft: true` in .goreleaser.yml on
+      # purpose: a local `goreleaser release` should not silently produce drafts,
+      # and this way the draft state lives next to the step that clears it.
+      #
+      # The Homebrew tap and Scoop bucket still publish in THIS run, which is a
+      # deliberate choice rather than an oversight. Deferring them to a second
+      # goreleaser invocation after promotion does not work, and I checked rather
+      # than assumed:
+      #
+      #   * there is no `goreleaser publish` or `goreleaser continue` subcommand —
+      #     `goreleaser publish --help` prints the *release* help, because the root
+      #     command falls through, exactly as it does for a nonsense subcommand
+      #   * `release.skip_upload: true` does NOT make a second `release` run leave
+      #     the GitHub release alone. Verified with a dummy token: the log shows
+      #     "skipped http upload" and then "release creation failed … POST
+      #     /repos/…/releases", i.e. it skips only the ASSETS and still creates or
+      #     replaces the release. With `mode: replace` that would delete and
+      #     re-upload the assets whose signature was just verified — turning a
+      #     safety measure into the thing that breaks the release
+      #
+      # Publishing the taps here is safe because the formula is correct
+      # independently of draft state: it pins `releases/download/<tag>/…` URLs, and
+      # the tag is fixed before this workflow starts. Those URLs simply begin
+      # resolving when the release is promoted seconds later. The failure mode is a
+      # brief 404 for anyone who runs `brew install` inside the verification window,
+      # not a wrong formula — and if verification fails, a formula pointing at a
+      # release that was never published is a far better outcome than the previous
+      # behaviour, where the artifacts themselves were already public.
+      - name: Run GoReleaser (draft)
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: '~> v2'
-          args: release --clean
+          args: release --clean --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
 
-      # Verify what we just published, the way a user would — same command, same
-      # identity flags documented in SECURITY.md. A signature nobody has verified
-      # is an assumption, and this is the cheapest possible place to find out that
-      # the identity or issuer string is wrong: right after producing it, rather
-      # than from a user who cannot verify a release.
+      # Verify the release the way a user would — same command and identity flags
+      # documented in SECURITY.md. A signature nobody has verified is an
+      # assumption, and this is the cheapest place to discover a wrong identity or
+      # issuer string: before anyone can download it.
       #
-      # Also re-checks the digests, which is the step that makes one signature
-      # meaningful for every artifact: checksums.txt is what got signed, so if it
-      # verifies AND its digests match, the whole release is covered.
-      - name: Verify the published signature and digests
+      # Downloads the assets back from the draft rather than verifying `dist/`
+      # (#360). Verifying the local build directory proves the signing step worked;
+      # it does NOT prove that what landed on the release is the same bytes. A
+      # truncated or mis-mapped upload would pass a dist/-only check and still hand
+      # users an artifact that fails `cosign verify-blob`. Round-tripping through
+      # the API closes that gap, and it is only possible because the release is
+      # still a draft.
+      #
+      # Re-checking the digests is what makes one signature cover everything:
+      # checksums.txt is the signed file, so if it verifies AND its digests match
+      # the downloaded artifacts, the whole release is covered.
+      - name: Verify the draft's published assets before promoting
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
           EXPECTED_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
         run: |
           set -euo pipefail
-          cd dist
+          rm -rf verify && mkdir verify && cd verify
+          # `gh release download` reaches draft releases with contents: write.
+          gh release download "$TAG" --clobber
           cosign verify-blob \
             --bundle checksums.txt.sigstore.json \
             --certificate-identity "$EXPECTED_IDENTITY" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             checksums.txt
-          # Ignore the SBOM/signature lines sha256sum cannot see and check the rest.
-          sha256sum --check --ignore-missing checksums.txt
+          # --ignore-missing skips the signature bundle, which is not itself listed
+          # in checksums.txt. Guard against that silently ignoring EVERYTHING: if a
+          # rename ever desynchronised the names, --check would report "0 checked"
+          # and still exit 0.
+          checked=$(sha256sum --check --ignore-missing checksums.txt | grep -c ': OK$')
+          expected=$(grep -c . checksums.txt)
+          echo "verified ${checked}/${expected} digests from the published assets"
+          if [ "$checked" -ne "$expected" ]; then
+            echo "::error::checksums.txt lists ${expected} artifacts but only ${checked} were verified"
+            exit 1
+          fi
           {
             echo "### Release provenance"
             echo ""
-            echo "\`checksums.txt\` signed and verified against:"
+            echo "Assets downloaded back from the draft release and verified against:"
             echo ""
             echo '```'
             echo "$EXPECTED_IDENTITY"
             echo '```'
             echo ""
-            echo "Digests re-checked; $(grep -c 'sbom.json' checksums.txt) SBOM(s) attached."
+            echo "${checked}/${expected} digests confirmed; $(grep -c 'sbom.json' checksums.txt) SBOM(s) attached."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Only now is the release public. Everything above can fail without a user
+      # ever seeing an unverifiable artifact, which is the entire point of #360.
+      #
+      # `prerelease: auto` in .goreleaser.yml already marked the draft as a
+      # prerelease if the tag has a suffix; --draft=false alone does not touch that
+      # flag, so the distinction survives promotion.
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # --verify-tag: refuse to publish if the tag somehow is not on the
+          # remote. It always is here (this workflow triggers on a tag push), which
+          # is why promotion cannot invent a release for a tag nobody pushed.
+          gh release edit "$TAG" --draft=false --verify-tag
+          state=$(gh release view "$TAG" --json isDraft,isPrerelease -q '"draft=\(.isDraft) prerelease=\(.isPrerelease)"')
+          echo "published: $state"
+          case "$state" in
+            draft=false*) ;;
+            *) echo "::error::release $TAG is still a draft after promotion"; exit 1 ;;
+          esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed rather than corrected: `security` is not an update-type, so the group
     was a no-op in intent as well as in syntax.
 
+- **Releases were published *before* their provenance was verified; the release
+  is now assembled as a draft, verified, and only then promoted.** From the
+  external security re-review of v0.21.0 (CSH-023, Low). The signature check
+  #349 added ran after `goreleaser release` had already made the artifacts
+  public, so a broken provenance chain could only be reported retroactively —
+  a strange property for a check whose purpose is to prevent shipping
+  unverifiable artifacts. (#360)
+  - **The verification step now downloads the assets back from the draft**
+    instead of checking the local `dist/` directory. Verifying `dist/` proves the
+    signing step worked; it does *not* prove the uploaded bytes are the same
+    bytes. A truncated or mis-mapped upload would pass a `dist/`-only check and
+    still hand users an artifact that fails `cosign verify-blob`. Round-tripping
+    through the API closes that gap, and it is only possible while the release is
+    a draft.
+  - `sha256sum --check --ignore-missing` skips the signature bundle, which is not
+    itself listed in `checksums.txt` — but it would just as happily skip
+    *everything* and still exit 0 if a rename ever desynchronised the names. The
+    step now counts verified digests against the line count of `checksums.txt`
+    and fails on a mismatch.
+  - **`packages: write` removed from the workflow's permissions.** Nothing in
+    this release publishes to a package registry: `.goreleaser.yml` has no
+    `dockers:`/`kos:`/`nfpms:` stanza, and the Homebrew tap and Scoop bucket push
+    to separate repositories with their own PATs. Least privilege matters more
+    than usual here, because the same permission block argues for *widening*
+    scope with `id-token: write` — an argument only as strong as the claim that
+    everything else in the list is justified.
+  - Two assumptions about goreleaser were checked rather than trusted, and both
+    were **wrong**; the first design was built on them and discarded. There is no
+    `goreleaser publish` or `goreleaser continue` subcommand — `goreleaser
+    publish --help` prints the *release* help, because the root command falls
+    through, exactly as it does for a nonsense subcommand. And
+    `release.skip_upload: true` does not make a second `release` run leave the
+    GitHub release alone: verified with a dummy token, the log shows `skipped
+    http upload` and then `release creation failed … POST /repos/…/releases`,
+    i.e. it skips only the **assets** and still creates or replaces the release.
+    With `mode: replace` that would have deleted and re-uploaded the assets whose
+    signature was just verified — turning a safety measure into the thing that
+    breaks the release.
+  - The Homebrew tap and Scoop bucket therefore still publish in the draft run.
+    That is safe because a formula is correct independently of draft state: it
+    pins `releases/download/<tag>/…` URLs and the tag is fixed before the
+    workflow starts, so those URLs simply begin resolving on promotion. The
+    failure mode is a brief 404 for anyone running `brew install` inside the
+    verification window — and if verification fails, a formula pointing at a
+    release that was never published is a far better outcome than the previous
+    behaviour, where the artifacts themselves were already public.
+  - **Honest limit:** the draft → verify → promote sequence cannot be exercised
+    without actually publishing a release, so it gets its first real run on the
+    next release tag. Every part testable in isolation was tested.
+
 ## [0.21.0] - 2026-08-03
 
 **Dead Surface & Provenance.** Removes the last abandoned duplicate in


### PR DESCRIPTION
Closes #360 — CSH-023 from the external security re-review of v0.21.0 (Low).

## The defect

The signature check #349 added ran **after** `goreleaser release` had already made
the artifacts public. A broken provenance chain could only be reported
retroactively, which is a strange property for a check whose purpose is to
prevent shipping unverifiable artifacts.

## The fix

`release --clean --draft` → verify → `gh release edit --draft=false --verify-tag`.
Nothing is public until verification passes.

Two further changes came out of writing it:

**Verification downloads the assets back from the draft, rather than checking
`dist/`.** Verifying the local build directory proves the *signing step* worked;
it does not prove the *uploaded bytes* match. A truncated or mis-mapped upload
would pass a `dist/`-only check and still hand users an artifact that fails
`cosign verify-blob`. Round-tripping through the API closes that gap, and is only
possible while the release is a draft.

**The digest recheck now counts what it verified.** `sha256sum --check
--ignore-missing` skips the signature bundle (correctly — it isn't listed in
`checksums.txt`), but it would just as happily skip *everything* and exit 0 if a
rename ever desynchronised the names. It now compares the verified count to the
line count of `checksums.txt` and fails on a mismatch.

**`packages: write` dropped.** Nothing here publishes to a package registry:
`.goreleaser.yml` has no `dockers:`/`kos:`/`nfpms:` stanza and the taps push to
separate repositories with their own PATs. This matters more than usual because
the same permission block argues for *widening* scope with `id-token: write` — an
argument only as strong as the claim that everything else in the list is
justified.

## Two assumptions I had wrong

The first design was a two-pass release, and it rested on two claims about
goreleaser that turned out to be false. Both are recorded in comments in the
workflow, because the wrong design looks more reasonable than the right one.

- **There is no `goreleaser publish` or `goreleaser continue` subcommand.**
  `goreleaser publish --help` prints the *release* help, because the root command
  falls through — byte-identical to what a nonsense subcommand prints. Had I not
  checked, the step would have quietly re-run a full release.
- **`release.skip_upload: true` does not make a second `release` run leave the
  GitHub release alone.** Verified with a dummy token: the log shows `skipped
  http upload` and then `release creation failed … POST /repos/…/releases`. It
  skips only the **assets**. With `mode: replace`, pass 2 would have deleted and
  re-uploaded the artifacts whose signature had just been verified — turning the
  safety measure into the thing that breaks the release.

(Getting to that answer needed two false starts of its own: `goreleaser check`
doesn't evaluate templates, and `--snapshot` implies `--skip=publish` so it never
reaches the publish pipe. A deliberately bogus template function producing *no*
error is what revealed the path wasn't being exercised.)

So the Homebrew tap and Scoop bucket still publish in the draft run. That is
safe: a formula is correct independently of draft state — it pins
`releases/download/<tag>/…` URLs and the tag is fixed before the workflow starts,
so those URLs simply begin resolving on promotion. The failure mode is a brief
404 for anyone running `brew install` inside the verification window. And if
verification fails, a formula pointing at a release that was never published is a
far better outcome than the previous behaviour, where the artifacts themselves
were already public.

## Verification

- Workflow YAML parses; all three `run:` blocks pass `bash -n`.
- The digest-counting guard tested against a fixture with an unlisted extra file:
  happy path gives `checked=2 expected=2`; tampering with one file makes
  `--check` report `FAILED` and exit 1.
- Both falsified goreleaser behaviours were reproduced locally, as described
  above, not inferred from docs.

**Honest limit:** the draft → verify → promote sequence cannot be exercised
without actually publishing a release. I declined to publish one speculatively,
so it gets its first real run on the next release tag. Everything testable in
isolation was tested.
