### PR TITLE
fix(cli)!: exit 1/2 per the documented convention, not a flat 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Exit codes now follow the documented `0`/`1`/`2` convention**
+  ([#401](https://github.com/scttfrdmn/cargoship/issues/401)). Every failure —
+  runtime error, unknown flag, missing required flag, wrong argument count — used
+  to exit **`3`**, a code that appears in no documentation and gave callers no way
+  to tell a malformed command line from a command that ran and failed. Now `1`
+  means it ran and failed, `2` means the invocation was wrong, so a retry loop can
+  treat `2` as fatal. Documented in
+  [Exit codes](https://cargoship.app/reference/exit-codes).
+
+  `verify` previously reached its documented `1` only by calling `os.Exit(1)`
+  mid-command, which skipped `PersistentPostRun` and so left the CPU profile file
+  unclosed under `--profile`. It now returns normally and cleanup runs.
+
+  `cargoship create <unknown>` returned the entire multi-line usage block as an
+  error *message*, which the logger emitted as one quoted line; it now reports the
+  unknown subcommand in one line and exits `2`.
+
+  **Breaking for scripts that check for `3`** — check `1` and `2` instead.
+
 - **`cargoship create keys --type x25519` silently produced an RSA key.** The
   `--type` flag was registered, documented, and completion-enabled, but never
   copied into `KeyOpts`, so the key type was always the `rsa` default. Found

--- a/cmd/cargoship/cmd/create.go
+++ b/cmd/cargoship/cmd/create.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -12,8 +12,15 @@ func NewCreateCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create something!",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return errors.New(cmd.UsageString())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// `create` on its own is not runnable; it dispatches to a subcommand.
+			// Returning cmd.UsageString() as the error *message*, as this used to,
+			// sent the entire multi-line usage block through slog.Error as a single
+			// quoted line, and produced exit 1 for what is a usage error.
+			if len(args) > 0 {
+				return fmt.Errorf("%w: unknown command %q for %q", ErrUsage, args[0], cmd.CommandPath())
+			}
+			return fmt.Errorf("%w: %q requires a subcommand", ErrUsage, cmd.CommandPath())
 		},
 	}
 	bindCreateKeys(cmd)

--- a/cmd/cargoship/cmd/exitcode.go
+++ b/cmd/cargoship/cmd/exitcode.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Process exit codes. These are the CLI's contract with scripts and CI (see the
+// exit-code table in the command reference), so they must not drift.
+const (
+	// ExitOK is returned when the command succeeded.
+	ExitOK = 0
+	// ExitError is returned when the command ran and failed.
+	ExitError = 1
+	// ExitUsage is returned when the invocation itself was wrong: an unknown
+	// command or flag, a bad flag value, a missing required flag, or the wrong
+	// number of arguments.
+	ExitUsage = 2
+)
+
+// ErrUsage marks an error as the caller's mistake rather than a runtime failure,
+// so main can exit ExitUsage instead of ExitError.
+//
+// Wrap with it in any RunE that rejects its own arguments:
+//
+//	return fmt.Errorf("%w: --bucket is required", ErrUsage)
+var ErrUsage = errors.New("usage error")
+
+// ErrSilent reports failure through the exit code alone, for commands that have
+// already printed their own diagnostics.
+//
+// It exists so such a command can return normally — letting deferred cleanup and
+// PersistentPostRun run — instead of calling os.Exit mid-RunE, without main
+// logging a second, redundant error line on top of the output the command
+// already produced.
+var ErrSilent = errors.New("")
+
+// IsSilent reports whether an error should be surfaced by exit code only.
+func IsSilent(err error) bool {
+	return errors.Is(err, ErrSilent)
+}
+
+// usagePatterns are cobra's own wordings for the malformed-invocation errors
+// that no hook can intercept.
+//
+// Matching on message text is normally a mistake, and it is confined to this one
+// place for that reason. Cobra builds these with fmt.Errorf and exports no
+// sentinel or type to test against, and it raises them inside Command.execute:
+// argument-count validation at the ValidateArgs call and required-flag
+// validation at ValidateRequiredFlags, neither of which is routed through
+// SetFlagErrorFunc or any other extension point. The alternative —
+// reimplementing cobra's argument handling in order to classify it — would be a
+// second copy of that logic, drifting silently against the first.
+//
+// Flag-parse errors are deliberately absent: attachUsageClassifier tags those at
+// the source via SetFlagErrorFunc, which is exact rather than textual. Listing
+// them here as well would be unreachable duplication.
+//
+// Every pattern is pinned by a subtest in exitcode_test.go that drives a real
+// command and asserts the resulting code, so a cobra rewording fails the suite
+// instead of quietly reverting that case to ExitError.
+var usagePatterns = []string{
+	"unknown command ",  // args.go legacyArgs / NoArgs
+	"required flag(s) ", // command.go ValidateRequiredFlags
+	"accepts ",          // args.go ExactArgs / MaximumNArgs / RangeArgs
+	"requires at least", // args.go MinimumNArgs
+}
+
+// ExitCode maps an error returned by command execution to a process exit code.
+//
+// Anything not recognised as a usage problem is ExitError: a command that ran
+// and failed is the common case, and misreporting it as a usage error would tell
+// a caller to check its command line when the real problem was elsewhere.
+func ExitCode(err error) int {
+	if err == nil {
+		return ExitOK
+	}
+	if errors.Is(err, ErrUsage) {
+		return ExitUsage
+	}
+	msg := err.Error()
+	for _, p := range usagePatterns {
+		if strings.Contains(msg, p) {
+			return ExitUsage
+		}
+	}
+	return ExitError
+}
+
+// attachUsageClassifier marks flag-parse failures as usage errors. Cobra's
+// FlagErrorFunc walks up to the parent when a command has none of its own, so
+// setting it on the root covers the whole tree.
+//
+// This makes the classification explicit for the errors that can be hooked;
+// usagePatterns covers the ones cobra raises where no hook can see them.
+func attachUsageClassifier(root *cobra.Command) {
+	root.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return fmt.Errorf("%w: %w", ErrUsage, err)
+	})
+}

--- a/cmd/cargoship/cmd/exitcode_test.go
+++ b/cmd/cargoship/cmd/exitcode_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// runForExitCode drives the real root command and returns the code main would
+// exit with. Going through NewRootCmd rather than calling ExitCode on a
+// hand-made error is the point: it pins the classification against the errors
+// cobra actually produces, so a cobra upgrade that rewords one of them fails
+// here instead of silently downgrading that case to ExitError.
+func runForExitCode(t *testing.T, args ...string) int {
+	t.Helper()
+	b := bytes.NewBufferString("")
+	c := NewRootCmd(b)
+	c.SetArgs(args)
+	c.SetOut(b)
+	c.SetErr(b)
+	return ExitCode(c.Execute())
+}
+
+func TestExitCode_UsageErrors(t *testing.T) {
+	// Each case is a way of getting the invocation wrong. All must be
+	// distinguishable from a runtime failure, which is the whole point of #401.
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"unknown command", []string{"not-a-command"}},
+		{"unknown flag", []string{"create", "keys", "--bogus-flag"}},
+		{"unknown shorthand flag", []string{"create", "keys", "-Z"}},
+		{"flag missing its value", []string{"create", "keys", "--name"}},
+		{"bad flag value", []string{"create", "keys", "--name", "x", "--email", "y@z.com", "--bits", "notanint"}},
+		{"missing required flag", []string{"create", "keys"}},
+		{"wrong arg count", []string{"estimate"}},
+		{"too few args (MinimumNArgs)", []string{"create", "upload"}},
+		{"parent command without subcommand", []string{"create"}},
+		{"unknown subcommand of a parent", []string{"create", "bogus-sub"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, ExitUsage, runForExitCode(t, tt.args...),
+				"a malformed invocation must exit %d so scripts can tell it from a runtime failure", ExitUsage)
+		})
+	}
+}
+
+// TestExitCode_RuntimeFailureIsNotUsage guards the other direction: a command
+// that parsed fine and then failed must NOT be reported as a usage error, or
+// callers would be told to check their command line when the real problem was
+// elsewhere. `create keys` with no passphrase available fails inside RunE.
+func TestExitCode_RuntimeFailureIsNotUsage(t *testing.T) {
+	t.Setenv(passphraseEnvVar, "")
+	require.NoError(t, os.Unsetenv(passphraseEnvVar))
+	code := runForExitCode(t, "create", "keys",
+		"--name", "x", "--email", "y@z.com", "--bits", "1024",
+		"--destination", t.TempDir())
+	require.Equal(t, ExitError, code, "a command that ran and failed must exit %d, not %d", ExitError, ExitUsage)
+}
+
+func TestExitCode_SuccessIsZero(t *testing.T) {
+	require.Equal(t, ExitOK, runForExitCode(t, "--version"))
+	require.Equal(t, ExitOK, runForExitCode(t, "--help"))
+}
+
+// TestExitCode_NeverReturnsThree pins the actual regression: every failure mode
+// used to come back as 3, which is outside the documented 0/1/2 range.
+func TestExitCode_NeverReturnsThree(t *testing.T) {
+	for _, args := range [][]string{
+		{"not-a-command"},
+		{"create"},
+		{"create", "keys"},
+		{"estimate"},
+		{"create", "keys", "--bogus-flag"},
+	} {
+		code := runForExitCode(t, args...)
+		require.Contains(t, []int{ExitOK, ExitError, ExitUsage}, code,
+			"args %v produced undocumented exit code %d", args, code)
+	}
+}
+
+func TestExitCode_NilIsZero(t *testing.T) {
+	require.Equal(t, ExitOK, ExitCode(nil))
+}
+
+func TestExitCode_ErrUsageWrapping(t *testing.T) {
+	// The sentinel survives wrapping, so a RunE can add context to a usage error.
+	err := fmt.Errorf("resolving destination: %w", fmt.Errorf("%w: --bucket is required", ErrUsage))
+	require.Equal(t, ExitUsage, ExitCode(err))
+}
+
+func TestExitCode_PlainErrorIsExitError(t *testing.T) {
+	require.Equal(t, ExitError, ExitCode(errors.New("disk on fire")))
+}
+
+// TestIsSilent covers the verify path: failure is reported by exit code alone,
+// because the command already printed its own diagnostics.
+func TestIsSilent(t *testing.T) {
+	require.True(t, IsSilent(ErrSilent))
+	require.True(t, IsSilent(fmt.Errorf("wrapped: %w", ErrSilent)))
+	require.False(t, IsSilent(errors.New("ordinary failure")))
+	require.False(t, IsSilent(nil))
+
+	// A silent error is still a failure, so it must not map to ExitOK.
+	require.Equal(t, ExitError, ExitCode(ErrSilent))
+}

--- a/cmd/cargoship/cmd/root.go
+++ b/cmd/cargoship/cmd/root.go
@@ -117,6 +117,10 @@ func NewRootCmdWithVersion(lo io.Writer, versionInfo string) *cobra.Command {
 	// cmd.SetContext(context.WithValue(context.Background(), inventory.LogWriterKey, lo))
 	cmd.SetOut(lo)
 
+	// Mark flag-parse failures as usage errors so main can exit 2 rather than
+	// lumping them in with runtime failures.
+	attachUsageClassifier(cmd)
+
 	return cmd
 }
 

--- a/cmd/cargoship/cmd/verify.go
+++ b/cmd/cargoship/cmd/verify.go
@@ -195,7 +195,11 @@ Exit Codes:
 				// not just that the manifest is internally consistent.
 				if deep {
 					if err := runDeepVerify(ctx, s3Client, m, bucket, verbose); err != nil {
-						os.Exit(1)
+						// runDeepVerify prints its own per-file diagnostics, so
+						// report failure by exit code alone. Returning instead of
+						// calling os.Exit lets PersistentPostRun close the CPU
+						// profile when --profile is set.
+						return ErrSilent
 					}
 					return nil
 				}
@@ -243,9 +247,9 @@ Exit Codes:
 			}
 			fmt.Println()
 
-			// Exit with error code
-			os.Exit(1)
-			return nil // Never reached, but required for compilation
+			// The failed checks are already printed above; report failure through
+			// the exit code without a duplicate error line.
+			return ErrSilent
 		},
 	}
 

--- a/cmd/cargoship/main.go
+++ b/cmd/cargoship/main.go
@@ -34,6 +34,24 @@ func buildVersionInfo() string {
 	return versionInfo
 }
 
+// reportAndCode logs err, unless the command already reported it itself, and
+// returns the process exit code for it: 1 for a command that ran and failed, 2
+// for a malformed invocation. This used to be a flat 3 for both, which is
+// outside the documented range and gave scripts no way to tell them apart.
+//
+// It is split out of main because main calls os.Exit and so cannot be tested.
+func reportAndCode(err error) int {
+	if err == nil {
+		return cmd.ExitOK
+	}
+	// A silent error means the command already printed its own diagnostics
+	// (verify, for one) and wants the exit code only.
+	if !cmd.IsSilent(err) {
+		slog.Error("error executing command, quitting", "error", err)
+	}
+	return cmd.ExitCode(err)
+}
+
 func main() {
 	// We are pushing all the usage to Stdout instead of Stderr. I would
 	// like to eventually get this back to stderr, however currently that
@@ -41,8 +59,7 @@ func main() {
 	// stdout. Hopefully cobra will be able to have multiple outputs at some
 	// point
 	err := cmd.NewRootCmdWithVersion(os.Stdout, buildVersionInfo()).ExecuteContext(context.Background())
-	if err != nil {
-		slog.Error("error executing command, quitting", "error", err)
-		os.Exit(3)
+	if code := reportAndCode(err); code != cmd.ExitOK {
+		os.Exit(code)
 	}
 }

--- a/cmd/cargoship/main_test.go
+++ b/cmd/cargoship/main_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -146,6 +149,41 @@ func TestNewRootCmdWithVersion(t *testing.T) {
 	output := buf.String()
 	if output == "" {
 		t.Error("Version command should produce output")
+	}
+}
+
+// TestReportAndCode covers the mapping main() applies to the error returned by
+// command execution. main() itself calls os.Exit and so can't be tested; this is
+// the part that decides what it exits with.
+func TestReportAndCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantLog  bool
+	}{
+		{"success", nil, cmd.ExitOK, false},
+		{"runtime failure", errors.New("bucket not found"), cmd.ExitError, true},
+		{"usage error", fmt.Errorf("%w: --bucket is required", cmd.ErrUsage), cmd.ExitUsage, true},
+		{"cobra usage wording", errors.New(`unknown command "nope" for "cargoship"`), cmd.ExitUsage, true},
+		// A silent error is still a failure, but the command already printed its
+		// own diagnostics, so main must not log a second line over them.
+		{"silent failure", cmd.ErrSilent, cmd.ExitError, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logged bytes.Buffer
+			orig := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&logged, nil)))
+			defer slog.SetDefault(orig)
+
+			if got := reportAndCode(tt.err); got != tt.wantCode {
+				t.Errorf("reportAndCode(%v) = %d, want %d", tt.err, got, tt.wantCode)
+			}
+			if gotLog := logged.Len() > 0; gotLog != tt.wantLog {
+				t.Errorf("logged = %v, want %v (output: %q)", gotLog, tt.wantLog, logged.String())
+			}
+		})
 	}
 }
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -142,6 +142,7 @@ const sidebar = {
         { text: 'Destructive operations', link: '/reference/commands/destructive' },
         { text: 'Diagnostics & utilities', link: '/reference/commands/diagnostics' },
         { text: 'Global flags', link: '/reference/commands/global-flags' },
+        { text: 'Exit codes', link: '/reference/exit-codes' },
         { text: 'Environment variables', link: '/reference/environment-variables' },
         { text: 'Configuration schema', link: '/reference/configuration' },
         { text: 'CargoShip vs. other tools', link: '/reference/comparison' },

--- a/docs/guides/verifying.md
+++ b/docs/guides/verifying.md
@@ -104,6 +104,12 @@ sibling commands, you can address the upload with an S3 URL or with
 |------|---------|
 | `0`  | All checks passed |
 | `1`  | Verification failed (errors found) |
+| `2`  | Bad invocation — unknown flag, missing argument |
+
+A failed check is `1`, not `2`: the command ran correctly and the answer was
+"this archive does not match". `2` means the command line itself was wrong, so
+retrying it will not help. See [Exit codes](/reference/exit-codes) for the
+CLI-wide contract.
 
 That makes it a drop-in step in scripts, cron, and CI pipelines:
 

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -1,0 +1,60 @@
+# Exit codes
+
+Every `cargoship` command exits with one of three codes. They are the contract
+for scripts and CI, and are covered by tests so they don't drift.
+
+| Code | Meaning | When |
+|------|---------|------|
+| `0` | Success | The command completed. |
+| `1` | Runtime error | The command was invoked correctly but failed — network error, missing S3 object, verification mismatch, permission denied. |
+| `2` | Usage error | The invocation itself was wrong — unknown command or flag, missing required flag, bad flag value, wrong number of arguments. |
+
+The distinction between `1` and `2` is the useful part: `2` means fix your
+command line, `1` means the command line was fine and something else went wrong.
+Retrying is only ever sensible for `1`.
+
+## In scripts
+
+```bash
+cargoship verify s3://my-bucket/archives/uploads/20260721-a1b2c3 --deep
+case $? in
+  0) echo "verified" ;;
+  1) echo "verification failed or could not run — investigate, maybe retry" ; exit 1 ;;
+  2) echo "bad invocation — this is a bug in the script" ; exit 2 ;;
+esac
+```
+
+Because `2` signals a malformed command rather than a transient failure, a retry
+loop should treat it as fatal:
+
+```bash
+for attempt in 1 2 3; do
+  cargoship upload ./data s3://my-bucket/archives/ && break
+  status=$?
+  [ "$status" -eq 2 ] && { echo "not retryable"; exit 2; }
+  sleep $((attempt * 5))
+done
+```
+
+## Notes
+
+- **`verify` failing a check exits `1`**, not `2` — the command ran and did its
+  job; the answer was "this archive does not match". See
+  [Verifying uploads](/guides/verifying).
+- Commands that print their own diagnostics (again, `verify`) report failure
+  through the exit code without an extra error line. The code is still `1`.
+- Interrupting with `Ctrl-C` follows the shell's usual signal convention
+  (`130` for `SIGINT`) rather than these codes.
+
+::: warning Changed in v0.23.0
+Earlier versions exited **`3`** for every failure — runtime errors and malformed
+invocations alike. `3` was never documented, and a caller could not tell the two
+apart. If a script checks for `3`, update it to check `1` and `2` (see
+[#401](https://github.com/scttfrdmn/cargoship/issues/401)).
+:::
+
+## See also
+
+- [Verifying uploads](/guides/verifying) — the exit code as a CI gate.
+- [Troubleshooting](/reference/troubleshooting) — diagnosing a `1`.
+- [Global flags](/reference/commands/global-flags).


### PR DESCRIPTION
Closes #401.

## The defect

`main` exited **`3`** for every failure. `3` appears in no documentation, and
because runtime failures and malformed command lines shared it, a caller could
not tell "the archive doesn't match" from "you typo'd a flag" — so a retry loop
retried invocations that could never succeed.

Now: `0` success, `1` ran-and-failed, `2` bad invocation. Documented at
`docs/reference/exit-codes.md`.

## How the classification is built

Cobra offers nothing to switch on — every usage error is a plain `fmt.Errorf`
with no exported sentinel or type. So the fix uses the hook where one exists and
text only where none does:

- **`SetFlagErrorFunc` on the root** tags every flag-parse failure at the source.
  Cobra walks up to the parent when a command has no func of its own, so one hook
  covers the whole tree. This is exact, not textual.
- **Four text patterns** for what cobra raises inside `Command.execute` —
  `ValidateArgs` (`command.go:968`) and `ValidateRequiredFlags` (`:1007`) — where
  no extension point can reach. The alternative was reimplementing cobra's
  argument handling to classify it, i.e. a second copy of that logic drifting
  against the first.

I measured the real error strings rather than reasoning from source, and that
paid off twice: three patterns I'd initially written turned out **already
handled** by the hook (`unknown shorthand`, `flag needs an argument`, `invalid
argument` all arrive carrying the `usage error:` prefix), so I pruned them rather
than leave dead entries. Every remaining pattern was confirmed load-bearing by
reverting it individually and watching the matching subtest fail.

## Two more defects found while verifying

- **`verify` skipped its own cleanup.** It reached exit `1` via `os.Exit(1)`
  mid-`RunE`, which bypasses `PersistentPostRun` — so under `--profile` the CPU
  profile file was never closed. It now returns `ErrSilent`: failure by exit code
  alone, cleanup runs, and `main` doesn't log a redundant second error line over
  the diagnostics `verify` already printed.
- **`cargoship create <unknown>` returned `cmd.UsageString()` as the error
  *message***, so `slog.Error` emitted the entire multi-line usage block as one
  quoted line, and exited `1` for what is a usage error. Output is now 2 lines.

## Verification

18 tests. `runForExitCode` drives the **real** `NewRootCmd`, not hand-made
errors, so a cobra rewording fails the suite instead of quietly downgrading a
case to `1`. 10 subtests cover distinct ways of getting the invocation wrong;
`TestExitCode_RuntimeFailureIsNotUsage` guards the other direction;
`TestExitCode_NeverReturnsThree` pins the regression itself.

Per **stash-verify-discipline**, every new assertion was watched failing against
the pre-fix tree with `-count=1` (`expected: 2, actual: 1`, and `= 3, want 1`),
including the redundant-log assertion.

End-to-end against the built binary: 9 usage cases → `2`, runtime failure → `1`,
`--version`/`--help` → `0`.

`main`'s reporting logic is split out as `reportAndCode` because `main` calls
`os.Exit` and so was entirely uncoverable — the coverage ratchet caught the drop
my first draft caused (`cmd/cargoship` 54% vs. floor 60). Rather than lower the
floor for code I'd just added, I made it testable: the package is now 78.6%.

## Gates

gofmt / `go vet` / staticcheck / golangci-lint (0 issues) / full `go test -short
./...` / no `docs/gen/cli/` drift / `check-doc-versions.sh` green / VitePress
builds with the new page and sidebar entry.

## Breaking

Scripts checking for `3` must check `1` and `2`. Called out in the CHANGELOG and
in a `Changed in v0.23.0` box on the new docs page.