### PR TITLE
feat(release): sign and notarize the macOS binaries (#381)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,13 @@ on:
 # which is a worse trade — it can leak, has to be rotated, and proves only
 # possession rather than provenance.
 #
-# The token is scoped to this job, expires in minutes, and grants no repository
-# write access of its own. It is declared here rather than at job level because
-# this workflow has exactly one job.
+# The token expires in minutes and grants no repository write access of its own.
+# It is declared on the `goreleaser` JOB rather than workflow-wide (#381): this
+# workflow used to have exactly one job, which made workflow-level scoping
+# equivalent, but the notarization and publish jobs neither sign nor need to
+# assert an identity. Granting them a signing token would be unnecessary
+# privilege for no benefit.
+#
 # `packages: write` used to be here and is gone (#360): nothing in this release
 # publishes to a package registry. `.goreleaser.yml` has no dockers:/kos:/nfpms:
 # stanza (the dockers: block is commented out), and brews:/scoops: push to
@@ -23,13 +27,19 @@ on:
 # privilege matters more than usual right here, because the block above argues for
 # *widening* permissions with id-token: write — an argument that is only as strong
 # as the claim that everything else in this list is justified.
+#
+# contents: write stays workflow-level: all three jobs need it (draft creation,
+# downloading the draft's assets, promotion).
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Only this job runs cosign, so only this job can mint an OIDC token.
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -99,6 +109,40 @@ jobs:
       # not a wrong formula — and if verification fails, a formula pointing at a
       # release that was never published is a far better outcome than the previous
       # behaviour, where the artifacts themselves were already public.
+      # A release must not silently ship unnotarized darwin binaries. The
+      # `notarize:` stanza is gated on `isEnvSet "MACOS_SIGN_P12"` so that forks
+      # and local snapshot builds work without credentials — which means a
+      # missing or misnamed secret here would make goreleaser skip signing and
+      # still report success. That is the one failure mode this whole change
+      # exists to prevent, so assert the material is present before building.
+      # (Deliberately not `if:` on the step — a skipped step is invisible in the
+      # summary, whereas this fails the release with a named cause.)
+      - name: Verify macOS signing material is present
+        env:
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in MACOS_SIGN_P12 MACOS_SIGN_PASSWORD MACOS_NOTARY_ISSUER_ID \
+                      MACOS_NOTARY_KEY_ID MACOS_NOTARY_KEY; do
+            # Indirect expansion, so the VALUE is never echoed — only the name.
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::${#missing[@]} macOS signing secret(s) missing: ${missing[*]}"
+            echo "Without these, goreleaser skips notarization and the darwin"
+            echo "binaries ship adhoc-signed — Gatekeeper SIGKILLs those under"
+            echo "quarantine. See the notarize: stanza in .goreleaser.yml."
+            exit 1
+          fi
+          echo "all 5 macOS signing secrets are present"
+
       - name: Run GoReleaser (draft)
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
@@ -108,6 +152,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
+          # Consumed by the notarize: stanza in .goreleaser.yml. The .p12 and the
+          # .p8 are base64 so they survive as environment variables; goreleaser
+          # decodes both. Never logged — goreleaser masks them, and the check
+          # above prints names only.
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
 
       # Verify the release the way a user would — same command and identity flags
       # documented in SECURITY.md. A signature nobody has verified is an
@@ -163,6 +216,54 @@ jobs:
             echo "${checked}/${expected} digests confirmed; $(grep -c 'sbom.json' checksums.txt) SBOM(s) attached."
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # Prove the darwin artifacts are actually notarized, before promotion (#381).
+  #
+  # A separate job because this is the one thing that CANNOT run on ubuntu:
+  # codesign, spctl and the quarantine bit are macOS-only. It downloads the
+  # draft's real artifacts rather than inspecting dist/ — same reasoning as the
+  # provenance step above. Inspecting the build directory proves the signing step
+  # ran; only the published archive proves users get a signed binary.
+  #
+  # This gates `publish`, so a release that would be SIGKILLed on a user's Mac
+  # never becomes public.
+  notarization:
+    needs: goreleaser
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Both darwin architectures. arm64 is what most Macs run now; x86_64 still
+      # ships, and signing is per-binary, so one being correct says nothing about
+      # the other.
+      - name: Verify darwin binaries are signed and notarized
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          # Execute the quarantined binary, not just inspect its metadata. Safe to
+          # enable here and off by default locally: an unnotarized binary raises a
+          # Gatekeeper popup, which is noise on a jobless runner and jarring on a
+          # developer's desktop.
+          QUARANTINE_PROBE: '1'
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          rm -rf notarize-check && mkdir notarize-check && cd notarize-check
+          for arch in arm64 x86_64; do
+            asset="cargoship_${version}_darwin_${arch}.tar.gz"
+            echo "::group::$asset"
+            gh release download "$TAG" --pattern "$asset" --clobber
+            rm -f cargoship
+            tar xzf "$asset" cargoship
+            bash ../scripts/ci/check-macos-notarization.sh ./cargoship
+            echo "::endgroup::"
+          done
+
+  publish:
+    needs: notarization
+    runs-on: ubuntu-latest
+    steps:
       # Only now is the release public. Everything above can fail without a user
       # ever seeing an unverifiable artifact, which is the entire point of #360.
       #

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,6 +92,61 @@ sboms:
   - id: archive
     artifacts: archive
 
+# Sign and notarize the darwin binaries with an Apple Developer ID (#381).
+#
+# Without this, our darwin artifacts are `adhoc,linker-signed` only. That is fine
+# until the file carries `com.apple.quarantine` — which anything downloaded by a
+# browser or a cask does — at which point Gatekeeper does not warn, it
+# **SIGKILLs the process**: rc=137, no output, no diagnostic. Measured on the
+# published v0.22.0 darwin_arm64 binary. A tool whose failure mode is "killed
+# with no message" is indistinguishable from a corrupt download.
+#
+# This is also the prerequisite for migrating `brews:` to `homebrew_casks:`:
+# casks propagate quarantine, formulae do not, so the migration had to wait for
+# notarization or `brew install` would have broken on macOS. Notarize first,
+# migrate second — deliberately two separate changes, so that if notarization is
+# misconfigured we find out while formulae are still serving users.
+#
+# Runs on ubuntu-latest, not a macOS runner: goreleaser uses `quill`, a pure-Go
+# Mach-O signer, rather than Apple's `codesign`. Verified against 2.17.1 — this
+# is OSS goreleaser, not Pro (confirmed by running it: it fails on a bad
+# certificate, not on a licence check).
+#
+# Ordering matters and is goreleaser's, not ours: build → **sign & notarize** →
+# archives → checksums. So the archive contains the signed binary, and the
+# signature is covered by the cosign-signed checksums.txt like everything else.
+# Verified by running a release with this stanza present.
+notarize:
+  macos:
+    # `enabled` is a template, not a literal `true`: a fork or a local
+    # `goreleaser release --snapshot` has no certificate, and a hard `true` would
+    # fail their build at the signing step. Gating on the secret being present
+    # means the pipe skips cleanly when it cannot run, and runs whenever the
+    # material exists. The tag-time release always has it — see release.yml.
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids:
+        - cargoship
+      sign:
+        # Base64-encoded .p12 holding the Developer ID Application certificate
+        # and its private key. Base64 because a secret has to survive being an
+        # environment variable; goreleaser decodes it.
+        certificate: '{{ .Env.MACOS_SIGN_P12 }}'
+        password: '{{ .Env.MACOS_SIGN_PASSWORD }}'
+      notarize:
+        # App Store Connect API key (Issuer ID + Key ID + base64 .p8). An API key
+        # is used rather than an Apple ID and app-specific password because it is
+        # scoped, revocable independently of the account, and carries no password
+        # that unlocks anything else.
+        issuer_id: '{{ .Env.MACOS_NOTARY_ISSUER_ID }}'
+        key_id: '{{ .Env.MACOS_NOTARY_KEY_ID }}'
+        key: '{{ .Env.MACOS_NOTARY_KEY }}'
+        # Wait for Apple to return a verdict rather than submitting and moving on.
+        # A release that ships an unnotarized binary because the submission was
+        # still queued is the exact failure this stanza exists to prevent, and
+        # the draft→verify→promote flow means waiting costs only wall-clock.
+        wait: true
+        timeout: 30m
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **macOS binaries are now signed with an Apple Developer ID and notarized**
+  ([#381](https://github.com/scttfrdmn/cargoship/issues/381)). Previously they
+  carried only an ad-hoc linker signature, which is fine until the file picks up
+  `com.apple.quarantine` — as anything downloaded by a browser does. Gatekeeper's
+  response to that is not a warning dialog: it **SIGKILLs the process**, rc=137,
+  no output and no diagnostic. Measured on the published v0.22.0 `darwin_arm64`
+  binary, so "cargoship does nothing at all" was a real and undiagnosable
+  experience for anyone who installed from a direct download.
+
+  Signing runs on the existing `ubuntu-latest` runner — goreleaser uses `quill`,
+  a pure-Go Mach-O signer, not Apple's `codesign`. A new macOS job then downloads
+  the draft release's actual artifacts and asserts all four properties (Developer
+  ID authority, hardened runtime, `spctl` notarization verdict, and that the
+  binary *runs* while quarantined) **before** the release is promoted, so a
+  release that would be killed on a user's Mac cannot become public. Note that
+  `codesign --verify --strict` is not used for this: it returns success for an
+  ad-hoc signed binary too, so it cannot tell signed from unsigned.
+
+  This also unblocks migrating the Homebrew formula to a cask, which was waiting
+  on notarization because casks propagate quarantine and formulae do not.
+
+### Changed
+
+- `id-token: write` is now scoped to the one release job that runs cosign, rather
+  than the whole workflow. It was workflow-level when the workflow had a single
+  job; it now has three, and neither the notarization nor the publish job needs to
+  assert an identity.
+
 ## [0.23.0] - 2026-08-04
 
 **Key Material & Contracts.** Two breaking changes, both closing a gap between

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -67,6 +67,35 @@ sudo mv cargoship-darwin-amd64 /usr/local/bin/cargoship
 
 :::
 
+## macOS: signing and Gatekeeper
+
+From **v0.24.0** the macOS binaries are signed with an Apple Developer ID and
+notarized by Apple, so they run from a download with no extra steps.
+
+**Earlier versions were not.** They carried only an ad-hoc signature, and macOS
+attaches a `com.apple.quarantine` attribute to anything a browser downloads.
+Gatekeeper's response to a quarantined, un-notarized binary is not a warning
+dialog — it **kills the process outright**, with no output. If you are on
+v0.23.0 or older and `cargoship` appears to do nothing at all, that is what
+happened. Either upgrade, or clear the attribute yourself:
+
+```bash
+xattr -d com.apple.quarantine /usr/local/bin/cargoship
+```
+
+Installing via Homebrew or `go install` avoids this on any version: neither path
+sets the quarantine attribute.
+
+You can confirm a binary is signed and notarized:
+
+```bash
+codesign -dvvv $(which cargoship) 2>&1 | grep Authority
+# Authority=Developer ID Application: ...
+
+spctl -a -vvv -t install $(which cargoship)
+# source=Notarized Developer ID
+```
+
 ## Docker
 
 Run CargoShip in a container without installing anything locally. Mount your data

--- a/scripts/ci/check-macos-notarization.sh
+++ b/scripts/ci/check-macos-notarization.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Assert that a released darwin binary is Developer-ID signed AND notarized, and
+# that it actually runs under quarantine (#381).
+#
+# Why this is not redundant with "the release step said it signed": goreleaser's
+# `notarize:` pipe is gated on a secret being present, so a missing or renamed
+# secret makes it SKIP and report success. And notarization is a round-trip
+# through Apple — a stapling or submission problem produces a binary that looks
+# signed locally and is still killed on a user's machine. The only claim worth
+# publishing is the one tested the way a user experiences it: download, quarantine,
+# execute.
+#
+# What "not notarized" costs, measured on the published v0.22.0 darwin_arm64
+# binary: under com.apple.quarantine, Gatekeeper does not warn — it SIGKILLs the
+# process. rc=137, no output, no diagnostic.
+#
+# MUST run on a macOS runner: codesign, spctl and the quarantine bit are all
+# macOS-only. There is no Linux equivalent, so this cannot be folded into the
+# ubuntu release job.
+#
+# Usage: scripts/ci/check-macos-notarization.sh <path-to-binary>
+set -uo pipefail
+
+bin="${1:-}"
+if [ -z "$bin" ] || [ ! -f "$bin" ]; then
+  echo "::error::usage: $0 <path-to-binary> (got '${bin}')"
+  exit 1
+fi
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "::error::this check requires macOS (codesign/spctl/quarantine are macOS-only)"
+  exit 1
+fi
+
+fail=0
+note() { echo "  $*"; }
+
+echo "== Checking $bin"
+
+# 1. Developer ID authority. An adhoc/linker-signed binary has NO Authority line
+#    at all, which is exactly what our releases looked like before #381.
+authority="$(codesign -dvvv "$bin" 2>&1 | grep -E '^Authority=' | head -1 | sed 's/^Authority=//')"
+if [ -z "$authority" ]; then
+  echo "::error::$bin has no signing authority — it is adhoc/linker-signed, not Developer ID signed"
+  note "codesign flags: $(codesign -dvvv "$bin" 2>&1 | grep -oE 'flags=0x[0-9a-f]+\([^)]*\)' | head -1)"
+  fail=1
+elif ! printf '%s' "$authority" | grep -q '^Developer ID Application:'; then
+  echo "::error::$bin is signed by '$authority', not a Developer ID Application certificate"
+  fail=1
+else
+  note "authority: $authority"
+fi
+
+# 2. Hardened runtime. Apple refuses to notarize without it, so this should be
+#    implied by step 3 — but assert it directly, because a check that only
+#    verifies a downstream consequence tells you less when it breaks.
+flags="$(codesign -dvvv "$bin" 2>&1 | grep -oE 'flags=0x[0-9a-f]+\([^)]*\)' | head -1)"
+if printf '%s' "$flags" | grep -q 'runtime'; then
+  note "hardened runtime: yes ($flags)"
+else
+  echo "::error::$bin lacks the hardened runtime flag ($flags); Apple will not notarize it"
+  fail=1
+fi
+
+# 3. Notarization, per Gatekeeper itself. This is THE discriminating check:
+#    `codesign --verify --strict` returns 0 for an adhoc-signed binary too
+#    (verified on both a Developer-ID binary and one of ours), so it cannot tell
+#    signed from unsigned and is not used here.
+#
+#    A notarized binary reports `source=Notarized Developer ID`; ours reported
+#    `rejected`.
+assessment="$(spctl -a -vvv -t install "$bin" 2>&1)"
+if printf '%s' "$assessment" | grep -q 'source=Notarized Developer ID'; then
+  note "gatekeeper: $(printf '%s' "$assessment" | grep -o 'source=[^ ]*.*' | head -1)"
+else
+  echo "::error::$bin is not notarized — Gatekeeper says: $(printf '%s' "$assessment" | tr '\n' ' ')"
+  fail=1
+fi
+
+# 4. The end-to-end claim: does it RUN when quarantined? Steps 1-3 inspect
+#    metadata; only this executes the thing a user downloads.
+#
+#    Off by default, because a REJECTED probe raises a "'probe' Not Opened —
+#    Apple could not verify..." notification on the machine running it. On a CI
+#    runner nobody sees that; on a developer's Mac it is an alarming popup caused
+#    by a script they ran for an unrelated reason, and it happened to this repo's
+#    owner twice. CI sets QUARANTINE_PROBE=1 (see release.yml); locally you opt in
+#    knowing what it does.
+probed=no
+if [ "${QUARANTINE_PROBE:-0}" = "1" ]; then
+  probed=yes
+  # Run from a copy so the xattr cannot leak into the caller's file.
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  cp "$bin" "$tmp/probe"
+  xattr -w com.apple.quarantine "0083;00000000;Safari;" "$tmp/probe"
+  note "quarantine set: $(xattr -p com.apple.quarantine "$tmp/probe" 2>&1)"
+
+  # Capture the status directly. Piping into `head` reports HEAD's exit code,
+  # which is how a SIGKILL first read as a success here.
+  out="$("$tmp/probe" --version 2>&1)"
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    note "quarantined run: ok (rc=0) — $out"
+  elif [ "$rc" -eq 137 ]; then
+    echo "::error::quarantined binary was SIGKILLed by Gatekeeper (rc=137) — this is the unnotarized failure mode"
+    fail=1
+  else
+    echo "::error::quarantined binary exited $rc: $out"
+    fail=1
+  fi
+else
+  note "quarantined run: SKIPPED (set QUARANTINE_PROBE=1 to enable; it raises a"
+  note "  Gatekeeper notification when the binary is not notarized)"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "::error::$bin is NOT properly signed and notarized"
+  exit 1
+fi
+
+echo
+# Don't claim the part that was skipped. A summary line that overstates what ran
+# is how a weakened check goes unnoticed.
+if [ "$probed" = "yes" ]; then
+  echo "$bin is Developer ID signed, notarized, and runs under quarantine"
+else
+  echo "$bin is Developer ID signed and notarized (quarantined-run probe skipped)"
+fi


### PR DESCRIPTION
Step 1 of #381: **notarize now, migrate `brews:` → `homebrew_casks:` after one
release**. This PR does not touch `brews:`, and the CI allowlist is unchanged.

## The problem

Our darwin artifacts are `adhoc,linker-signed` only. That is fine until the file
carries `com.apple.quarantine` — as anything a browser downloads does — at which
point Gatekeeper does not warn, it **SIGKILLs the process**: `rc=137`, no output,
no diagnostic. Measured on the published v0.22.0 `darwin_arm64` binary. So
"cargoship does nothing at all" was a real and undiagnosable experience for
anyone installing from a direct download.

## What this does

- `notarize.macos` in `.goreleaser.yml`, signing + notarizing both darwin builds.
- Five new secrets, asserted present in `release.yml` before the build runs.
- A new `macos-latest` job that verifies the **draft's** artifacts before
  promotion, so a release that would be killed on a user's Mac cannot publish.
- `scripts/ci/check-macos-notarization.sh`, checking four properties.
- `docs/start/install.md`: a macOS signing section, including how to recover on
  v0.23.0 and older.
- Scopes `id-token: write` to the one job that runs cosign.

## Things I verified rather than assumed

- **`notarize` is OSS, not Pro.** Ran it: fails on a bad certificate
  (`unable to decode p12 file`), not on a licence gate.
- **No macOS runner needed for signing.** goreleaser uses `quill`, a pure-Go
  Mach-O signer, not Apple's `codesign`. The macOS job is only for *verifying*,
  since `codesign`/`spctl`/quarantine have no Linux equivalent.
- **Pipeline order is already correct** — build → sign & notarize → archives →
  checksums, confirmed by running a release. The archive contains the signed
  binary and the signature is covered by the cosign-signed `checksums.txt`. No
  reordering needed.
- **The `isEnvSet` gate works in both directions.** Secret absent →
  `reason=disabled` and the build succeeds (forks, local snapshots). Secret
  present → attempts and fails loudly. It cannot silently skip on a real release.
- **`codesign --verify --strict` is useless here** and is deliberately not used:
  it returns `0` for an adhoc-signed binary too. The discriminating check is
  `spctl -a -t install` (`source=Notarized Developer ID` vs `rejected`).
- **The checker was tested against both controls**, per stash-verify-discipline:
  it fails all four checks on the real v0.23.0 release binary — including
  reproducing `rc=137` — and passes on `docker-credential-osxkeychain`, a
  genuinely notarized standalone CLI. My first positive control was invalid
  (I copied a binary out of its `.app`, which invalidates its resource
  directory); testing in place and then against a standalone CLI fixed that.

## Jarring-popup jitters

A rejected quarantine probe raises a Gatekeeper *"could not verify"*
notification on whatever machine runs it. That is invisible on a CI runner and
alarming on a desktop — it fired on the repo owner's Mac while I was developing
this. So the probe is **off by default** and enabled only via
`QUARANTINE_PROBE=1` in `release.yml`; the summary line states when it was
skipped, so a weakened check can't read as a full pass.

## Jobs

`goreleaser` (ubuntu) → `notarization` (macOS) → `publish` (ubuntu).

## Before merging

The five secrets must exist or **the release job will fail by design**. See the
PR discussion for the exact generation steps.

## Noticed in passing

Every `curl` command under "Pre-built binaries" in `install.md` 404s — filed as
#406, not fixed here.

Refs #381