### PR TITLE
test(multiregion): stop asserting a timing race between two loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`TestPerformance_CompetitorComparison` no longer races two loops against each
+  other** ([#383](https://github.com/scttfrdmn/cargoship/issues/383)). It asserted
+  that basic round-robin out-throughputs CargoShip's region selection, comparing
+  two single samples of millions of ops/sec from in-memory loops that both report
+  `0.00ms` latency. The sides weren't even shaped alike — CargoShip's helper runs
+  at concurrency 10 against a sequential loop — so the assertion required a
+  1-goroutine loop to beat a 10-goroutine one. Measured across 30 rounds the
+  ratio spanned 1.51x–10.34x idle and 1.04x–9.50x under load: true by a wide
+  margin on an idle machine, by 4% on a busy one, which is why it failed in CI and
+  full-suite runs but never in isolation. The ordering assertion is gone (the
+  throughput floors, which catch real regressions, stay), and the overhead
+  comparison moved to `BenchmarkBasicRoundRobinSelection` alongside the existing
+  `BenchmarkRegionSelection`, where repeated samples make it meaningful: 1.73
+  ns/op vs ~13 ns/op, stable to ±1%.
+
 - **The Homebrew formula and Scoop manifest declared the wrong license.** Both
   said `MIT`; the project is Apache-2.0 (`LICENSE`). Every published formula has
   carried the wrong value, including the tap as it stands today — it will correct

--- a/pkg/multiregion/performance_test.go
+++ b/pkg/multiregion/performance_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -486,8 +487,32 @@ func TestPerformance_CompetitorComparison(t *testing.T) {
 		// It should maintain reasonable throughput despite additional complexity
 		assert.Greater(t, cargoshipResult.OperationsPerSec, float64(1000),
 			"CargoShip should maintain reasonable throughput (>1000 ops/sec)")
-		assert.Greater(t, basicResult.OperationsPerSec, cargoshipResult.OperationsPerSec,
-			"Basic round-robin should be faster due to simplicity")
+		assert.Greater(t, basicResult.OperationsPerSec, float64(1000),
+			"Basic round-robin should maintain reasonable throughput (>1000 ops/sec)")
+
+		// There is deliberately NO assertion that basic round-robin is faster
+		// than CargoShip (#383). It used to assert exactly that, and it is not a
+		// claim a single sample can support:
+		//
+		//   - Both figures are millions of ops/sec from tight in-memory loops
+		//     with no I/O; both report 0.00ms latency, i.e. the operations are
+		//     too fast to measure at the resolution being compared.
+		//   - The two sides are not even shaped alike. BenchmarkCargoShipSelection
+		//     runs at concurrency 10 while BenchmarkBasicRoundRobin is one
+		//     sequential loop, so the assertion required a 1-goroutine loop to
+		//     out-throughput a 10-goroutine one.
+		//   - Measured over 30 back-to-back rounds, the basic/CargoShip ratio
+		//     ranged 1.51x–10.34x idle and 1.04x–9.50x under CPU contention. It
+		//     holds by a wide margin on an idle machine and by 4% on a loaded
+		//     one, which is why it inverted on CI and in full-suite runs rather
+		//     than in isolation.
+		//
+		// Per-operation overhead is a real thing to track, but it needs repeated
+		// samples and a tolerance, which is what Benchmark* with -benchtime is
+		// for — not a pass/fail assert in a correctness suite. The existing
+		// perf-regression lane is non-blocking for the same reason.
+		t.Logf("basic/cargoship throughput ratio: %.2fx (informational; not asserted, see #383)",
+			basicResult.OperationsPerSec/cargoshipResult.OperationsPerSec)
 	})
 
 	t.Run("failover vs no-failover", func(t *testing.T) {
@@ -703,6 +728,51 @@ func BenchmarkRegionSelection(b *testing.B) {
 		}
 	})
 }
+
+// BenchmarkBasicRoundRobinSelection is the counterpart to
+// BenchmarkRegionSelection: the same operation with none of CargoShip's
+// health-checking, latency-tracking, or load-balancing logic.
+//
+// This is where the "does the extra machinery cost much?" question belongs
+// (#383). A TestPerformance_CompetitorComparison subtest used to answer it by
+// racing the two implementations once and asserting an ordering, which inverted
+// under CPU contention. Running both benchmarks gives a ratio from repeated
+// samples that can be compared with judgement:
+//
+//	go test -run '^$' -bench 'BenchmarkRegionSelection|BenchmarkBasicRoundRobinSelection' \
+//	  -benchtime 2s ./pkg/multiregion/
+//
+// It is deliberately not wired into a pass/fail gate. Both use b.RunParallel so
+// the comparison is like-for-like, which the original assertion was not — it
+// pitted a concurrency-10 loop against a sequential one.
+func BenchmarkBasicRoundRobinSelection(b *testing.B) {
+	config := createValidMultiRegionConfig()
+	regions := config.Regions
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Counter and sink are per-goroutine on purpose. A shared atomic counter
+		// and a single package-level sink measured 150 ns/op against
+		// BenchmarkRegionSelection's 13 ns/op — i.e. the harness's own
+		// cache-line contention, not the indexing being benchmarked, and it made
+		// the "simpler" implementation look 11x slower. The real round-robin
+		// state in a sequential caller is a plain local, so this matches it.
+		counter := 0
+		var sink Region
+		for pb.Next() {
+			sink = regions[counter%len(regions)]
+			counter++
+		}
+		// Publish once, outside the timed loop's hot path, so the compiler cannot
+		// eliminate the indexing as a dead store.
+		roundRobinSink.Store(&sink)
+	})
+}
+
+// roundRobinSink defeats dead-store elimination in
+// BenchmarkBasicRoundRobinSelection without putting a contended write inside the
+// measured loop.
+var roundRobinSink atomic.Pointer[Region]
 
 func BenchmarkFailoverDetection(b *testing.B) {
 	config := createValidMultiRegionConfig()


### PR DESCRIPTION
Closes #383.

## The assertion

`pkg/multiregion/performance_test.go:489` asserted that basic round-robin
out-throughputs CargoShip's region selection, from **one sample of each**. Both
are millions of ops/sec from in-memory loops, and both report `0.00ms` latency —
the operations are too fast to measure at the resolution being compared.

The sides aren't even shaped alike, which the issue didn't note:
`BenchmarkCargoShipSelection` runs at **concurrency 10** while
`BenchmarkBasicRoundRobin` is a **single sequential loop**. The assertion required
a 1-goroutine loop to out-throughput a 10-goroutine one.

## Measured before changing anything

I couldn't reproduce a failure by running it repeatedly (20 concurrent runs, 0
failures), so rather than declare it fixed by luck I measured the *margin* — 30
back-to-back rounds of both helpers, recording the ratio:

| condition | basic/cargoship ratio |
|---|---|
| idle | **1.51x – 10.34x** |
| under CPU contention | **1.04x – 9.50x** |

A 7x spread with the low end at **1.04** — true by a wide margin on an idle
machine and by 4% on a loaded one. That's the whole explanation for why it passes
in isolation and fails in CI and full-suite runs, and why re-running it would
have been the wrong fix.

## The change

- Ordering assertion **removed**.
- Throughput floors **kept** — they're absolute, not comparative, and they catch
  real regressions. Basic round-robin also gets the `>1000 ops/sec` floor it never
  had, so dropping the comparison doesn't leave it unchecked.
- The ratio is still logged, marked informational.
- The overhead question moves to `BenchmarkBasicRoundRobinSelection`, beside the
  existing `BenchmarkRegionSelection`, both using `b.RunParallel` so the
  comparison is like-for-like:

```
BenchmarkRegionSelection-12              100000000    14.48 ns/op
BenchmarkRegionSelection-12              100000000    13.39 ns/op
BenchmarkRegionSelection-12               98269028    11.55 ns/op
BenchmarkBasicRoundRobinSelection-12     702156960     1.730 ns/op
BenchmarkBasicRoundRobinSelection-12     688907702     1.735 ns/op
BenchmarkBasicRoundRobinSelection-12     696285894     1.747 ns/op
```

~7.5x, stable to ±1% — the same conclusion the flaky assertion was reaching for,
now supported by repeated samples instead of a coin flip.

## A mistake worth recording

My first version of that benchmark used a shared `atomic.Uint64` counter and one
package-level sink, and measured **150 ns/op against RegionSelection's 13** —
making the simpler implementation look 11x *slower*. That was my harness's own
cache-line contention, not the indexing. Both are per-goroutine now, with a
single publish outside the hot path so the compiler can't elide the work. Had I
not sanity-checked the number against the thing it was supposed to be measuring, I
would have shipped a benchmark that inverted the very comparison it exists to
make.

## Verification

10 runs under full CPU saturation (14 spinners on 12 cores): **0 failures**.
gofmt/vet/lint clean; full `-short` suite and the coverage ratchet pass.

Non-blocking pre-existing warning, unrelated to this change: the hook notes
`performance_test.go` lacks a `//go:build performance` tag. Left alone — adding it
would remove the file from the default lane, which is a separate decision.