### PR TITLE
feat(s3): wire real congestion control into the upload path (#424)

### DIFF
--- a/cmd/cargoship/cmd/upload.go
+++ b/cmd/cargoship/cmd/upload.go
@@ -607,6 +607,12 @@ Examples:
 				// `magika:` block), threaded through to the scanner.
 				MagikaConfig: magikaConfigFromViper(),
 
+				// #424: real congestion control on the upload path (--optimization,
+				// --congestion-control). The multi-prefix uploader paces each stream
+				// through a BBR-fed pacer and backs off on S3 503 SlowDown.
+				EnableOptimization: enableOptimization,
+				CongestionControl:  congestionControl,
+
 				// Manifest generation
 				EnableManifest:              true,
 				EnablePartialManifest:       true,

--- a/pkg/aws/s3/congestion_pacer.go
+++ b/pkg/aws/s3/congestion_pacer.go
@@ -88,6 +88,24 @@ func (p *CongestionPacer) sample(n int, start, now time.Time) {
 	p.mu.Unlock()
 }
 
+// WrapReadCloser is WrapReader for an io.ReadCloser: it paces reads while
+// delegating Close to rc, so the caller's cleanup still runs. Returns rc
+// unchanged when the pacer is disabled.
+func (p *CongestionPacer) WrapReadCloser(rc io.ReadCloser) io.ReadCloser {
+	if !p.enabled || p.prober == nil {
+		return rc
+	}
+	return &pacedReadCloser{Reader: p.WrapReader(rc), closer: rc}
+}
+
+// pacedReadCloser adds Close (delegated to the wrapped stream) to a paced reader.
+type pacedReadCloser struct {
+	io.Reader
+	closer io.Closer
+}
+
+func (p *pacedReadCloser) Close() error { return p.closer.Close() }
+
 // SignalThrottle reports a server-side congestion signal (e.g. an S3 503
 // SlowDown / RequestLimitExceeded). It is BBR's loss input: the estimate and
 // window contract, so subsequent pacing actually limits the send rate.

--- a/pkg/aws/s3/congestion_pacer.go
+++ b/pkg/aws/s3/congestion_pacer.go
@@ -1,0 +1,203 @@
+package s3
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+)
+
+// mbpsToBytesPerSec converts megabits/sec — the unit BBRBandwidthProber reports
+// bandwidth and pacing in — to bytes/sec. It matches the Mbps→Bps conversion the
+// prober itself uses (mebibits: Mbps * 1024 * 1024 / 8), so a pacing rate handed
+// back here means the same thing it does inside the prober.
+func mbpsToBytesPerSec(mbps float64) float64 {
+	return mbps * 1024 * 1024 / 8
+}
+
+// pacerWarmup is how long a paced reader only measures before it will enforce a
+// rate. BBR starts in STARTUP with an initial 10 Mbps estimate; enforcing that
+// before real samples have raised the estimate would throttle a fast link down
+// to 10 Mbps. During warmup we feed the prober real samples so its estimate
+// climbs to the bottleneck first; only then can pacing engage, and by then the
+// STARTUP gain (>1) keeps the rate at or above observed throughput.
+const pacerWarmup = 750 * time.Millisecond
+
+// CongestionPacer wires a real BBR bandwidth prober into an upload. It feeds the
+// prober delivery-rate samples measured from the actual drain of the body reader
+// and paces the body at the prober's estimated rate.
+//
+// Because BBR's pacing rate is the observed bottleneck bandwidth times a gain
+// that is >= 1 outside of recovery, pacing converges to the link and does not
+// throttle below measured throughput on an uncongested path. It only bites when
+// a congestion signal — an S3 503 SlowDown fed through SignalThrottle, or BBR's
+// own ProbeRTT/Drain phases — lowers the estimate. When optimization is disabled
+// the pacer is a transparent passthrough with no prober and no overhead.
+type CongestionPacer struct {
+	prober  *BBRBandwidthProber
+	enabled bool
+
+	mu        sync.Mutex
+	started   bool
+	bytesSeen int64
+}
+
+// NewCongestionPacer builds a pacer. algorithm is "bbr", "cubic" or "auto"
+// (retained for reporting and future CUBIC-only pacing; BBR drives pacing in all
+// enabled modes today). When enabled is false the pacer does nothing.
+func NewCongestionPacer(ctx context.Context, algorithm string, enabled bool) *CongestionPacer {
+	// algorithm ("bbr"/"cubic"/"auto") is accepted for API stability and future
+	// CUBIC-only pacing; BBR drives pacing in all enabled modes today.
+	_ = algorithm
+	p := &CongestionPacer{enabled: enabled}
+	if !enabled {
+		return p
+	}
+	p.prober = NewBBRBandwidthProber(ctx, nil)
+	// StartProbing runs the BBR state machine loop; without it the pacing rate
+	// and congestion window never advance past their initial values.
+	if err := p.prober.StartProbing(); err == nil {
+		p.started = true
+	}
+	return p
+}
+
+// WrapReader returns a reader that paces and measures r. When the pacer is
+// disabled it returns r unchanged.
+func (p *CongestionPacer) WrapReader(r io.Reader) io.Reader {
+	if !p.enabled || p.prober == nil {
+		return r
+	}
+	return newPacedReader(r,
+		func() float64 { return mbpsToBytesPerSec(p.prober.GetPacingRate()) },
+		p.sample,
+		pacerWarmup,
+	)
+}
+
+// sample feeds one measured drain interval to the prober and tallies bytes.
+func (p *CongestionPacer) sample(n int, start, now time.Time) {
+	rtt := now.Sub(start)
+	if rtt <= 0 {
+		rtt = time.Microsecond
+	}
+	p.prober.OnPacketSent(int64(n), start)
+	p.prober.OnPacketAcknowledged(int64(n), start, now, rtt)
+	p.mu.Lock()
+	p.bytesSeen += int64(n)
+	p.mu.Unlock()
+}
+
+// SignalThrottle reports a server-side congestion signal (e.g. an S3 503
+// SlowDown / RequestLimitExceeded). It is BBR's loss input: the estimate and
+// window contract, so subsequent pacing actually limits the send rate.
+func (p *CongestionPacer) SignalThrottle(bytesInFlight int64) {
+	if p.prober == nil {
+		return
+	}
+	if bytesInFlight <= 0 {
+		bytesInFlight = 1
+	}
+	p.prober.OnPacketLost(bytesInFlight, time.Now())
+}
+
+// PacingRateMbps is the prober's current pacing rate, or 0 when disabled.
+func (p *CongestionPacer) PacingRateMbps() float64 {
+	if p.prober == nil {
+		return 0
+	}
+	return p.prober.GetPacingRate()
+}
+
+// Close stops the BBR loop. Safe to call more than once.
+func (p *CongestionPacer) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started && p.prober != nil {
+		_ = p.prober.StopProbing()
+		p.started = false
+	}
+}
+
+// bbrMetrics exposes the prober's live metrics for real (measured) reporting.
+// Returns nil when disabled.
+func (p *CongestionPacer) bbrMetrics() *BBRMetrics {
+	if p.prober == nil {
+		return nil
+	}
+	return p.prober.GetMetrics()
+}
+
+// pacedReader wraps the upload body. Each Read (1) waits for token-bucket credit
+// at the current pacing rate, then (2) reads from the underlying body and hands
+// the elapsed-time/bytes pair to sampleFn as a delivery-rate sample. The read
+// itself blocks on the SDK's part-buffer backpressure, so its duration reflects
+// real upload throughput rather than local buffering.
+//
+// rateFn returns the current allowed rate in bytes/sec; <= 0 means unlimited.
+// It is a function rather than a fixed value because BBR revises the rate
+// continuously as samples arrive.
+type pacedReader struct {
+	r        io.Reader
+	rateFn   func() float64
+	sampleFn func(n int, start, now time.Time)
+	warmup   time.Duration
+
+	tokens     float64
+	lastRefill time.Time
+	firstRead  time.Time
+}
+
+func newPacedReader(r io.Reader, rateFn func() float64, sampleFn func(int, time.Time, time.Time), warmup time.Duration) *pacedReader {
+	return &pacedReader{r: r, rateFn: rateFn, sampleFn: sampleFn, warmup: warmup, lastRefill: time.Now()}
+}
+
+func (pr *pacedReader) Read(b []byte) (int, error) {
+	pr.throttle(len(b))
+
+	start := time.Now()
+	n, err := pr.r.Read(b)
+	if n > 0 {
+		now := time.Now()
+		if pr.sampleFn != nil {
+			pr.sampleFn(n, start, now)
+		}
+		if pr.firstRead.IsZero() {
+			pr.firstRead = now
+		}
+	}
+	return n, err
+}
+
+// throttle enforces the token bucket at the current rate. It is a no-op during
+// warmup and whenever the rate is non-positive.
+func (pr *pacedReader) throttle(want int) {
+	if pr.rateFn == nil || pr.firstRead.IsZero() || time.Since(pr.firstRead) < pr.warmup {
+		return
+	}
+	rate := pr.rateFn()
+	if rate <= 0 {
+		return
+	}
+
+	now := time.Now()
+	// Credits accrue at the pacing rate over wall-clock elapsed, capped at one
+	// read's worth of burst so a stall can't bank unbounded credit.
+	pr.tokens += rate * now.Sub(pr.lastRefill).Seconds()
+	pr.lastRefill = now
+	if burst := float64(want); pr.tokens > burst {
+		pr.tokens = burst
+	}
+
+	if pr.tokens >= float64(want) {
+		pr.tokens -= float64(want)
+		return
+	}
+	// Not enough credit: sleep just long enough to accrue the shortfall.
+	need := float64(want) - pr.tokens
+	wait := time.Duration(need / rate * float64(time.Second))
+	if wait > 0 {
+		time.Sleep(wait)
+	}
+	pr.tokens = 0
+}

--- a/pkg/aws/s3/congestion_pacer_test.go
+++ b/pkg/aws/s3/congestion_pacer_test.go
@@ -1,0 +1,145 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"testing"
+	"time"
+)
+
+// TestPacedReader_EnforcesRate proves the token bucket actually limits
+// throughput: 512 KiB at 1 MiB/s must take on the order of half a second, versus
+// microseconds unthrottled.
+func TestPacedReader_EnforcesRate(t *testing.T) {
+	const size = 512 * 1024
+	const rate = 1024 * 1024 // bytes/sec
+
+	src := bytes.NewReader(bytes.Repeat([]byte("x"), size))
+	pr := newPacedReader(src, func() float64 { return rate }, nil, 0)
+
+	start := time.Now()
+	n, err := io.Copy(io.Discard, pr)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != size {
+		t.Fatalf("copied %d bytes, want %d", n, size)
+	}
+	// Expected ~0.5s. Assert clearly-throttled without being flaky about the
+	// exact figure.
+	if elapsed < 250*time.Millisecond {
+		t.Errorf("expected pacing to slow the copy to ~0.5s, took only %v", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("pacing overshot badly: %v", elapsed)
+	}
+}
+
+// TestPacedReader_UnlimitedIsTransparent confirms a non-positive rate does not
+// throttle and preserves the bytes exactly.
+func TestPacedReader_UnlimitedIsTransparent(t *testing.T) {
+	want := make([]byte, 256*1024)
+	if _, err := rand.Read(want); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	pr := newPacedReader(bytes.NewReader(want), func() float64 { return 0 }, nil, 0)
+
+	start := time.Now()
+	got, err := io.ReadAll(pr)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("data corrupted through paced reader (got %d bytes, want %d)", len(got), len(want))
+	}
+	if elapsed > 250*time.Millisecond {
+		t.Errorf("unlimited rate should not throttle, took %v", elapsed)
+	}
+}
+
+// TestPacedReader_SampleReceivesEveryByte checks the sample callback observes the
+// full byte count — the delivery-rate signal fed to BBR must not miss data.
+func TestPacedReader_SampleReceivesEveryByte(t *testing.T) {
+	const size = 200 * 1024
+	var sampled int64
+	pr := newPacedReader(
+		bytes.NewReader(bytes.Repeat([]byte("y"), size)),
+		func() float64 { return 0 },
+		func(n int, _, _ time.Time) { sampled += int64(n) },
+		0,
+	)
+	n, err := io.Copy(io.Discard, pr)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != size || sampled != size {
+		t.Fatalf("copied=%d sampled=%d, want both %d", n, sampled, size)
+	}
+}
+
+func TestCongestionPacer_DisabledIsPassthrough(t *testing.T) {
+	p := NewCongestionPacer(context.Background(), "auto", false)
+	defer p.Close()
+
+	src := bytes.NewReader([]byte("hello world"))
+	wrapped := p.WrapReader(src)
+	if wrapped != io.Reader(src) {
+		t.Errorf("disabled pacer must return the reader unchanged")
+	}
+	if got := p.PacingRateMbps(); got != 0 {
+		t.Errorf("disabled pacer PacingRateMbps() = %v, want 0", got)
+	}
+	if p.bbrMetrics() != nil {
+		t.Errorf("disabled pacer should have no BBR metrics")
+	}
+	p.SignalThrottle(1024) // must not panic
+	p.Close()              // idempotent
+}
+
+// TestCongestionPacer_EnabledFeedsProber runs data through an enabled pacer and
+// verifies the bytes are intact, the BBR prober is live (non-zero pacing rate),
+// and real metrics are available.
+func TestCongestionPacer_EnabledFeedsProber(t *testing.T) {
+	p := NewCongestionPacer(context.Background(), "bbr", true)
+	defer p.Close()
+
+	want := make([]byte, 300*1024)
+	if _, err := rand.Read(want); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	got, err := io.ReadAll(p.WrapReader(bytes.NewReader(want)))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("data corrupted through enabled pacer")
+	}
+	if p.PacingRateMbps() <= 0 {
+		t.Errorf("enabled pacer should report a positive pacing rate, got %v", p.PacingRateMbps())
+	}
+	if p.bbrMetrics() == nil {
+		t.Errorf("enabled pacer should expose BBR metrics")
+	}
+	if p.bytesSeen != int64(len(want)) {
+		t.Errorf("pacer saw %d bytes, want %d", p.bytesSeen, len(want))
+	}
+}
+
+func TestCongestionPacer_SignalThrottleIsSafe(t *testing.T) {
+	p := NewCongestionPacer(context.Background(), "auto", true)
+	defer p.Close()
+	// Feed a little data so the prober has state, then signal repeated throttles.
+	_, _ = io.Copy(io.Discard, p.WrapReader(bytes.NewReader(bytes.Repeat([]byte("z"), 64*1024))))
+	for i := 0; i < 10; i++ {
+		p.SignalThrottle(1 << 20)
+	}
+	if p.PacingRateMbps() <= 0 {
+		t.Errorf("prober should still report a rate after throttles, got %v", p.PacingRateMbps())
+	}
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -556,6 +556,9 @@ func (p *Pipeline) startStages(ctx context.Context, rootPath string) error {
 				Prefix:       p.config.S3Prefix,
 				StorageClass: types.StorageClass(p.config.S3StorageClass),
 				TierSelector: p.config.TierSelector,
+				// #424: real congestion control on the multi-prefix upload path.
+				EnableOptimization: p.config.EnableOptimization,
+				CongestionControl:  p.config.CongestionControl,
 			}
 
 			if p.config.S3PartSize == 0 {
@@ -621,6 +624,9 @@ func (p *Pipeline) startStages(ctx context.Context, rootPath string) error {
 				Prefix:       p.config.S3Prefix,
 				StorageClass: types.StorageClass(p.config.S3StorageClass),
 				TierSelector: p.config.TierSelector,
+				// #424: real congestion control on the multi-prefix upload path.
+				EnableOptimization: p.config.EnableOptimization,
+				CongestionControl:  p.config.CongestionControl,
 			}
 
 			if p.config.S3PartSize == 0 {
@@ -664,6 +670,9 @@ func (p *Pipeline) startStages(ctx context.Context, rootPath string) error {
 				Prefix:       p.config.S3Prefix,
 				StorageClass: types.StorageClass(p.config.S3StorageClass),
 				TierSelector: p.config.TierSelector,
+				// #424: real congestion control on the multi-prefix upload path.
+				EnableOptimization: p.config.EnableOptimization,
+				CongestionControl:  p.config.CongestionControl,
 			}
 
 			if p.config.S3PartSize == 0 {

--- a/pkg/pipeline/s3_multiprefix_uploader.go
+++ b/pkg/pipeline/s3_multiprefix_uploader.go
@@ -3,6 +3,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithy "github.com/aws/smithy-go"
 	s3transport "github.com/scttfrdmn/cargoship/pkg/aws/s3"
 	"github.com/scttfrdmn/cargoship/pkg/manifest"
 	"github.com/scttfrdmn/cargoship/pkg/observability/tracing"
@@ -54,8 +56,12 @@ type S3MultiPrefixUploaderStage struct {
 	uploader *manager.Uploader
 
 	// v0.6.2: Advanced transporter (optional, shared across all shards)
-	// Future enhancement: Create per-shard transporter instances for independent BBR/CUBIC state
 	transporter s3transport.BasicTransporter
+
+	// #424: real congestion control. Shared across all shard workers (one BBR
+	// prober fed by every stream); nil-safe passthrough when optimization is off.
+	// Note: per-shard pacers for independent BBR/CUBIC state is a future refinement.
+	pacer *s3transport.CongestionPacer
 
 	// Manifest tracking (Issue #97)
 	pipeline *Pipeline // Reference to parent pipeline for manifest tracking
@@ -145,6 +151,11 @@ func NewS3MultiPrefixUploaderStage(
 		stage.transporter = config.Transporter
 	}
 
+	// #424: build the congestion pacer. Disabled → a transparent passthrough with
+	// no prober goroutine. Uses context.Background(); the prober loop is torn down
+	// by Stop() → pacer.Close().
+	stage.pacer = s3transport.NewCongestionPacer(context.Background(), config.CongestionControl, config.EnableOptimization)
+
 	return stage, nil
 }
 
@@ -182,6 +193,9 @@ func (s *S3MultiPrefixUploaderStage) Stop() error {
 		s.cancel()
 	}
 	s.wg.Wait()
+	if s.pacer != nil {
+		s.pacer.Close() // #424: stop the BBR prober goroutine
+	}
 	return nil
 }
 
@@ -456,6 +470,14 @@ func (s *S3MultiPrefixUploaderStage) uploadToS3(ctx context.Context, job *Job) e
 		job.Archive = job.archiveHasher
 	}
 
+	// #424: pace the stream through the real congestion controller. After the
+	// hashing wrap so the checksum still covers the exact uploaded bytes; a
+	// passthrough when optimization is off. Both upload paths below read
+	// job.Archive, so wrapping here covers transporter and manager alike.
+	if s.pacer != nil && job.Archive != nil {
+		job.Archive = s.pacer.WrapReadCloser(job.Archive)
+	}
+
 	// Prepare metadata
 	metadata := map[string]string{
 		"cargoship-chunk-id":    fmt.Sprintf("%d", job.ID),
@@ -485,6 +507,7 @@ func (s *S3MultiPrefixUploaderStage) uploadViaTransporter(ctx context.Context, s
 	// Upload via transporter.
 	_, err := s.transporter.Upload(ctx, archive)
 	if err != nil {
+		s.maybeSignalThrottle(err, job)
 		return fmt.Errorf("transporter upload failed for %s: %w", job.S3Key, err)
 	}
 
@@ -495,6 +518,24 @@ func (s *S3MultiPrefixUploaderStage) uploadViaTransporter(ctx context.Context, s
 	// sibling keys relative to the bucket). The object was written at
 	// Prefix + "/" + job.S3Key, so the relative key is correct as-is.
 	return nil
+}
+
+// maybeSignalThrottle feeds an S3 server-side throttle (503 SlowDown /
+// RequestLimitExceeded / ServiceUnavailable) to the congestion pacer as its loss
+// signal (#424), so the estimated rate contracts and subsequent sends back off.
+// Other errors are ignored — they aren't congestion.
+func (s *S3MultiPrefixUploaderStage) maybeSignalThrottle(err error, job *Job) {
+	if s.pacer == nil || err == nil {
+		return
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return
+	}
+	switch apiErr.ErrorCode() {
+	case "SlowDown", "RequestLimitExceeded", "ServiceUnavailable", "Throttling", "ThrottlingException":
+		s.pacer.SignalThrottle(atomic.LoadInt64(&job.ArchiveSize))
+	}
 }
 
 // uploadViaManager uploads using basic AWS SDK manager.Uploader (backward compatibility)
@@ -525,6 +566,7 @@ func (s *S3MultiPrefixUploaderStage) uploadViaManager(ctx context.Context, s3Key
 	// Upload using AWS SDK manager (handles multipart automatically)
 	_, err := s.uploader.Upload(ctx, input)
 	if err != nil {
+		s.maybeSignalThrottle(err, job)
 		return fmt.Errorf("S3 upload failed for %s: %w", job.S3Key, err)
 	}
 

--- a/pkg/pipeline/s3_uploader.go
+++ b/pkg/pipeline/s3_uploader.go
@@ -40,6 +40,13 @@ type S3UploaderConfig struct {
 	// Advanced transporter (v0.6.2)
 	// If set, uses advanced S3 transporter instead of basic manager.Uploader
 	Transporter s3transport.BasicTransporter // Optional advanced transporter
+
+	// #424: real congestion control. When EnableOptimization is set, the
+	// multi-prefix uploader paces each archive stream through a BBR-fed pacer
+	// (CongestionControl selects "bbr"/"cubic"/"auto") and feeds S3 503 SlowDown
+	// back as a loss signal. Disabled → the pacer is a transparent passthrough.
+	EnableOptimization bool
+	CongestionControl  string
 }
 
 // S3UploaderStage uploads streaming archives to real AWS S3

--- a/pkg/pipeline/torture_test.go
+++ b/pkg/pipeline/torture_test.go
@@ -97,6 +97,21 @@ func TestTorture(t *testing.T) {
 		})
 	})
 
+	// #424: the wired congestion pacer must move bytes intact. Run the real
+	// BBR-fed pacer on the upload path (chunked + multipart) and assert
+	// byte-identity for each algorithm.
+	for _, algo := range []string{"bbr", "cubic", "auto"} {
+		algo := algo
+		t.Run("congestion_"+algo, func(t *testing.T) {
+			src := t.TempDir()
+			corpus := plantHostileCorpus(t, src, rng, 6*1024*1024)
+			tortureRoundTrip(t, corpus, src, func(pc *PipelineConfig) {
+				pc.EnableOptimization = true
+				pc.CongestionControl = algo
+			})
+		})
+	}
+
 	t.Run("idempotent_rerun", func(t *testing.T) {
 		// Uploading the same corpus twice must round-trip byte-identically both
 		// times (no partial/duplicated state corrupting the second run).

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -233,6 +233,13 @@ type PipelineConfig struct {
 	// the output channel.
 	ShardStrategy string
 
+	// #424: real congestion control on the upload path. EnableOptimization turns
+	// on the BBR-fed pacer in the multi-prefix uploader; CongestionControl selects
+	// the algorithm ("bbr", "cubic", "auto"). Passed to the uploader stage, which
+	// paces job.Archive and feeds an S3 503 SlowDown back as a loss signal.
+	EnableOptimization bool
+	CongestionControl  string
+
 	// Phase 3.3: Compressed-aware chunking with adaptive sizing and padding
 	EnableCompressedAwareChunking bool    // Enable compression-aware chunking (default: true)
 	EnableArchivePadding          bool    // Enable padding to reach target sizes (default: true)

--- a/pkg/s3optimization/optimizer.go
+++ b/pkg/s3optimization/optimizer.go
@@ -176,10 +176,7 @@ func (o *S3Optimizer) GetObjectOptimized(ctx context.Context, input *s3.GetObjec
 
 	startTime := time.Now()
 
-	// Apply network optimizations (BBR/CUBIC algorithms)
-	o.applyOptimizations("GET", safeStringValue(input.Key))
-
-	// Execute request using optimized S3 client
+	// Execute request (congestion control lives on the upload path now, #424).
 	result, err := o.client.GetObject(ctx, input)
 	duration := time.Since(startTime)
 
@@ -206,10 +203,7 @@ func (o *S3Optimizer) PutObjectOptimized(ctx context.Context, input *s3.PutObjec
 
 	startTime := time.Now()
 
-	// Apply network optimizations (BBR/CUBIC algorithms)
-	o.applyOptimizations("PUT", safeStringValue(input.Key))
-
-	// Execute request using optimized S3 client
+	// Execute request (congestion control lives on the upload path now, #424).
 	result, err := o.client.PutObject(ctx, input)
 	duration := time.Since(startTime)
 
@@ -346,25 +340,6 @@ func (o *S3Optimizer) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// applyOptimizations applies network-level optimizations (BBR, CUBIC, adaptive algorithms)
-func (o *S3Optimizer) applyOptimizations(operation, key string) {
-	// In full implementation, this would:
-	// 1. Apply BBR bandwidth probing from network/bbr.go
-	// 2. Adjust CUBIC congestion window from network/cubic.go
-	// 3. Update RTT estimations from network/rtt.go
-	// 4. Detect and recover from packet loss from network/loss.go
-	// 5. Optimize connection pooling from connection/pool.go
-	// 6. Apply adaptive transport from adaptive/transporter.go
-	// 7. Use predictive adaptation from adaptive/predictor.go
-
-	o.logger.Debug("applied CargoShip optimizations",
-		"operation", operation,
-		"key", key,
-		"bbr_enabled", o.config.EnableBBR,
-		"cubic_enabled", o.config.EnableCUBIC,
-		"optimization_ratio", "4.6x")
-}
-
 // recordRequest records request metrics
 func (o *S3Optimizer) recordRequest(duration time.Duration, err error) {
 	o.metrics.mu.Lock()
@@ -405,15 +380,17 @@ func (m *Metrics) getPerformanceMetrics() *PerformanceMetrics {
 		throughputMbps = (bytesPerSecond * 8) / (1024 * 1024)
 	}
 
+	// Only measured values are reported. OptimizationRatio/BandwidthSavings/
+	// LatencyReduction are left zero: this component does not run congestion
+	// control (that moved to the upload pacer, #424), so it has no measured
+	// improvement to claim. They were previously hardcoded to 4.6/78.3/25 — a
+	// fabricated figure the audit flagged.
 	return &PerformanceMetrics{
 		TotalRequests:      m.totalRequests,
 		SuccessfulRequests: m.successfulRequests,
 		FailedRequests:     m.failedRequests,
 		AverageLatency:     avgLatency,
 		ThroughputMbps:     throughputMbps,
-		OptimizationRatio:  4.6,  // CargoShip's proven improvement ratio
-		BandwidthSavings:   78.3, // (4.6-1)/4.6 * 100
-		LatencyReduction:   25.0,
 		CollectedAt:        time.Now(),
 	}
 }

--- a/pkg/s3optimization/optimizer_test.go
+++ b/pkg/s3optimization/optimizer_test.go
@@ -84,12 +84,18 @@ func TestPerformanceMetrics(t *testing.T) {
 		t.Errorf("Expected 2 failed requests, got %d", perfMetrics.FailedRequests)
 	}
 
-	if perfMetrics.OptimizationRatio != 4.6 {
-		t.Errorf("Expected optimization ratio 4.6, got %f", perfMetrics.OptimizationRatio)
+	// #424: improvement figures are measured, not fabricated. With no congestion
+	// control in this component they are zero rather than a hardcoded 4.6x/78.3%.
+	if perfMetrics.OptimizationRatio != 0 {
+		t.Errorf("OptimizationRatio must not be fabricated, got %f", perfMetrics.OptimizationRatio)
+	}
+	if perfMetrics.BandwidthSavings != 0 {
+		t.Errorf("BandwidthSavings must not be fabricated, got %f%%", perfMetrics.BandwidthSavings)
 	}
 
-	if perfMetrics.BandwidthSavings != 78.3 {
-		t.Errorf("Expected bandwidth savings 78.3%%, got %f%%", perfMetrics.BandwidthSavings)
+	// Throughput IS measured: 1024 bytes over ~1 minute must be > 0.
+	if perfMetrics.ThroughputMbps <= 0 {
+		t.Errorf("ThroughputMbps should be measured (>0), got %f", perfMetrics.ThroughputMbps)
 	}
 }
 
@@ -449,11 +455,16 @@ func TestS3OptimizerMetricsRecording(t *testing.T) {
 		t.Errorf("Expected 0 successful requests, got %d", metrics.SuccessfulRequests)
 	}
 
-	// Verify performance metrics structure
-	if metrics.OptimizationRatio != 4.6 {
-		t.Errorf("Expected optimization ratio 4.6, got %f", metrics.OptimizationRatio)
+	// #424: the improvement figures are no longer fabricated. This component runs
+	// no congestion control (that moved to the upload pacer), so it reports no
+	// improvement rather than a hardcoded 4.6x/78.3%.
+	if metrics.OptimizationRatio != 0 {
+		t.Errorf("OptimizationRatio must not be fabricated, got %f", metrics.OptimizationRatio)
 	}
-	if metrics.BandwidthSavings != 78.3 {
-		t.Errorf("Expected bandwidth savings 78.3%%, got %f%%", metrics.BandwidthSavings)
+	if metrics.BandwidthSavings != 0 {
+		t.Errorf("BandwidthSavings must not be fabricated, got %f", metrics.BandwidthSavings)
+	}
+	if metrics.LatencyReduction != 0 {
+		t.Errorf("LatencyReduction must not be fabricated, got %f", metrics.LatencyReduction)
 	}
 }

--- a/scripts/ci/theater-allowlist.txt
+++ b/scripts/ci/theater-allowlist.txt
@@ -5,11 +5,6 @@
 #
 # Burn-down inventory (2026-09 advertised-vs-wired audit):
 
-# #424 — congestion control is inert: applyOptimizations is a log-only stub and
-# getPerformanceMetrics returns hardcoded 4.6x / 78.3% / 25%. Removed when the
-# real BBR pacing (branch feat/424-wire-congestion-control) is wired in.
-pkg/s3optimization/optimizer.go
-
 # TUI dashboard returns mock data (fetchDataCmd), tied to the controller/agent
 # APIs deleted in v0.20.0. Pending the TUI rebuild-or-remove decision.
 pkg/tui/essential_functions.go


### PR DESCRIPTION
The flagship. `--congestion-control` / `--optimization` were inert: the flags fed
a log-only stub while the real BBR/CUBIC code sat unreachable, and
`getPerformanceMetrics` returned a hardcoded `4.6x / 78.3% / 25%`. This wires the
tested `CongestionPacer` (BBR-fed token bucket) into the **real** byte path and
stops fabricating metrics.

## Wiring
- `S3MultiPrefixUploaderStage.uploadToS3` paces `job.Archive` through the pacer —
  after the hashing wrap, so the checksum still covers the exact uploaded bytes.
  Covers both the transporter and manager upload paths.
- `--optimization` / `--congestion-control` plumb `upload.go → PipelineConfig →
  S3UploaderConfig →` the stage. Disabled ⇒ transparent passthrough, no prober
  goroutine.
- S3 `503 SlowDown` / `RequestLimitExceeded` / `ServiceUnavailable` → BBR loss
  signal (`maybeSignalThrottle`), so the rate contracts and sends back off.
- The BBR loop is torn down in the stage's `Stop()`.

## Honesty (kills the theater)
- Deleted the `applyOptimizations` stub + call sites.
- `getPerformanceMetrics` reports only measured values; the fabricated
  `4.6/78.3/25` constants are gone (tests updated to assert they are **not**
  fabricated; throughput, which *is* measured, stays).
- Removed `pkg/s3optimization/optimizer.go` from the theater allowlist — the
  guard confirms it clean (allowlist now down to the TUI dashboard + a staging
  comment).

## Validation
New torture scenarios `congestion_{bbr,cubic,auto}` (chunked + multipart)
round-trip **byte-identical**; the full `make torture` suite stays green. Pacer
unit tests cover enabled-vs-disabled behavior and rate enforcement. All under Go
1.26.6.

Note: a shared prober feeds all shard workers (per-shard BBR state is a future
refinement, noted in code). A real-AWS throughput comparison via
`CARGOSHIP_ENABLE_S3_INTEGRATION_TESTS=1 make torture` is the recommended
follow-up check.

Closes #424.