### PR TITLE
fix(sync): actually upload — set UseRealS3/S3Client on the pipeline (#425)

### DIFF
--- a/cmd/cargoship/cmd/sync.go
+++ b/cmd/cargoship/cmd/sync.go
@@ -221,40 +221,31 @@ Examples:
 				includeFiles = append(includeFiles, file.Path)
 			}
 
-			pipelineConfig := &pipeline.PipelineConfig{
-				S3Bucket:          bucket,
-				S3Prefix:          prefix,
-				S3Region:          region,
-				S3StorageClass:    storageClass,
-				EnableMultiPrefix: true,
-				ShardCount:        shardCount,
-				WorkersPerPrefix:  2,
-				EnableManifest:    true,
-				SourcePath:        absPath,
-
-				// #316: sync advertised --shard-strategy and --compression-level
-				// and dropped both, without even upload's printout to hint that
-				// they were inert. --compression-level is an override, so only
-				// an explicitly passed value is forwarded; 0 keeps content-aware
-				// per-chunk selection.
-				ShardStrategy: shardStrategy,
-				CompressionLevel: func() int {
-					if cmd.Flags().Changed("compression-level") {
-						return compressionLevel
-					}
-					return 0
-				}(),
-
-				// Issue #148: Incremental sync configuration
-				IncludeOnlyFiles: includeFiles,
-				SyncType:         syncType,
-				PreviousUploadID: func() string {
-					if previousManifest != nil {
-						return previousManifest.UploadID
-					}
-					return ""
-				}(),
+			// #316: --compression-level is an override, so only an explicitly
+			// passed value is forwarded; 0 keeps content-aware per-chunk selection.
+			effectiveCompression := 0
+			if cmd.Flags().Changed("compression-level") {
+				effectiveCompression = compressionLevel
 			}
+			previousUploadID := ""
+			if previousManifest != nil {
+				previousUploadID = previousManifest.UploadID
+			}
+
+			pipelineConfig := newSyncPipelineConfig(syncPipelineParams{
+				bucket:           bucket,
+				prefix:           prefix,
+				region:           region,
+				storageClass:     storageClass,
+				shardCount:       shardCount,
+				shardStrategy:    shardStrategy,
+				compressionLevel: effectiveCompression,
+				sourcePath:       absPath,
+				includeFiles:     includeFiles,
+				syncType:         syncType,
+				previousUploadID: previousUploadID,
+				s3Client:         s3Client,
+			})
 
 			pipe, err := pipeline.NewPipeline(pipelineConfig)
 			if err != nil {
@@ -307,6 +298,56 @@ Examples:
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Quiet mode (minimal output)")
 
 	return cmd
+}
+
+// syncPipelineParams carries the already-resolved inputs for a sync upload.
+type syncPipelineParams struct {
+	bucket           string
+	prefix           string
+	region           string
+	storageClass     string
+	shardStrategy    string
+	sourcePath       string
+	previousUploadID string
+	syncType         string
+	shardCount       int
+	compressionLevel int
+	includeFiles     []string
+	s3Client         *s3.Client
+}
+
+// newSyncPipelineConfig builds the pipeline config for `cargoship sync`.
+//
+// #425: this MUST set UseRealS3 + S3Client. Without them NewPipeline defaults
+// UseRealS3 to false, which silently selects the simulated read-and-discard
+// uploader and skips the manifest — so sync would report success while
+// transferring nothing. Extracted from the command closure so a test can assert
+// the real-upload fields are set (the closure itself is not unit-testable).
+func newSyncPipelineConfig(p syncPipelineParams) *pipeline.PipelineConfig {
+	return &pipeline.PipelineConfig{
+		S3Bucket:          p.bucket,
+		S3Prefix:          p.prefix,
+		S3Region:          p.region,
+		S3StorageClass:    p.storageClass,
+		EnableMultiPrefix: true,
+		ShardCount:        p.shardCount,
+		WorkersPerPrefix:  2,
+		EnableManifest:    true,
+		SourcePath:        p.sourcePath,
+
+		// Real S3 upload — see the #425 note above.
+		UseRealS3: true,
+		S3Client:  p.s3Client,
+
+		// #316: forwarded sync flags.
+		ShardStrategy:    p.shardStrategy,
+		CompressionLevel: p.compressionLevel,
+
+		// #148: incremental sync configuration.
+		IncludeOnlyFiles: p.includeFiles,
+		SyncType:         p.syncType,
+		PreviousUploadID: p.previousUploadID,
+	}
 }
 
 // downloadLatestManifest attempts to download the latest manifest for a source path (Issue #148)

--- a/cmd/cargoship/cmd/sync_test.go
+++ b/cmd/cargoship/cmd/sync_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// TestNewSyncPipelineConfig_UsesRealS3 guards #425: `cargoship sync` must build a
+// pipeline that actually uploads. If UseRealS3/S3Client are dropped the pipeline
+// silently falls back to the simulated uploader and skips the manifest — the
+// command reports success while transferring nothing. This test fails if that
+// regresses.
+func TestNewSyncPipelineConfig_UsesRealS3(t *testing.T) {
+	client := &s3.Client{}
+	cfg := newSyncPipelineConfig(syncPipelineParams{
+		bucket:           "bucket",
+		prefix:           "prefix",
+		region:           "us-west-2",
+		storageClass:     "STANDARD",
+		shardCount:       4,
+		shardStrategy:    "round-robin",
+		compressionLevel: 0,
+		sourcePath:       "/data/src",
+		includeFiles:     []string{"a.txt", "b.txt"},
+		syncType:         "incremental",
+		previousUploadID: "prev-123",
+		s3Client:         client,
+	})
+
+	if !cfg.UseRealS3 {
+		t.Fatal("#425: sync must set UseRealS3=true, else it uploads nothing")
+	}
+	if cfg.S3Client == nil {
+		t.Fatal("#425: sync must set S3Client when UseRealS3 is true")
+	}
+	if got, ok := cfg.S3Client.(*s3.Client); !ok || got != client {
+		t.Errorf("S3Client = %v, want the provided *s3.Client", cfg.S3Client)
+	}
+	if !cfg.EnableManifest {
+		t.Error("sync must enable the manifest")
+	}
+
+	// Spot-check the rest of the plumbing so the extraction didn't drop fields.
+	if cfg.S3Bucket != "bucket" || cfg.S3Prefix != "prefix" || cfg.S3Region != "us-west-2" {
+		t.Errorf("bucket/prefix/region not mapped: %+v", cfg)
+	}
+	if cfg.ShardCount != 4 || cfg.ShardStrategy != "round-robin" {
+		t.Errorf("shard settings not mapped: count=%d strategy=%q", cfg.ShardCount, cfg.ShardStrategy)
+	}
+	if cfg.SyncType != "incremental" || cfg.PreviousUploadID != "prev-123" {
+		t.Errorf("sync/manifest chaining not mapped: type=%q prev=%q", cfg.SyncType, cfg.PreviousUploadID)
+	}
+	if len(cfg.IncludeOnlyFiles) != 2 {
+		t.Errorf("IncludeOnlyFiles = %v, want 2 files", cfg.IncludeOnlyFiles)
+	}
+	if cfg.CompressionLevel != 0 {
+		t.Errorf("CompressionLevel = %d, want 0 (content-aware)", cfg.CompressionLevel)
+	}
+}


### PR DESCRIPTION
## The bug (silent data loss)

`cargoship sync` computed the correct delta, printed `📤 Uploading N changed
files`, ran the pipeline, and exited **0 having transferred nothing** — and wrote
no manifest. Its `PipelineConfig` (`sync.go:224`) omitted **`UseRealS3`** and
**`S3Client`**, so `NewPipeline` defaulted `UseRealS3` to `false`, selected the
**simulated** read-and-discard uploader, and gated off the manifest write
(`pipeline.go:185`). An `s3.Client` was already built at `sync.go:117` for the
manifest fetch — it just wasn't passed. `upload`/`create`/`migrate` all set both
fields; `sync` was the lone omission, and there was no `sync_test.go`.

Found during the "advertised vs actually-wired" audit (same sweep as #424).

## Fix

- Extracted the config construction into `newSyncPipelineConfig` (the cobra
  `RunE` closure isn't unit-testable) and set `UseRealS3: true` + `S3Client`.
- Added `TestNewSyncPipelineConfig_UsesRealS3`, which fails if either field is
  dropped. Per stash-verify-discipline I confirmed it **fails against the pre-fix
  construction** (`UseRealS3=false`) before restoring the fix.
- Dry-run still returns before the pipeline, so `--dry-run` uploads nothing as
  before.

## Follow-up (not in this PR)

A cmd-level emulator end-to-end test that runs `sync` and asserts the object
lands (HeadObject) would prove the whole path, not just the config. Worth adding;
kept out here to keep the fix tight and get the data-loss fix in quickly.

Closes #425