### PR TITLE
feat(resume): wire real resumable uploads (#119)

### DIFF
--- a/cmd/cargoship/cmd/resume.go
+++ b/cmd/cargoship/cmd/resume.go
@@ -1,12 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
+	cargoconfig "github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/pipeline"
 	"github.com/scttfrdmn/cargoship/pkg/resume"
 )
 
@@ -56,11 +60,34 @@ Each state file contains upload progress, configuration, and file hashes.
 			// Display upload info
 			displayUploadInfo(state)
 
-			// TODO: Actually resume the upload by calling pipeline
-			// This requires refactoring upload command to support resume
-			fmt.Println("\n⚠️  Direct resume not yet implemented")
-			fmt.Println("💡 Use: cargoship upload <path> <destination> --resume --upload-id", uploadID)
+			if state.IsComplete() {
+				fmt.Println("\n✅ This upload already completed — nothing to resume.")
+				return nil
+			}
 
+			// Rebuild the S3 client and pipeline from the saved state, in resume
+			// mode: the pipeline downloads the S3 partial manifest for this upload
+			// ID and skips every chunk already uploaded, transferring only the rest.
+			ctx := context.Background()
+			httpConfig := cargoconfig.DefaultHTTPTransportConfig()
+			s3Client, err := cargoconfig.GetOrCreateS3Client(ctx, state.Bucket, state.Region, "", httpConfig)
+			if err != nil {
+				return fmt.Errorf("failed to create S3 client: %w", err)
+			}
+
+			fmt.Printf("\n🔄 Resuming — already-uploaded chunks will be skipped.\n\n")
+			pipe, err := pipeline.NewPipeline(newResumePipelineConfig(state, s3Client))
+			if err != nil {
+				return fmt.Errorf("failed to create pipeline: %w", err)
+			}
+			result, err := pipe.Run(ctx, state.SourceDir)
+			if err != nil {
+				return fmt.Errorf("resume failed: %w", err)
+			}
+			if !result.Success {
+				return fmt.Errorf("resume did not complete successfully")
+			}
+			fmt.Printf("✅ Upload %s resumed and completed.\n", uploadID)
 			return nil
 		},
 	}
@@ -192,6 +219,50 @@ Each file is typically 10-50 KB.
 }
 
 // displayUploadInfo displays formatted information about an upload state
+// newResumePipelineConfig rebuilds a pipeline config from a saved UploadState in
+// resume mode (#119). It reuses the prior run's UploadID as both UploadID and
+// ResumeUploadID, so the pipeline downloads that upload's S3 partial manifest
+// (#157) and skips every chunk already marked UploadedAt — transferring only the
+// remainder. Extracted so the resume wiring is unit-testable (the cobra RunE
+// closure is not). Knobs not persisted in UploadState (compression level, shard
+// strategy) fall back to defaults; the remaining chunks still upload correctly
+// because compression is content-aware per chunk.
+func newResumePipelineConfig(state *resume.UploadState, s3Client *s3.Client) *pipeline.PipelineConfig {
+	shardCount := state.ShardCount
+	if shardCount <= 0 {
+		shardCount = 8
+	}
+	return &pipeline.PipelineConfig{
+		ScannerWorkers:  2,
+		ArchiverWorkers: 4,
+		UploaderWorkers: 4,
+
+		S3Bucket:       state.Bucket,
+		S3Prefix:       state.Prefix,
+		S3Region:       state.Region,
+		S3StorageClass: state.StorageClass,
+		S3PartSize:     64 * 1024 * 1024,
+		S3SSEKMSKeyId:  state.KMSKeyID,
+
+		UseRealS3:  true,
+		S3Client:   s3Client,
+		SourcePath: state.SourceDir,
+
+		EnableMultiPrefix:     true,
+		ShardCount:            shardCount,
+		WorkersPerPrefix:      2,
+		ArchiveBufferSize:     100,
+		EnableManifest:        true,
+		EnablePartialManifest: true,
+
+		// #119: resume the prior upload — reuse its ID so the #157 partial-manifest
+		// skip machinery kicks in for chunks already uploaded.
+		UploadID:       state.UploadID,
+		ResumeMode:     true,
+		ResumeUploadID: state.UploadID,
+	}
+}
+
 func displayUploadInfo(state *resume.UploadState) {
 	// Progress percentage
 	progress := state.Progress()

--- a/cmd/cargoship/cmd/resume_test.go
+++ b/cmd/cargoship/cmd/resume_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/scttfrdmn/cargoship/pkg/resume"
+)
+
+// TestNewResumePipelineConfig_EnablesResume guards #119: rebuilding a pipeline
+// from saved state must set ResumeMode + ResumeUploadID + reuse the prior
+// UploadID, or the pipeline would re-upload everything instead of skipping the
+// chunks already done. Fails if any of those regress.
+func TestNewResumePipelineConfig_EnablesResume(t *testing.T) {
+	client := &s3.Client{}
+	state := &resume.UploadState{
+		UploadID:     "20260101-deadbeef",
+		SourceDir:    "/data/src",
+		Bucket:       "bucket",
+		Prefix:       "prefix",
+		Region:       "us-west-2",
+		StorageClass: "GLACIER",
+		KMSKeyID:     "kms-1",
+		ShardCount:   6,
+	}
+
+	cfg := newResumePipelineConfig(state, client)
+
+	if !cfg.ResumeMode {
+		t.Fatal("#119: resume config must set ResumeMode=true or it re-uploads everything")
+	}
+	if cfg.ResumeUploadID != state.UploadID {
+		t.Fatalf("ResumeUploadID = %q, want %q", cfg.ResumeUploadID, state.UploadID)
+	}
+	if cfg.UploadID != state.UploadID {
+		t.Fatalf("UploadID = %q, want the prior run's %q", cfg.UploadID, state.UploadID)
+	}
+	if !cfg.UseRealS3 {
+		t.Error("resume must use real S3")
+	}
+	if got, ok := cfg.S3Client.(*s3.Client); !ok || got != client {
+		t.Errorf("S3Client = %v, want the provided client", cfg.S3Client)
+	}
+
+	// Field mapping from the saved state.
+	if cfg.S3Bucket != "bucket" || cfg.S3Prefix != "prefix" || cfg.S3Region != "us-west-2" {
+		t.Errorf("bucket/prefix/region not mapped: %+v", cfg)
+	}
+	if cfg.SourcePath != "/data/src" {
+		t.Errorf("SourcePath = %q, want /data/src", cfg.SourcePath)
+	}
+	if cfg.S3StorageClass != "GLACIER" || cfg.S3SSEKMSKeyId != "kms-1" {
+		t.Errorf("storage class / KMS not mapped: class=%q kms=%q", cfg.S3StorageClass, cfg.S3SSEKMSKeyId)
+	}
+	if cfg.ShardCount != 6 {
+		t.Errorf("ShardCount = %d, want 6", cfg.ShardCount)
+	}
+	if !cfg.EnablePartialManifest {
+		t.Error("EnablePartialManifest must be true — it is the resume skip source")
+	}
+
+	// Zero shard count in state falls back to a sane default.
+	if got := newResumePipelineConfig(&resume.UploadState{}, client).ShardCount; got <= 0 {
+		t.Errorf("ShardCount fallback should be > 0, got %d", got)
+	}
+}

--- a/cmd/cargoship/cmd/upload.go
+++ b/cmd/cargoship/cmd/upload.go
@@ -56,6 +56,7 @@ func NewUploadCmd() *cobra.Command {
 
 		// Issue #119: Resume configuration
 		forceRestart bool
+		resumeFlag   bool
 
 		// Issue #168: Skip confirmation prompts
 		skipConfirmation bool
@@ -234,21 +235,28 @@ Examples:
 				}
 			}
 
-			// Issue #119: Auto-detect interrupted uploads
+			// Issue #119: detect an interrupted upload of this source→destination
+			// and, if the user resumes, carry its UploadID so the pipeline skips
+			// chunks already uploaded (resume fields applied to the config below).
+			var resumeUploadID string
 			if !forceRestart {
-				detectedState, err := resume.DetectInterruptedUpload(absPath, bucket, prefix)
-				if err != nil {
-					fmt.Printf("⚠️  Warning: Failed to check for interrupted uploads: %v\n", err)
-				} else if detectedState != nil && resume.ShouldPromptForResume(detectedState) {
-					// Found an interrupted upload - prompt user
-					if promptForResume(detectedState) {
-						fmt.Println("\n⚠️  Direct resume via upload command not yet fully implemented")
-						fmt.Printf("💡 Use: cargoship resume %s\n", detectedState.UploadID)
-						fmt.Println("    Or use --force-restart to ignore saved state and start fresh")
-						return fmt.Errorf("resume via upload command pending implementation")
+				detectedState, derr := resume.DetectInterruptedUpload(absPath, bucket, prefix)
+				if derr != nil {
+					fmt.Printf("⚠️  Warning: Failed to check for interrupted uploads: %v\n", derr)
+				} else if detectedState != nil && !detectedState.IsComplete() {
+					resumeThis := false
+					switch {
+					case resumeFlag:
+						resumeThis = true // explicit --resume: no prompt
+					case resume.ShouldPromptForResume(detectedState):
+						resumeThis = promptForResume(detectedState)
 					}
-					// User chose not to resume - continue with fresh upload
-					fmt.Println("Starting fresh upload...")
+					if resumeThis {
+						resumeUploadID = detectedState.UploadID
+						fmt.Printf("🔄 Resuming upload %s — already-uploaded chunks will be skipped.\n\n", resumeUploadID)
+					} else if !resumeFlag && resume.ShouldPromptForResume(detectedState) {
+						fmt.Println("Starting fresh upload...")
+					}
 				}
 			}
 
@@ -666,6 +674,15 @@ Examples:
 				fmt.Printf("   Storage Class:     %s\n\n", storageClass)
 			}
 
+			// #119: resume the detected interrupted upload — reuse its UploadID so
+			// the pipeline loads that upload's S3 partial manifest and skips the
+			// chunks already uploaded, transferring only the remainder.
+			if resumeUploadID != "" {
+				pipelineConfig.UploadID = resumeUploadID
+				pipelineConfig.ResumeMode = true
+				pipelineConfig.ResumeUploadID = resumeUploadID
+			}
+
 			// Create pipeline
 			pipe, err := pipeline.NewPipeline(pipelineConfig)
 			if err != nil {
@@ -896,6 +913,7 @@ Examples:
 
 	// Issue #119: Resume configuration
 	cmd.Flags().BoolVar(&forceRestart, "force-restart", false, "Ignore saved state and start fresh upload (bypasses resume detection)")
+	cmd.Flags().BoolVar(&resumeFlag, "resume", false, "Resume an interrupted upload of this source→destination without prompting (skips already-uploaded chunks)")
 
 	// Issue #168: Skip confirmation prompts (for automation)
 	cmd.Flags().BoolVarP(&skipConfirmation, "yes", "y", false, "Skip confirmation prompts (auto-accept warnings)")

--- a/docs/gen/cli/cargoship_upload.md
+++ b/docs/gen/cli/cargoship_upload.md
@@ -81,6 +81,7 @@ cargoship upload SOURCE_DIR DESTINATION [flags]
       --prometheus-addr string           Prometheus metrics HTTP address (e.g., :9090)
       --quiet                            Disable progress display
   -r, --region string                    AWS region (default "us-west-2")
+      --resume                           Resume an interrupted upload of this source→destination without prompting (skips already-uploaded chunks)
       --shard-count int                  Shards for parallel uploads: 0 auto-selects 4-32 (falls back to 8), or set 4-32 manually
       --shard-strategy string            Shard distribution strategy (round-robin, hash, size, type, directory) (default "round-robin")
       --storage-class string             S3 storage class (STANDARD, INTELLIGENT_TIERING, GLACIER, etc.) (default "STANDARD")

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -17,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 	s3transport "github.com/scttfrdmn/cargoship/pkg/aws/s3"
 	"github.com/scttfrdmn/cargoship/pkg/manifest"
 	"github.com/scttfrdmn/cargoship/pkg/observability/tracing"
@@ -196,23 +198,31 @@ func NewPipeline(config *PipelineConfig) (*Pipeline, error) {
 				config.S3Prefix,
 				config.ResumeUploadID,
 			)
-			if downloadErr != nil {
+			switch {
+			case downloadErr == nil:
+				// Create builder from existing manifest
+				builder, err = manifest.NewBuilderFromExisting(partialManifest)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create builder from existing manifest: %w", err)
+				}
+				// Override UploadID with the resumed upload ID
+				config.UploadID = config.ResumeUploadID
+				fmt.Printf("📦 Resuming upload %s (%d files, %d chunks already uploaded)\n",
+					config.ResumeUploadID, len(partialManifest.Files), len(partialManifest.Chunks))
+			case isNoSuchKeyErr(downloadErr):
+				// #119: no saved progress in S3 — the run was interrupted before
+				// the first partial-manifest save, or already completed. Resume as
+				// a fresh upload under the resume ID rather than failing hard.
+				fmt.Printf("📦 No saved progress for %s in S3 — starting a fresh upload.\n", config.ResumeUploadID)
+				config.UploadID = config.ResumeUploadID
+				config.ResumeMode = false
+			default:
 				return nil, fmt.Errorf("failed to download partial manifest for resume: %w", downloadErr)
 			}
+		}
 
-			// Create builder from existing manifest
-			builder, err = manifest.NewBuilderFromExisting(partialManifest)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create builder from existing manifest: %w", err)
-			}
-
-			// Override UploadID with the resumed upload ID
-			config.UploadID = config.ResumeUploadID
-
-			fmt.Printf("📦 Resuming upload %s (%d files, %d chunks already uploaded)\n",
-				config.ResumeUploadID, len(partialManifest.Files), len(partialManifest.Chunks))
-		} else {
-			// Normal mode - create new manifest builder
+		if builder == nil {
+			// Normal mode (or resume with no saved progress) - create new builder
 			builder, err = manifest.NewBuilder(
 				config.UploadID,
 				config.SourcePath,
@@ -412,6 +422,24 @@ func (p *Pipeline) shouldUseDirectUpload(fileCount int64, totalSize int64) bool 
 }
 
 // startStages initializes and starts all pipeline stages
+// isNoSuchKeyErr reports whether err is an S3 "object not found" (NoSuchKey /
+// NotFound / 404). Used to treat a missing partial manifest as "no saved
+// progress" during resume (#119) rather than a hard failure.
+func isNoSuchKeyErr(err error) bool {
+	var nsk *types.NoSuchKey
+	if errors.As(err, &nsk) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NoSuchKey", "NotFound", "404":
+			return true
+		}
+	}
+	return false
+}
+
 // buildScannerConfig derives the scanner stage config from the pipeline config.
 // Extracted from startStages so the plumbing is unit-testable — in particular
 // MagikaConfig (#30), which the scanner needs to run AI file-type detection and

--- a/pkg/pipeline/torture_test.go
+++ b/pkg/pipeline/torture_test.go
@@ -112,6 +112,11 @@ func TestTorture(t *testing.T) {
 		})
 	}
 
+	// #119: resume must skip chunks already uploaded and never corrupt the data.
+	t.Run("resume_skips_completed", func(t *testing.T) {
+		runResumeTorture(t, rng)
+	})
+
 	t.Run("idempotent_rerun", func(t *testing.T) {
 		// Uploading the same corpus twice must round-trip byte-identically both
 		// times (no partial/duplicated state corrupting the second run).
@@ -196,6 +201,88 @@ func tortureRoundTrip(t *testing.T, corpus []genFile, srcDir string, mutate func
 	}
 	t.Logf("torture round-trip OK: %d files byte-identical (chunks=%d)", len(corpus), m.TotalChunks)
 	return m
+}
+
+// runResumeTorture proves the #119 wiring produces a working, non-corrupting
+// resume: a resume-mode run of a prior upload (same UploadID) completes and the
+// data still restores byte-identically. It does NOT assert skip efficiency —
+// demonstrating a partial skip deterministically requires an interrupted run,
+// and seeding an artificial partial manifest exposed a separate #157 rough edge
+// (files re-added / ChunksSkipped not reflected in Result) tracked separately.
+func runResumeTorture(t *testing.T, rng *rand.Rand) {
+	bucket := tortureEnv("CARGOSHIP_TEST_BUCKET", "cargoship-pipeline-test")
+	region := tortureEnv("AWS_REGION", "us-east-1")
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
+	require.NoError(t, err)
+	var s3Opts []func(*s3.Options)
+	if substrateURL != "" {
+		s3Opts = append(s3Opts, func(o *s3.Options) { o.UsePathStyle = true })
+	}
+	s3Client := s3.NewFromConfig(cfg, s3Opts...)
+	ctx := context.Background()
+
+	src := t.TempDir()
+	corpus := plantHostileCorpus(t, src, rng, 0)
+	prefix := fmt.Sprintf("resume-%d", time.Now().UnixNano())
+	uploadID := fmt.Sprintf("%d-resume", time.Now().UnixNano())
+
+	newCfg := func(resume bool) *PipelineConfig {
+		resumeID := ""
+		if resume {
+			resumeID = uploadID
+		}
+		return &PipelineConfig{
+			ScannerWorkers: 2, ArchiverWorkers: 4, UploaderWorkers: 4,
+			S3Bucket: bucket, S3Prefix: prefix, S3Region: region,
+			UseRealS3: true, S3Client: s3Client, S3PartSize: 5 * 1024 * 1024,
+			EnableManifest: true, EnablePartialManifest: true, SourcePath: src,
+			UploadID: uploadID, EnableMultiPrefix: true, ShardCount: 4, FileChecksums: true,
+			ResumeMode: resume, ResumeUploadID: resumeID,
+		}
+	}
+
+	// Run 1: full upload.
+	p1, err := NewPipeline(newCfg(false))
+	require.NoError(t, err)
+	r1, err := p1.Run(ctx, src)
+	require.NoError(t, err)
+	require.True(t, r1.Success)
+
+	// Run 2: resume mode (same UploadID). Must complete without error.
+	p2, err := NewPipeline(newCfg(true))
+	require.NoError(t, err)
+	r2, err := p2.Run(ctx, src)
+	require.NoError(t, err)
+	require.True(t, r2.Success, "resume-mode run must complete")
+
+	// After the resume, the data must still restore byte-identically.
+	finalKey := fmt.Sprintf("%s/uploads/%s/manifest.json.gz", prefix, uploadID)
+	obj, err := s3Client.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String(bucket), Key: aws.String(finalKey)})
+	require.NoError(t, err)
+	mBytes, err := readAll(obj.Body)
+	require.NoError(t, err)
+	_ = obj.Body.Close()
+	m, err := manifest.FromJSONCompressed(mBytes)
+	require.NoError(t, err)
+
+	outDir := t.TempDir()
+	se := manifest.NewSelectiveExtractor(m, s3Client, 0)
+	targets := make([]string, len(corpus))
+	for i, f := range corpus {
+		targets[i] = f.relPath
+	}
+	stats, err := se.BatchRestore(ctx, targets, outDir)
+	require.NoError(t, err)
+	require.Zero(t, stats.Failed)
+	byBase := indexFilesByBase(t, outDir)
+	for _, want := range corpus {
+		path, ok := byBase[want.base]
+		require.True(t, ok, "restored file not found for %s", want.relPath)
+		got, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, want.sum, sha256hex(got), "BYTE MISMATCH after resume for %s", want.relPath)
+	}
+	t.Logf("resume-mode round-trip OK: %d files byte-identical (run1 chunks=%d, resume chunks=%d)", len(corpus), r1.ChunksUploaded, r2.ChunksUploaded)
 }
 
 func tortureEnv(key, def string) string {


### PR DESCRIPTION
Phase 2 item 4. `cargoship resume <id>` and `upload --resume` were advertised but
stubbed; upload even pointed at `--resume --upload-id` flags that didn't exist.
This wires them into the **existing** #157 chunk-level resume machinery
(`ResumeMode` + partial-manifest skip) that was only reachable via `create`.

## Why chunk-level
The default upload uses `manager.Uploader` with `LeavePartsOnError=false`, which
discards a failed object's parts — so per-part (mid-object) resume is impossible
without replacing the uploader. The raw-multipart engine in
`pkg/resume/multipart.go` is the wrong model and stays dead (separate cleanup).

## Changes
- **resume.go:** replace the stub — `LoadState` → build S3 client
  (`GetOrCreateS3Client`) → rebuild a resume `PipelineConfig` from the saved
  `UploadState` (new, unit-tested `newResumePipelineConfig`) → run the pipeline.
- **upload.go:** add a real `--resume` flag; on resume, reuse the detected
  state's UploadID as `UploadID`+`ResumeUploadID` and set `ResumeMode=true`, then
  run (instead of erroring). CLI docs regenerated.
- **pipeline.go:** resume no longer hard-fails when there's no saved progress in
  S3 (interrupted before the first partial-manifest save, or already completed) —
  a `NoSuchKey` on the partial manifest falls through to a fresh upload under the
  resume ID (`isNoSuchKeyErr`). This is what makes resume actually usable.

## Tests
- `TestNewResumePipelineConfig_EnablesResume` (unit guard; verified to fail if
  the resume fields are dropped, per stash-verify-discipline).
- Torture `resume_skips_completed` (`make torture RUN=resume_skips_completed`):
  a resume-mode round-trip completes and restores **byte-identical**.

## Noted for follow-up (out of scope)
Seeding an artificial *complete* partial manifest surfaced a separate #157 rough
edge (files re-added / `Result.ChunksSkipped` not reflected in the result) — real
partial-skip behavior warrants its own look. The dead `pkg/resume/multipart.go`
is a separate cleanup. A real-AWS interrupt/resume is the recommended manual check.

Closes #119.