### PR TITLE
fix(docs): correct the Pre-built binaries download URLs in install.md (#406)

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -41,31 +41,62 @@ scoop install cargoship
 
 Download the archive for your platform from the
 [releases page](https://github.com/scttfrdmn/cargoship/releases/latest), unpack
-it, and move the binary onto your PATH.
+it, and move the binary onto your PATH. Each archive contains a single
+`cargoship` binary (plus `README.md`, `LICENSE`, and docs).
+
+The commands below pin the current release, `v0.23.0`. For a different version,
+swap the tag and the version in the filename (the release assets embed the
+version, e.g. `cargoship_0.23.0_linux_x86_64.tar.gz`).
 
 ::: code-group
 
 ```bash [Linux x86_64]
-curl -sSL https://github.com/scttfrdmn/cargoship/releases/latest/download/cargoship-linux-amd64.tar.gz | tar -xz
-sudo mv cargoship-linux-amd64 /usr/local/bin/cargoship
+curl -sSL https://github.com/scttfrdmn/cargoship/releases/download/v0.23.0/cargoship_0.23.0_linux_x86_64.tar.gz | tar -xz
+sudo mv cargoship /usr/local/bin/cargoship
 ```
 
 ```bash [Linux ARM64]
-curl -sSL https://github.com/scttfrdmn/cargoship/releases/latest/download/cargoship-linux-arm64.tar.gz | tar -xz
-sudo mv cargoship-linux-arm64 /usr/local/bin/cargoship
+curl -sSL https://github.com/scttfrdmn/cargoship/releases/download/v0.23.0/cargoship_0.23.0_linux_arm64.tar.gz | tar -xz
+sudo mv cargoship /usr/local/bin/cargoship
 ```
 
 ```bash [macOS (Apple Silicon)]
-curl -sSL https://github.com/scttfrdmn/cargoship/releases/latest/download/cargoship-darwin-arm64.tar.gz | tar -xz
-sudo mv cargoship-darwin-arm64 /usr/local/bin/cargoship
+curl -sSL https://github.com/scttfrdmn/cargoship/releases/download/v0.23.0/cargoship_0.23.0_darwin_arm64.tar.gz | tar -xz
+sudo mv cargoship /usr/local/bin/cargoship
 ```
 
 ```bash [macOS (Intel)]
-curl -sSL https://github.com/scttfrdmn/cargoship/releases/latest/download/cargoship-darwin-amd64.tar.gz | tar -xz
-sudo mv cargoship-darwin-amd64 /usr/local/bin/cargoship
+curl -sSL https://github.com/scttfrdmn/cargoship/releases/download/v0.23.0/cargoship_0.23.0_darwin_x86_64.tar.gz | tar -xz
+sudo mv cargoship /usr/local/bin/cargoship
+```
+
+```bash [Windows x86_64]
+curl -sSL -o cargoship.tar.gz https://github.com/scttfrdmn/cargoship/releases/download/v0.23.0/cargoship_0.23.0_windows_x86_64.tar.gz
+tar -xzf cargoship.tar.gz
+# move cargoship.exe onto your PATH
 ```
 
 :::
+
+### Verify the download
+
+Every release ships a signed `checksums.txt` (SHA-256) whose signature is bound
+to the GitHub Actions build via a keyless cosign Sigstore bundle
+(`checksums.txt.sigstore.json`).
+
+```bash
+# Fetch the checksums file and verify your archive against it
+curl -sSLO https://github.com/scttfrdmn/cargoship/releases/download/v0.23.0/checksums.txt
+sha256sum -c checksums.txt --ignore-missing
+
+# Optionally verify the checksums file itself with cosign (keyless)
+curl -sSLO https://github.com/scttfrdmn/cargoship/releases/download/v0.23.0/checksums.txt.sigstore.json
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/scttfrdmn/cargoship' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+```
 
 ## Docker
 


### PR DESCRIPTION
## Problem

Every download command under **Pre-built binaries** in `docs/start/install.md` 404'd. The documented asset names (`cargoship-<os>-<arch>.tar.gz`) never matched what goreleaser actually produces.

The `archives:name_template` in `.goreleaser.yml` emits:

```
cargoship_<version>_<os>_<arch>.tar.gz
```

with `amd64` mapped to `x86_64`, `arm64` kept as-is, and **no leading `v`** on the version. The `sudo mv` was also wrong — the archive contains a binary named simply `cargoship` (plus README/LICENSE/docs), not `cargoship-linux-amd64`.

## Fix

Rewrote the URLs to the real, version-stamped asset names pinned to the `v0.23.0` tag, fixed the `mv`, added a Windows x86_64 lane, and documented `checksums.txt` + cosign Sigstore verification with the correct asset names.

Because the asset names embed the version, `/latest/download/<name>` cannot resolve — pinned tag URLs are the verifiable form.

### Before / after (representative)

| | Before (404) | After |
|---|---|---|
| Linux x86_64 | `.../releases/latest/download/cargoship-linux-amd64.tar.gz` | `.../releases/download/v0.23.0/cargoship_0.23.0_linux_x86_64.tar.gz` |
| macOS Apple Silicon | `.../releases/latest/download/cargoship-darwin-arm64.tar.gz` | `.../releases/download/v0.23.0/cargoship_0.23.0_darwin_arm64.tar.gz` |
| move step | `sudo mv cargoship-linux-amd64 /usr/local/bin/cargoship` | `sudo mv cargoship /usr/local/bin/cargoship` |

## Verification

Every rewritten filename appears verbatim in `gh release view v0.23.0 --json assets` (checked Linux + macOS assets, plus `checksums.txt` and `checksums.txt.sigstore.json`).

Docs-only change; `gofmt -l .` clean.

Closes #406