### PR TITLE
test(ci): anti-theater guard — block new stub/fabricated-metric code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Check nested modules resolve against root
         run: bash scripts/ci/check-nested-modules.sh
 
+      # Anti-theater ratchet (#424 audit): fail on NEW stub/mock/fabricated-metric
+      # markers in production code. Known, tracked instances are allowlisted in
+      # scripts/ci/theater-allowlist.txt and burn down as each is wired or deleted.
+      - name: Check for new theater (stubbed/fabricated behaviour)
+        run: bash scripts/ci/check-no-theater.sh
+
   e2e-quickstart:
     name: Quick Start E2E (emulator)
     runs-on: ubuntu-latest

--- a/scripts/ci/check-no-theater.sh
+++ b/scripts/ci/check-no-theater.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Anti-theater guard: fail if production Go code contains high-signal markers of
+# fake/stubbed behaviour presented as real. Born from the 2026-09 "advertised vs
+# actually-wired" audit, which found stub functions that only log, hardcoded
+# "improvement" metrics (4.6x / 78.3% / 25%), and mock data returned as if live.
+#
+# This is a RATCHET, not a big-bang cleaner: every currently-known instance is
+# listed in theater-allowlist.txt with a tracking reference, so the gate passes
+# today while forbidding NEW theater anywhere else. When a subsystem is wired for
+# real or deleted, remove its allowlist line — that is the "done" signal.
+#
+# Usage:
+#   scripts/ci/check-no-theater.sh            # gate: allowlisted debt tolerated
+#   scripts/ci/check-no-theater.sh --all      # report every match, ignore allowlist
+#
+# Exit: 0 = clean (modulo allowlist), 1 = new theater found, 2 = usage.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+ALLOWLIST="scripts/ci/theater-allowlist.txt"
+show_all=0
+[ "${1:-}" = "--all" ] && show_all=1
+
+# High-signal lie-markers. Kept deliberately narrow to avoid false positives on
+# honest simulation (benchmarks, estimators, test data legitimately "simulate").
+#  1. stub bodies that only describe what they'd do
+#  2. placeholder-for-real-implementation comments
+#  3. mock data returned on a production path
+#  4. hardcoded POSITIVE "improvement" metrics (a real metric comes from a
+#     variable; ": 0" is an honest default and is not matched)
+PATTERNS=(
+  'In full implementation'
+  'would be replaced with (a |an )?actual'
+  'For now, return mock'
+  '(OptimizationRatio|BandwidthSavings|LatencyReduction):[[:space:]]*[1-9]'
+)
+
+# Production Go only: no tests, examples, nested example modules, or benchmarks
+# (those are honestly allowed to simulate).
+mapfile -t files < <(git ls-files '*.go' ':!:*_test.go' ':!:examples/*' ':!:tests/*' ':!:benchmarks/*')
+
+# Load allowlist globs (lines: "<path-glob>  # reason (issue)"; blanks/comments skipped).
+allow=()
+if [ -f "$ALLOWLIST" ]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="$(printf '%s' "$line" | xargs || true)"
+    [ -n "$line" ] && allow+=("$line")
+  done < "$ALLOWLIST"
+fi
+
+is_allowlisted() {
+  local f="$1"
+  ((show_all)) && return 1
+  local g
+  for g in "${allow[@]}"; do
+    # shellcheck disable=SC2053
+    [[ "$f" == $g ]] && return 0
+  done
+  return 1
+}
+
+violations=0
+allowed_hits=0
+for f in "${files[@]}"; do
+  for pat in "${PATTERNS[@]}"; do
+    while IFS= read -r hit; do
+      [ -z "$hit" ] && continue
+      if is_allowlisted "$f"; then
+        allowed_hits=$((allowed_hits + 1))
+      else
+        echo "::error::theater marker in $f:$hit"
+        violations=$((violations + 1))
+      fi
+    done < <(grep -nE "$pat" "$f" 2>/dev/null)
+  done
+done
+
+if ((show_all)); then
+  echo "reported all matches (allowlist ignored)"
+  exit 0
+fi
+
+if [ "$violations" -gt 0 ]; then
+  echo
+  echo "::error::$violations new theater marker(s) found in production code."
+  echo "Wire the behaviour for real, or — if this is known, tracked debt — add the"
+  echo "file to $ALLOWLIST with an issue reference."
+  exit 1
+fi
+
+echo "no new theater markers ($allowed_hits allowlisted instance(s) still pending burn-down)"
+exit 0

--- a/scripts/ci/theater-allowlist.txt
+++ b/scripts/ci/theater-allowlist.txt
@@ -1,0 +1,20 @@
+# Anti-theater allowlist — known, TRACKED fake/stub behaviour in production code.
+# Each line is a path glob whose theater markers check-no-theater.sh tolerates.
+# The gate still blocks NEW theater in every other file. Removing a line here is
+# the "wired for real or deleted" done-signal. Every entry MUST cite an issue.
+#
+# Burn-down inventory (2026-09 advertised-vs-wired audit):
+
+# #424 — congestion control is inert: applyOptimizations is a log-only stub and
+# getPerformanceMetrics returns hardcoded 4.6x / 78.3% / 25%. Removed when the
+# real BBR pacing (branch feat/424-wire-congestion-control) is wired in.
+pkg/s3optimization/optimizer.go
+
+# TUI dashboard returns mock data (fetchDataCmd), tied to the controller/agent
+# APIs deleted in v0.20.0. Pending the TUI rebuild-or-remove decision.
+pkg/tui/essential_functions.go
+
+# Aspirational "would be replaced with actual ML model" comment on a rule-based
+# compression heuristic that is itself real (the audit confirmed the fallback
+# works). Kept until the ML selector is either built or the comment dropped.
+pkg/staging/adaptive_compression_selector.go


### PR DESCRIPTION
First of the trust-hardening guards (the "testing that checks for this fake
stuff" ask). A CI ratchet that blocks **new** theater from creeping back in.

## What it catches

`scripts/ci/check-no-theater.sh` greps production Go — excluding tests, examples,
and benchmarks, which may honestly simulate — for high-signal lie-markers:

- `In full implementation, this would…` (log-only stub bodies)
- `would be replaced with actual …` (placeholder-for-real)
- `For now, return mock` (mock data on a production path)
- hardcoded **positive** `OptimizationRatio`/`BandwidthSavings`/`LatencyReduction`
  literals (a real metric comes from a variable; `: 0` is an honest default and
  is not flagged)

Deliberately narrow to avoid false positives on legitimate simulation.

## Ratchet, not big-bang

The currently-known, audited instances are allowlisted in
`scripts/ci/theater-allowlist.txt`, each citing its tracking issue, so the gate
**passes today** while blocking new theater everywhere else:

- `pkg/s3optimization/optimizer.go` — the inert congestion optimizer + 4.6x
  constants (#424)
- `pkg/tui/essential_functions.go` — dashboard mock data (pending TUI decision)
- `pkg/staging/adaptive_compression_selector.go` — aspirational "…actual ML"
  comment on a real rule-based heuristic

Removing an allowlist line is the "wired for real or deleted" done-signal.
`check-no-theater.sh --all` prints the full current inventory.

Verified: passes clean on `main`, fails when a marker is injected into a
non-allowlisted file, restores clean. Wired into the Tests workflow beside the
build-tags / nested-modules gates.

Refs #424.