### PR TITLE
feat(detection): actually run Magika — thread config into the scanner (#30)

### DIFF
--- a/cmd/cargoship/cmd/create_pipeline.go
+++ b/cmd/cargoship/cmd/create_pipeline.go
@@ -235,6 +235,9 @@ func createPipelineRunE(cmd *cobra.Command, args []string) error {
 		S3StorageClass:  storageClass,
 		S3PartSize:      64 * 1024 * 1024, // 64MB parts
 
+		// Issue #30: AI file-type detection, if configured.
+		MagikaConfig: magikaConfigFromViper(),
+
 		// Multi-prefix optimization (Phase 3)
 		EnableMultiPrefix: true,
 		ShardCount:        shardCount,

--- a/cmd/cargoship/cmd/magika_config.go
+++ b/cmd/cargoship/cmd/magika_config.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/cargoship/pkg/config"
+)
+
+// magikaConfigFromViper reads the optional `magika:` block from the loaded
+// cargoship config (see initConfig in root.go). It returns nil when no magika
+// block is present — which leaves AI file-type detection disabled — and
+// otherwise a config seeded from defaults and overlaid with the user's keys.
+//
+// #30: the upload/sync/create commands pass the result into
+// PipelineConfig.MagikaConfig. Before this existed, MagikaConfig was never
+// populated, so the scanner's `MagikaConfig != nil && .Enabled` gate never
+// opened and Magika never ran regardless of what the user configured.
+func magikaConfigFromViper() *config.MagikaConfig {
+	if !viper.IsSet("magika") {
+		return nil
+	}
+	m := config.DefaultConfig().Magika
+	if err := viper.UnmarshalKey("magika", &m); err != nil {
+		return nil
+	}
+	return &m
+}

--- a/cmd/cargoship/cmd/sync.go
+++ b/cmd/cargoship/cmd/sync.go
@@ -246,6 +246,8 @@ Examples:
 				previousUploadID: previousUploadID,
 				s3Client:         s3Client,
 			})
+			// Issue #30: AI file-type detection, if configured.
+			pipelineConfig.MagikaConfig = magikaConfigFromViper()
 
 			pipe, err := pipeline.NewPipeline(pipelineConfig)
 			if err != nil {

--- a/cmd/cargoship/cmd/upload.go
+++ b/cmd/cargoship/cmd/upload.go
@@ -603,6 +603,10 @@ Examples:
 				ArchiveBufferSize: 100,
 				ResultBufferSize:  200,
 
+				// Issue #30: AI file-type detection (nil unless the config has a
+				// `magika:` block), threaded through to the scanner.
+				MagikaConfig: magikaConfigFromViper(),
+
 				// Manifest generation
 				EnableManifest:              true,
 				EnablePartialManifest:       true,

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -412,20 +412,29 @@ func (p *Pipeline) shouldUseDirectUpload(fileCount int64, totalSize int64) bool 
 }
 
 // startStages initializes and starts all pipeline stages
+// buildScannerConfig derives the scanner stage config from the pipeline config.
+// Extracted from startStages so the plumbing is unit-testable — in particular
+// MagikaConfig (#30), which the scanner needs to run AI file-type detection and
+// which was previously never set, so Magika never ran regardless of user config.
+func buildScannerConfig(cfg *PipelineConfig, rootPath string) *ScannerConfig {
+	return &ScannerConfig{
+		RootPath:                   rootPath,
+		Workers:                    cfg.ScannerWorkers,
+		IncludeOnlyFiles:           cfg.IncludeOnlyFiles,              // Issue #148: Incremental sync file filtering
+		UseCompressedAwareChunking: cfg.EnableCompressedAwareChunking, // Phase 3.3
+		ChunkTargetSizeMB:          cfg.ForceChunkSizeMB,              // Phase 3.3
+		ChunkingConfig:             cfg.ChunkingConfig,                // Phase 5: Pass chunking config
+		TierSelector:               cfg.TierSelector,                  // Issue #164: Tier-aware chunking
+		TierChunkingStrategy:       cfg.TierChunkingStrategy,          // Issue #164: Tier chunking strategy
+		MagikaConfig:               cfg.MagikaConfig,                  // Issue #30: AI file-type detection
+	}
+}
+
 func (p *Pipeline) startStages(ctx context.Context, rootPath string) error {
 	var err error
 
 	// Create scanner stage
-	scannerConfig := &ScannerConfig{
-		RootPath:                   rootPath,
-		Workers:                    p.config.ScannerWorkers,
-		IncludeOnlyFiles:           p.config.IncludeOnlyFiles,              // Issue #148: Incremental sync file filtering
-		UseCompressedAwareChunking: p.config.EnableCompressedAwareChunking, // Phase 3.3
-		ChunkTargetSizeMB:          p.config.ForceChunkSizeMB,              // Phase 3.3
-		ChunkingConfig:             p.config.ChunkingConfig,                // Phase 5: Pass chunking config
-		TierSelector:               p.config.TierSelector,                  // Issue #164: Tier-aware chunking
-		TierChunkingStrategy:       p.config.TierChunkingStrategy,          // Issue #164: Tier chunking strategy
-	}
+	scannerConfig := buildScannerConfig(p.config, rootPath)
 	p.scanner, err = NewScannerStage(scannerConfig, p.chunkChan, p) // Pass pipeline reference for manifest tracking
 	if err != nil {
 		return fmt.Errorf("failed to create scanner: %w", err)

--- a/pkg/pipeline/scanner_config_test.go
+++ b/pkg/pipeline/scanner_config_test.go
@@ -1,0 +1,38 @@
+//go:build !integration
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/scttfrdmn/cargoship/pkg/config"
+)
+
+// TestBuildScannerConfig_ThreadsMagika guards #30: the scanner only runs Magika
+// when its ScannerConfig.MagikaConfig is set, and that must come from the
+// pipeline config. Before this plumbing existed the field was never populated,
+// so Magika never ran regardless of user config. This fails if the wiring
+// regresses.
+func TestBuildScannerConfig_ThreadsMagika(t *testing.T) {
+	mc := &config.MagikaConfig{Enabled: true, BatchSize: 100}
+	sc := buildScannerConfig(&PipelineConfig{
+		ScannerWorkers:   3,
+		IncludeOnlyFiles: []string{"a.txt"},
+		MagikaConfig:     mc,
+	}, "/root")
+
+	if sc.MagikaConfig != mc {
+		t.Fatal("#30: buildScannerConfig must thread MagikaConfig to the scanner, else Magika never runs")
+	}
+	if sc.RootPath != "/root" || sc.Workers != 3 {
+		t.Errorf("scanner config fields not mapped: root=%q workers=%d", sc.RootPath, sc.Workers)
+	}
+	if len(sc.IncludeOnlyFiles) != 1 {
+		t.Errorf("IncludeOnlyFiles not mapped: %v", sc.IncludeOnlyFiles)
+	}
+
+	// No magika config → stays nil (detection disabled).
+	if got := buildScannerConfig(&PipelineConfig{}, "/x").MagikaConfig; got != nil {
+		t.Errorf("nil MagikaConfig must stay nil (Magika disabled), got %+v", got)
+	}
+}

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -242,6 +242,11 @@ type PipelineConfig struct {
 	// Chunking configuration
 	ChunkingConfig *chunking.ChunkingConfig
 
+	// Issue #30: Magika AI file-type detection (optional; nil = disabled). Passed
+	// through to the scanner stage's ScannerConfig.MagikaConfig — without this
+	// plumbing the scanner never receives it and Magika never runs.
+	MagikaConfig *config.MagikaConfig
+
 	// Manifest configuration
 	EnableManifest bool   // Enable manifest generation (default: true for real S3)
 	SourcePath     string // Original source path for manifest


### PR DESCRIPTION
Phase 2 item 1a. The Magika detector and its scanner/compression consumers were
real, but the config was never threaded in, so **AI file-type detection never
ran** — compression always fell back to file extensions, regardless of the
user's `magika:` config. Classic "advertised but inert."

## Wiring
- `PipelineConfig` gains `MagikaConfig` (`pkg/pipeline/types.go`).
- `buildScannerConfig` — extracted from `startStages` so it's unit-testable —
  copies it into `ScannerConfig` (consumed at `scanner.go:95`).
- `magikaConfigFromViper()` reads the optional `magika:` block from the loaded
  cargoship config; `upload`/`sync`/`create` pass it through. No block → `nil` →
  detection stays disabled (unchanged default; Magika is opt-in).

## Guard
`TestBuildScannerConfig_ThreadsMagika` fails if the threading is dropped
(verified against the pre-fix construction, per stash-verify-discipline). No CLI
flags changed, so no doc regen.

Closes #30.