### PR TITLE
fix(s3): honour an explicit per-object storage class in Transporter (#352)

### DIFF
--- a/pkg/aws/s3/s3_test.go
+++ b/pkg/aws/s3/s3_test.go
@@ -151,6 +151,36 @@ func TestOptimizeStorageClass(t *testing.T) {
 			},
 			expectedStorage: types.StorageClassStandard,
 		},
+		{
+			// #352: an explicitly requested class must win over the config
+			// default. The config here is STANDARD, so a naive fallback would
+			// return STANDARD and drop the caller's GLACIER request.
+			name: "explicit storage class overrides config default",
+			archive: Archive{
+				StorageClass: awsconfig.StorageClassGlacier,
+			},
+			expectedStorage: types.StorageClassGlacier,
+		},
+		{
+			// #352: an explicit class must also win over the access-pattern
+			// heuristics. AccessPattern "rare" would otherwise force GLACIER;
+			// the caller asked for STANDARD_IA and gets it.
+			name: "explicit storage class overrides access-pattern heuristic",
+			archive: Archive{
+				StorageClass:  awsconfig.StorageClassStandardIA,
+				AccessPattern: "rare",
+			},
+			expectedStorage: types.StorageClassStandardIa,
+		},
+		{
+			// Guard the fallback: no explicit class still uses the config
+			// default, so honouring StorageClass didn't break the common path.
+			name: "empty storage class falls back to config default",
+			archive: Archive{
+				StorageClass: "",
+			},
+			expectedStorage: types.StorageClassStandard,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/aws/s3/transporter.go
+++ b/pkg/aws/s3/transporter.go
@@ -141,6 +141,15 @@ func (t *Transporter) Upload(ctx context.Context, archive Archive) (*UploadResul
 
 // optimizeStorageClass selects the optimal storage class based on archive characteristics
 func (t *Transporter) optimizeStorageClass(archive Archive) types.StorageClass {
+	// An explicitly requested class is a decision the caller already made, so it
+	// wins over both the configured default and the heuristics below (which are
+	// for archives that express an intent via AccessPattern/RetentionDays rather
+	// than naming a class). Without this, a per-object StorageClass is silently
+	// ignored on this path while OptimizedTransporter honours it — see #352.
+	if archive.StorageClass != "" {
+		return types.StorageClass(archive.StorageClass)
+	}
+
 	// Use configured default if no optimization criteria
 	if archive.AccessPattern == "" && archive.RetentionDays == 0 {
 		return types.StorageClass(t.config.StorageClass)


### PR DESCRIPTION
`Transporter.optimizeStorageClass` returned the transporter's **config** storage
class for any archive with no `AccessPattern` and no `RetentionDays`, never
consulting `Archive.StorageClass`. A caller setting the field per object — the
documented way to request a class — was silently ignored: the object stored,
read back, and only billed differently. `OptimizedTransporter` already honours
it (`optimized_transporter.go:108,141`), so the two transporters disagreed.

## Fix
Explicit `Archive.StorageClass` now wins over the config default **and** the
access-pattern heuristics; empty still falls back. Matches `OptimizedTransporter`.

## Tests
Three cases added to `TestOptimizeStorageClass` (explicit beats default; explicit
beats the `"rare"`→GLACIER heuristic; empty still falls back). The first two were
confirmed to **fail** against the pre-fix tree per stash-verify-discipline.

## Downstream
ObjectFS builds one `Archive` per object with `StorageClass` set and no
`AccessPattern`/`RetentionDays` — exactly the shape that hit the fallback — and
had to bypass the transporter to place small objects in STANDARD.

Closes #352

_(Recreated on `main` after #418 merged; supersedes the auto-closed #419.)_