### PR TITLE
ci: validate .goreleaser.yml on every PR; fix the declared license

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,6 +196,41 @@ jobs:
           version: v2.10.1
           args: --timeout=10m
 
+  # Validate the release config on every PR (#381). release.yml pins goreleaser
+  # to '~> v2', so a property deprecated today can be REMOVED by an upstream
+  # minor release on its own schedule — and without this lane the first sign of
+  # that is a failed release on an already-pushed tag. The wrapper distinguishes
+  # a deprecation (schedulable, allowlisted with a reason) from a hard config
+  # error (never acceptable); see its header.
+  goreleaser-config:
+    name: Release Config Valid
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # goreleaser resolves `builds:` against the module, so Go must be present.
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      # Installed via the action rather than a curl|tar so the download is
+      # verified, matching how release.yml obtains it. The pinned major must
+      # track release.yml's `version:` — a lane checking a different goreleaser
+      # than the one that releases would be worse than no lane.
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: '~> v2'
+          install-only: true
+
+      - name: Check .goreleaser.yml
+        run: bash scripts/ci/check-goreleaser-config.sh
+
   # Security scanning (govulncheck, gitleaks, trivy, semgrep) lives in
   # security.yml. Removed the duplicate govulncheck-only job here.
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -172,6 +172,12 @@ release:
     _Built with ❤️ using [GoReleaser](https://goreleaser.com)_
 
 # Homebrew tap
+#
+# Still `brews:` (a formula), not `homebrew_casks:`, deliberately — see #381 and
+# the header of scripts/ci/check-goreleaser-config.sh, which allowlists this one
+# deprecation. Short version: casks propagate macOS quarantine, our darwin
+# binaries are not notarized, and a quarantined release binary is SIGKILLed by
+# Gatekeeper. Migrating before notarization would break `brew install` on macOS.
 brews:
   - repository:
       owner: scttfrdmn
@@ -180,7 +186,9 @@ brews:
     directory: Formula
     homepage: https://github.com/scttfrdmn/cargoship
     description: High-performance S3 upload tool with intelligent sharding and compression
-    license: MIT
+    # The repo is Apache-2.0 (see LICENSE). This said MIT, so every published
+    # formula has declared the wrong license — including the live tap today.
+    license: Apache-2.0
     skip_upload: auto
     test: |
       system "#{bin}/cargoship", "--version"
@@ -195,7 +203,8 @@ scoops:
       token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
     homepage: https://github.com/scttfrdmn/cargoship
     description: High-performance S3 upload tool with intelligent sharding and compression
-    license: MIT
+    # Apache-2.0, matching LICENSE — this also said MIT.
+    license: Apache-2.0
     skip_upload: auto
 
 # Docker images (optional - can be added later)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Homebrew formula and Scoop manifest declared the wrong license.** Both
+  said `MIT`; the project is Apache-2.0 (`LICENSE`). Every published formula has
+  carried the wrong value, including the tap as it stands today — it will correct
+  itself on the next release. No code change, but a licensing statement is not a
+  cosmetic field.
+
+- **`.goreleaser.yml` is now validated on every PR**
+  ([#381](https://github.com/scttfrdmn/cargoship/issues/381)). `release.yml` pins
+  goreleaser to `~> v2`, so an upstream minor release can remove a property that
+  only warns today — and with no lane running `goreleaser check`, the first sign
+  would have been a **failed release on an already-pushed tag**. A deprecated
+  `brews:` sat in the config across six releases for exactly that reason. The new
+  check distinguishes a deprecation (schedulable; allowlisted with an issue and a
+  reason) from a hard config error (always fatal), so accepting one is a
+  reviewable edit rather than a silence.
+
 - **Exit codes now follow the documented `0`/`1`/`2` convention**
   ([#401](https://github.com/scttfrdmn/cargoship/issues/401)). Every failure —
   runtime error, unknown flag, missing required flag, wrong argument count — used

--- a/scripts/ci/check-goreleaser-config.sh
+++ b/scripts/ci/check-goreleaser-config.sh
@@ -56,8 +56,17 @@ if ! command -v goreleaser >/dev/null 2>&1; then
   exit 1
 fi
 
-output="$(goreleaser check 2>&1)"
+# NO_COLOR is set because goreleaser colourises when it detects CI, which puts
+# ANSI escapes *inside* the deprecation line — between "DEPRECATED:" and the
+# property name. Parsing that yielded an empty name, so the property matched
+# nothing in the allowlist and the lane failed on its own known-good config.
+# Belt and braces: the escapes are also stripped below, and an empty name is
+# rejected explicitly, so this cannot silently degrade again if NO_COLOR stops
+# being honoured.
+output="$(NO_COLOR=1 goreleaser check 2>&1)"
 status=$?
+# shellcheck disable=SC2001 # a character-class sed is clearer here than ${//}
+output="$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g')"
 echo "$output"
 echo
 
@@ -84,10 +93,14 @@ fi
 # Exit 2: valid, but deprecated properties are in use. Extract which ones. The
 # line looks like:
 #   • DEPRECATED:  brews  should not be used anymore, check https://...
+# `+` not `*`: a zero-length match would produce an empty property name that
+# matches nothing in the allowlist, failing the lane with a blank name in the
+# message — which is exactly what the ANSI escapes above caused.
 mapfile -t found < <(
   echo "$output" \
-    | grep -o 'DEPRECATED:[[:space:]]*[A-Za-z0-9_.]*' \
+    | grep -o 'DEPRECATED:[[:space:]]*[A-Za-z0-9_.]\{1,\}' \
     | sed 's/DEPRECATED:[[:space:]]*//' \
+    | grep -v '^$' \
     | sort -u
 )
 

--- a/scripts/ci/check-goreleaser-config.sh
+++ b/scripts/ci/check-goreleaser-config.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Validate .goreleaser.yml on every PR, so a config problem surfaces here rather
+# than at tag-push time.
+#
+# Why this exists (#381): the release workflow pins `version: '~> v2'`, which
+# tracks goreleaser minor releases as they land. Nothing in CI ran
+# `goreleaser check`, so a deprecation could be removed upstream and we would
+# learn about it from a FAILED RELEASE on a pushed tag — the one moment when the
+# tree is frozen, the tag already public, and a fix means a retag. A `brews:`
+# deprecation sat in the config across six releases, warning into a log nobody
+# read, precisely because of this gap.
+#
+# The three states `goreleaser check` distinguishes, verified against 2.17.1 in a
+# real repository (a scratch dir gives a misleading "configuration is invalid:
+# scm releases: current folder is not a git repository" for every input, so this
+# must run from the checkout):
+#
+#   exit 0  valid, no deprecations
+#   exit 2  valid, but uses deprecated properties
+#   exit 1  genuinely broken — unknown field, unparseable YAML
+#
+# The distinction is the useful part, and it is why this wraps `check` instead of
+# calling it directly in the workflow. A deprecation is a scheduling problem: the
+# release still works today and there may be a deliberate reason to wait (for
+# `brews:` there is — see the KNOWN_DEPRECATIONS note below). A hard error is
+# never acceptable. Collapsing both into one red X would mean either blocking
+# every PR on a known-and-accepted deprecation, or ignoring the lane entirely.
+#
+# So: exit 1 is always a failure. Exit 2 fails only for deprecations that are NOT
+# in the allowlist below, which makes accepting one an explicit, reviewable edit
+# to this file rather than a silence.
+#
+# Usage: scripts/ci/check-goreleaser-config.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+# Deprecations we have looked at and are deliberately still carrying. Each entry
+# needs an issue and a reason — the point is that the decision is written down,
+# not that the warning is hidden.
+#
+#   brews  → #381. Migrating to `homebrew_casks:` is NOT a rename: `test:` and
+#            `install:` do not exist on a cask, and casks propagate macOS
+#            quarantine. Our darwin artifacts are adhoc/linker-signed only, not
+#            notarized, and a quarantined v0.22.0 darwin_arm64 binary is
+#            SIGKILLed by Gatekeeper (rc=137, measured). Migrating before we
+#            notarize would break `brew install` on macOS, so `brews:` stays
+#            until the signing question is settled.
+KNOWN_DEPRECATIONS=(
+  "brews"
+)
+
+if ! command -v goreleaser >/dev/null 2>&1; then
+  echo "::error::goreleaser not installed — this check needs it on PATH"
+  exit 1
+fi
+
+output="$(goreleaser check 2>&1)"
+status=$?
+echo "$output"
+echo
+
+# A hard configuration error. Never allowlisted: the release cannot run.
+if [ "$status" -eq 1 ]; then
+  echo "::error::.goreleaser.yml is invalid — a release would fail at tag time"
+  echo "Run 'goreleaser check' locally to reproduce."
+  exit 1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "goreleaser config is valid with no deprecations"
+  exit 0
+fi
+
+if [ "$status" -ne 2 ]; then
+  # An exit code this script has not characterised. Treat as a failure rather
+  # than assume it is benign.
+  echo "::error::'goreleaser check' exited $status, which this check does not recognise"
+  echo "Inspect the output above and update scripts/ci/check-goreleaser-config.sh."
+  exit 1
+fi
+
+# Exit 2: valid, but deprecated properties are in use. Extract which ones. The
+# line looks like:
+#   • DEPRECATED:  brews  should not be used anymore, check https://...
+mapfile -t found < <(
+  echo "$output" \
+    | grep -o 'DEPRECATED:[[:space:]]*[A-Za-z0-9_.]*' \
+    | sed 's/DEPRECATED:[[:space:]]*//' \
+    | sort -u
+)
+
+if [ ${#found[@]} -eq 0 ]; then
+  echo "::error::'goreleaser check' reported deprecations but none could be parsed"
+  echo "The output format may have changed; update the parser in this script."
+  exit 1
+fi
+
+unexpected=()
+for dep in "${found[@]}"; do
+  known=false
+  for allowed in "${KNOWN_DEPRECATIONS[@]}"; do
+    if [ "$dep" = "$allowed" ]; then
+      known=true
+      break
+    fi
+  done
+  if $known; then
+    echo "known deprecation (accepted, see this script's header): $dep"
+  else
+    unexpected+=("$dep")
+  fi
+done
+
+if [ ${#unexpected[@]} -gt 0 ]; then
+  echo
+  echo "::error::.goreleaser.yml uses ${#unexpected[@]} deprecated property(ies) not yet triaged: ${unexpected[*]}"
+  echo "goreleaser removes deprecated properties on its own schedule, and the"
+  echo "release workflow pins '~> v2', so this WILL become a failed release at"
+  echo "tag-push time. Either migrate the property now, or add it to"
+  echo "KNOWN_DEPRECATIONS in scripts/ci/check-goreleaser-config.sh with an issue"
+  echo "and a reason."
+  exit 1
+fi
+
+echo
+echo "goreleaser config is valid; ${#found[@]} deprecation(s), all triaged"


### PR DESCRIPTION
Refs #381 — implements step 1 of that issue (the CI lane). Deliberately does
**not** migrate `brews:` → `homebrew_casks:`; see below, because I now have
measured evidence that migrating today would break macOS installs.

## The gap

`release.yml` pins goreleaser to `~> v2`, so a property that only *warns* today
can be **removed** by an upstream minor release on its own schedule. No lane ran
`goreleaser check`, so the first sign of that would have been a **failed release
on an already-pushed tag** — tree frozen, tag public, fix means a retag. A
deprecated `brews:` has been sitting in the config across six releases, warning
into a log nobody reads, for exactly this reason.

## Three states, not two

`goreleaser check` reports three outcomes. Measured against 2.17.1 **from a real
checkout** — my first attempt used synthetic configs in a scratch dir and every
one came back exit 1 with `current folder is not a git repository`, which is the
tool being unhappy about the fixture, not the config:

| exit | meaning |
|------|---------|
| `0` | valid, no deprecations |
| `2` | valid, uses deprecated properties |
| `1` | genuinely broken — unknown field, unparseable YAML |

The distinction is why this wraps `check` rather than calling it in the workflow.
A deprecation is a *scheduling* problem and may have a good reason to wait; a
hard error never does. Collapsing both into one red X would mean either blocking
every PR on a known, accepted deprecation, or ignoring the lane entirely.

So exit 1 always fails, and exit 2 fails only for deprecations **not** in an
allowlist that requires an issue and a reason. Accepting one becomes a reviewable
edit instead of a silence. An unrecognised exit code also fails, rather than
being assumed benign.

## Why `brews:` is allowlisted, not migrated

The migration isn't a rename, and it isn't currently safe. Casks propagate macOS
quarantine, and our darwin artifacts are adhoc/linker-signed only — never
notarized. I downloaded the **real released** `v0.22.0_darwin_arm64` binary,
applied `com.apple.quarantine` as a cask download would, and ran it:

```
rc=137          # SIGKILL — Gatekeeper
out=[]
$ xattr -dr com.apple.quarantine ./cargoship
rc=0
out=[0.22.0 (994db09...) built on 2026-08-04T01:00:12Z]
```

Worth noting my *locally built* binary survived the same test, because the local
linker adhoc-signs it — testing the actual release artifact is what produced the
right answer. (This is also what set off the Gatekeeper notifications on my
machine; the xattr was applied to a `/tmp` copy and has been cleaned up.)

So migrating before notarization would break `brew install` on macOS for every
user. #381 stays open on the signing decision, now with evidence rather than an
open question.

## A real bug found in the same stanza

Both the brew and scoop stanzas declared **`license: MIT`**. The project is
**Apache-2.0** (`LICENSE`, and the README badge). Every published formula has
carried the wrong license — including the live tap right now
(`Formula/cargoship.rb:9` reads `license "MIT"`). Corrects itself on the next
release.

## Verification

The script was exercised in all four states, each confirmed by actually running
it — including the negative controls, which is the part that matters for a guard:

- current tree (`brews`, allowlisted) → **0**, "1 deprecation(s), all triaged"
- same tree with the allowlist entry changed so `brews` is untriaged → **1** with
  the migrate-or-triage message
- `not_a_real_top_field` injected → **1**, hard-error branch
- `brews:` block removed entirely → **0**, "no deprecations"

`shellcheck` clean. The workflow parses as YAML and the job registers. The
goreleaser action SHA **and** `version: '~> v2'` match `release.yml` exactly —
verified, not assumed; a lane validating a different goreleaser than the one that
releases would be worse than no lane.