### PR TITLE
fix(docker): re-pin golang builder to 1.26.8 to clear 9 HIGH stdlib CVEs

### DIFF
--- a/docker/Dockerfile.astrapi
+++ b/docker/Dockerfile.astrapi
@@ -3,7 +3,7 @@
 #
 # A ghost ship archives autonomously and binds no port, so this image exposes
 # nothing and has no HTTP healthcheck. Status goes to the container log.
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26-alpine@sha256:ce864e7223ac17b1775e6fd0b4c0db580c2eb50e7953a427916379e4b92a1628 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/docker/Dockerfile.ghost-ship
+++ b/docker/Dockerfile.ghost-ship
@@ -5,7 +5,7 @@
 # inbound connections, so there is nothing to EXPOSE and no HTTP endpoint to
 # health-check. Status goes to the container log (see runStatusReporter) — read
 # it with `docker logs`.
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26-alpine@sha256:ce864e7223ac17b1775e6fd0b4c0db580c2eb50e7953a427916379e4b92a1628 AS builder
 
 # Install dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/docker/Dockerfile.qnap
+++ b/docker/Dockerfile.qnap
@@ -3,7 +3,7 @@
 #
 # A ghost ship archives autonomously and binds no port, so this image exposes
 # nothing and has no HTTP healthcheck. Status goes to the container log.
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26-alpine@sha256:ce864e7223ac17b1775e6fd0b4c0db580c2eb50e7953a427916379e4b92a1628 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata


### PR DESCRIPTION
The three `docker/Dockerfile.*` builders pinned `golang:1.26-alpine` at a digest
resolving to **Go 1.26.5**. Trivy's *image* scan (`docker-build.yml`,
`exit-code=1`) flags **9 HIGH stdlib CVEs** compiled into the shipped binaries —
`CVE-2026-33818` (encoding/asn1 DoS), `CVE-2026-56853` (net/http HTTP/2 DoS),
`CVE-2026-56862` (crypto/tls) and others — all fixed in **Go 1.26.6+**.

This is the baseline that was failing **Deployment images build and start** on
every scheduled Docker Build run since 2026-08-17 and on every Go-touching PR.

## Fix

Re-pin to the current `golang:1.26-alpine` digest, which resolves to **Go
1.26.8** (verified: `docker run … go version` → `go1.26.8`). Still 1.26.x — CI's
declared toolchain is unchanged, only the patch moves. Chosen over #413's jump to
`1.27-alpine` to stay on the same minor CargoShip builds and tests against.

## Stacked on #418

Based on `fix/govulncheck-go-git-xcrypto` on purpose: the image scan also reads
the Go **modules** embedded in the binary, so without #418's go-git/x-crypto/grpc
bumps in the same tree Trivy would flag those in the image instead. GitHub
retargets this to `main` when #418 merges.

Supersedes the base-image half of #413.