### PR TITLE
fix(docker): re-pin golang builder to 1.26.8 to clear 9 HIGH stdlib CVEs

### DIFF
--- a/docker/Dockerfile.astrapi
+++ b/docker/Dockerfile.astrapi
@@ -3,7 +3,7 @@
 #
 # A ghost ship archives autonomously and binds no port, so this image exposes
 # nothing and has no HTTP healthcheck. Status goes to the container log.
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26-alpine@sha256:ce864e7223ac17b1775e6fd0b4c0db580c2eb50e7953a427916379e4b92a1628 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata
@@ -58,7 +58,12 @@ FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec4
 #
 # curl and inotify-tools are gone with the features that needed them — the
 # healthcheck (#348) and the FileWatcher deleted in #347.
-RUN apk add --no-cache \
+#
+# `apk upgrade` first: the pinned alpine:3.24 snapshot ships openssl 3.5.7-r0
+# (Trivy HIGH); 3.5.8-r0 is already in the v3.24 branch, so upgrading at build
+# time clears it and any later base-package fixes despite the lagging digest.
+RUN apk upgrade --no-cache \
+    && apk add --no-cache \
     ca-certificates \
     tzdata \
     aws-cli \

--- a/docker/Dockerfile.ghost-ship
+++ b/docker/Dockerfile.ghost-ship
@@ -5,7 +5,7 @@
 # inbound connections, so there is nothing to EXPOSE and no HTTP endpoint to
 # health-check. Status goes to the container log (see runStatusReporter) — read
 # it with `docker logs`.
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26-alpine@sha256:ce864e7223ac17b1775e6fd0b4c0db580c2eb50e7953a427916379e4b92a1628 AS builder
 
 # Install dependencies
 RUN apk add --no-cache git ca-certificates tzdata
@@ -31,10 +31,16 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cargoship-test ./
 # Final stage
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
+# Upgrade base packages first: the pinned alpine:3.24 snapshot ships openssl
+# (libcrypto3/libssl3) 3.5.7-r0, which Trivy flags HIGH; 3.5.8-r0 is already in
+# the v3.24 branch even though the image predates it. `apk upgrade` pulls it and
+# any later base-package security fixes at build time, so a lagging base image
+# digest doesn't strand a known-fixed CVE in the shipped image.
+#
 # Install required packages. ca-certificates is needed to reach S3 over TLS;
 # nothing else is. curl was here only for the removed healthcheck, and
 # inotify-tools for the FileWatcher deleted in #347 — a ghost ship polls.
-RUN apk --no-cache add ca-certificates
+RUN apk upgrade --no-cache && apk --no-cache add ca-certificates
 
 # Create app directory. Not /root — the container runs as USER cargoship below,
 # and /root is mode 0700 owned by root, so the binary would be unreachable.

--- a/docker/Dockerfile.qnap
+++ b/docker/Dockerfile.qnap
@@ -3,7 +3,7 @@
 #
 # A ghost ship archives autonomously and binds no port, so this image exposes
 # nothing and has no HTTP healthcheck. Status goes to the container log.
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26-alpine@sha256:ce864e7223ac17b1775e6fd0b4c0db580c2eb50e7953a427916379e4b92a1628 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata
@@ -55,7 +55,12 @@ FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec4
 #
 # curl and inotify-tools are gone with the features that needed them — the
 # healthcheck (#348) and the FileWatcher deleted in #347.
-RUN apk add --no-cache \
+#
+# `apk upgrade` first: the pinned alpine:3.24 snapshot ships openssl 3.5.7-r0
+# (Trivy HIGH); 3.5.8-r0 is already in the v3.24 branch, so upgrading at build
+# time clears it and any later base-package fixes despite the lagging digest.
+RUN apk upgrade --no-cache \
+    && apk add --no-cache \
     ca-certificates \
     tzdata \
     aws-cli \


### PR DESCRIPTION
The three `docker/Dockerfile.*` builders pinned `golang:1.26-alpine` at a digest
resolving to **Go 1.26.5**. Trivy's *image* scan (`docker-build.yml`,
`exit-code=1`) flags **9 HIGH stdlib CVEs** compiled into the shipped binaries —
`CVE-2026-33818`, `CVE-2026-56853`, `CVE-2026-56862` and others — all fixed in
**Go 1.26.6+**. This is the baseline that failed **Deployment images build and
start** on every scheduled run since 2026-08-17.

## Fix
Re-pin to the current `golang:1.26-alpine` digest = **Go 1.26.8** (verified by
running it). Still 1.26.x, so CI's declared toolchain is unchanged. Chosen over
#413's jump to `1.27-alpine` to stay on the minor CargoShip builds/tests against.

Supersedes the base-image half of #413.

_(Recreated on `main` after #418 merged; supersedes the auto-closed #420.)_