### PR TITLE
feat(format): per-frame content checksums for incremental verification (#439)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ benchmark-current.txt
 .env
 .env.*
 !.env.example
+.claude/worktrees/

--- a/docs/reference/format/compression.md
+++ b/docs/reference/format/compression.md
@@ -109,14 +109,46 @@ The index lives in three additive fields (all `omitempty`):
 - `files[].archive_offset` — the byte offset of the file's data within the
   uncompressed tar stream (right after its tar header).
 
+Each frame also carries `checksum` — the SHA-256 (hex) of its **compressed**
+bytes, i.e. exactly what a ranged `GET` of `[compressed_offset, compressed_size)`
+returns.
+
 To read a single file with the index: find the frame whose
 `[uncompressed_offset, uncompressed_offset+uncompressed_size)` contains the
 file's `archive_offset`; ranged-`GET` `[compressed_offset, compressed_size)`;
+**verify the fetched bytes against the frame's `checksum` before decoding**;
 zstd-decode that one frame; slice at `archive_offset − uncompressed_offset` for
 the file's `size` (or `length` for a split part). Frames tile the object
-contiguously and each begins with the zstd magic `0x28 0xB5 0x2F 0xFD`, both of
-which `cargoship verify --deep` checks. Readers without frame support decode the
-whole (concatenated-frame) stream exactly as before.
+contiguously, each begins with the zstd magic `0x28 0xB5 0x2F 0xFD`, and each
+`checksum` matches its bytes — all three of which `cargoship verify --deep`
+checks. Readers without frame support decode the whole (concatenated-frame)
+stream exactly as before.
+
+## Content-integrity contract (for readers and mount layers)
+
+A reader — including a random-access mount layer such as
+[lith](https://github.com/scttfrdmn/lith) — should verify bytes against the
+manifest's strong hashes rather than a weak witness like an S3 ETag (a multipart
+ETag is not a content hash). The manifest records SHA-256 (hex; the algorithm is
+`checksum_algorithm`) at three granularities, all optional:
+
+| Granularity | Field | Attests | Use for |
+|---|---|---|---|
+| Whole file | `files[].checksum` | the file's full content | verifying a reassembled file |
+| Whole object | `chunks[].checksum` | the entire chunk object | `verify --deep`, full-object fetches |
+| Per frame | `chunks[].frames[].checksum` | one frame's compressed bytes | **incremental verification of a ranged fetch** |
+
+Per-frame checksums are the granularity a streaming/mount reader wants: fetch a
+frame's byte range, verify it against `frames[].checksum`, then decode — so a
+changed or hostile endpoint is caught at the range level without downloading the
+whole object.
+
+**Fallbacks.** These fields are additive and may be absent:
+- A chunk without `frames` (a single-frame chunk, or any pre-2.1 archive) has no
+  per-frame hashes; verify at whole-file or whole-object granularity instead.
+- An archive written before per-file checksums existed may lack `files[].checksum`
+  (and `checksum_algorithm`); `verify --deep` reports such data as *unverifiable*
+  rather than assuming it. A reader must decide its own policy for that case.
 
 ## Manifest compression (separate concern)
 

--- a/docs/reference/format/manifest.md
+++ b/docs/reference/format/manifest.md
@@ -205,10 +205,11 @@ type ChunkEntry struct {
 // FrameEntry maps one independent zstd frame to the tar bytes it decodes to.
 // Frames tile the chunk object and every file lies entirely within one frame.
 type FrameEntry struct {
-	CompressedOffset   int64 `json:"compressed_offset"`   // byte offset of the frame in the object
-	CompressedSize     int64 `json:"compressed_size"`     // frame length in compressed bytes
-	UncompressedOffset int64 `json:"uncompressed_offset"` // frame's first byte in the tar stream
-	UncompressedSize   int64 `json:"uncompressed_size"`   // frame length after decompression
+	CompressedOffset   int64  `json:"compressed_offset"`   // byte offset of the frame in the object
+	CompressedSize     int64  `json:"compressed_size"`     // frame length in compressed bytes
+	UncompressedOffset int64  `json:"uncompressed_offset"` // frame's first byte in the tar stream
+	UncompressedSize   int64  `json:"uncompressed_size"`   // frame length after decompression
+	Checksum           string `json:"checksum,omitempty"`  // SHA-256 (hex) of the frame's compressed bytes (#439)
 }
 ```
 

--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -800,6 +800,19 @@ func (se *SelectiveExtractor) tryFrameRestore(ctx context.Context, entry *FileEn
 	}
 	stats.ChunksDownloaded++
 
+	// #439: when the frame carries a content checksum, verify the fetched
+	// compressed bytes before decoding — the strong per-range witness that
+	// catches a changed/hostile endpoint without trusting the S3 ETag. Only when
+	// the Range was honored (otherwise comp is the whole object, not the frame).
+	if partial && fr.Checksum != "" &&
+		(se.manifest.ChecksumAlgorithm == "" || se.manifest.ChecksumAlgorithm == ChecksumAlgorithmSHA256) {
+		got := sha256.Sum256(comp)
+		if hex.EncodeToString(got[:]) != fr.Checksum {
+			stats.Failed++
+			return true
+		}
+	}
+
 	raw, err := decodeZstdFrame(comp)
 	if err != nil {
 		stats.Failed++

--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"sort"
 	"strings"
@@ -258,14 +259,16 @@ func (dv *DeepVerifier) verifyChunk(ctx context.Context, chunk *ChunkEntry) Chun
 	defer func() { _ = output.Body.Close() }()
 
 	hasher := sha256.New()
-	// #436: when the chunk carries a frame index, verify in the same streaming
-	// pass that the zstd frame magic appears at each recorded frame offset — no
-	// extra download and no buffering of the (possibly large) object.
-	var magic *frameMagicWriter
+	// #436/#439: when the chunk carries a frame index, verify in the same
+	// streaming pass that the zstd frame magic appears at each recorded frame
+	// offset AND that each frame's content checksum matches its bytes — no extra
+	// download and no buffering of the (possibly large) object.
+	var fv *frameStreamVerifier
 	dst := io.Writer(hasher)
 	if len(chunk.Frames) > 0 {
-		magic = newFrameMagicWriter(chunk.Frames)
-		dst = io.MultiWriter(hasher, magic)
+		algoOK := dv.manifest.ChecksumAlgorithm == "" || dv.manifest.ChecksumAlgorithm == ChecksumAlgorithmSHA256
+		fv = newFrameStreamVerifier(chunk.Frames, algoOK)
+		dst = io.MultiWriter(hasher, fv)
 	}
 	n, err := io.Copy(dst, output.Body)
 	if err != nil {
@@ -281,17 +284,18 @@ func (dv *DeepVerifier) verifyChunk(ctx context.Context, chunk *ChunkEntry) Chun
 		return cr
 	}
 
-	// #436: the bytes matched; now confirm the frame index is well-formed —
-	// frames tile the object contiguously and each begins with the zstd magic.
+	// #436/#439: the bytes matched; now confirm the frame index is well-formed —
+	// frames tile the object contiguously, each begins with the zstd magic, and
+	// each recorded per-frame checksum matches its bytes.
 	if len(chunk.Frames) > 0 {
 		if ferr := validateFrameTiling(chunk.Frames, n); ferr != nil {
 			cr.Status = ChunkVerifyMismatch
 			cr.Err = ferr.Error()
 			return cr
 		}
-		if magic.err != nil {
+		if fv.err != nil {
 			cr.Status = ChunkVerifyMismatch
-			cr.Err = magic.err.Error()
+			cr.Err = fv.err.Error()
 			return cr
 		}
 	}
@@ -316,60 +320,82 @@ func (c *countingReader) Read(p []byte) (int, error) {
 // zstdFrameMagic is the 4-byte magic number that begins every zstd frame.
 var zstdFrameMagic = []byte{0x28, 0xB5, 0x2F, 0xFD}
 
-// frameMagicWriter verifies, as a chunk object streams through it, that the zstd
-// frame magic appears at each recorded frame's CompressedOffset (#436). It
-// collects the four magic bytes for one frame at a time and tolerates a magic
-// that straddles two Write calls. Frames must be sorted by CompressedOffset.
-type frameMagicWriter struct {
-	frames []FrameEntry
-	pos    int64  // absolute stream offset of the next byte to be written
-	idx    int    // index of the frame whose magic we're still collecting
-	got    []byte // magic bytes collected so far for frames[idx]
-	err    error
+// frameStreamVerifier verifies a chunk object's frame index as the object
+// streams through it (#436/#439): each frame must begin with the zstd magic, and
+// — when the frame carries a checksum — its bytes must hash to that checksum. It
+// consumes the frames in order, CompressedSize bytes each (they tile the object,
+// which validateFrameTiling confirms separately), so it needs no buffering and
+// tolerates arbitrary Write chunking. Frames are sorted by CompressedOffset.
+type frameStreamVerifier struct {
+	frames   []FrameEntry
+	idx      int       // current frame
+	consumed int64     // bytes of the current frame seen so far
+	magic    []byte    // first up-to-4 bytes of the current frame
+	h        hash.Hash // per-frame content hash (nil when algorithm unsupported)
+	hashing  bool      // whether the current frame's checksum is being verified
+	algoOK   bool      // manifest checksum algorithm is sha256 (or unset)
+	err      error
 }
 
-func newFrameMagicWriter(frames []FrameEntry) *frameMagicWriter {
+func newFrameStreamVerifier(frames []FrameEntry, algoOK bool) *frameStreamVerifier {
 	sorted := make([]FrameEntry, len(frames))
 	copy(sorted, frames)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].CompressedOffset < sorted[j].CompressedOffset })
-	return &frameMagicWriter{frames: sorted, got: make([]byte, 0, 4)}
+	v := &frameStreamVerifier{frames: sorted, magic: make([]byte, 0, 4), algoOK: algoOK}
+	if algoOK {
+		v.h = sha256.New()
+	}
+	v.hashing = len(sorted) > 0 && algoOK && sorted[0].Checksum != ""
+	return v
 }
 
-func (w *frameMagicWriter) Write(p []byte) (int, error) {
-	if w.err == nil {
-		w.scan(p)
+func (w *frameStreamVerifier) Write(p []byte) (int, error) {
+	total := len(p)
+	for len(p) > 0 && w.idx < len(w.frames) && w.err == nil {
+		fr := &w.frames[w.idx]
+		remaining := fr.CompressedSize - w.consumed
+		if remaining <= 0 { // defensive: non-positive frame size (tiling check reports it)
+			w.finishFrame(fr)
+			continue
+		}
+		take := int64(len(p))
+		if take > remaining {
+			take = remaining
+		}
+		seg := p[:take]
+		for i := 0; i < len(seg) && len(w.magic) < 4; i++ {
+			w.magic = append(w.magic, seg[i])
+		}
+		if w.hashing {
+			_, _ = w.h.Write(seg)
+		}
+		w.consumed += take
+		p = p[take:]
+		if w.consumed == fr.CompressedSize {
+			w.finishFrame(fr)
+		}
 	}
-	w.pos += int64(len(p))
-	return len(p), nil
+	return total, nil
 }
 
-func (w *frameMagicWriter) scan(p []byte) {
-	for w.idx < len(w.frames) {
-		off := w.frames[w.idx].CompressedOffset
-		start := off + int64(len(w.got)) // absolute position of the next magic byte we need
-		rel := start - w.pos
-		if rel < 0 {
-			w.err = fmt.Errorf("frame %d offset %d precedes the stream position", w.idx, off)
-			return
-		}
-		if rel >= int64(len(p)) {
-			return // the bytes we need are in a later buffer
-		}
-		take := int64(4 - len(w.got))
-		if avail := int64(len(p)) - rel; avail < take {
-			take = avail
-		}
-		w.got = append(w.got, p[rel:rel+take]...)
-		if len(w.got) < 4 {
-			return // wait for the rest in the next buffer
-		}
-		if !bytes.Equal(w.got, zstdFrameMagic) {
-			w.err = fmt.Errorf("frame %d at offset %d does not begin with the zstd frame magic", w.idx, off)
-			return
-		}
-		w.got = w.got[:0]
-		w.idx++
+func (w *frameStreamVerifier) finishFrame(fr *FrameEntry) {
+	if len(w.magic) < 4 || !bytes.Equal(w.magic, zstdFrameMagic) {
+		w.err = fmt.Errorf("frame %d does not begin with the zstd frame magic", w.idx)
+		return
 	}
+	if w.hashing {
+		if hex.EncodeToString(w.h.Sum(nil)) != fr.Checksum {
+			w.err = fmt.Errorf("frame %d content checksum does not match its bytes", w.idx)
+			return
+		}
+	}
+	w.idx++
+	w.consumed = 0
+	w.magic = w.magic[:0]
+	if w.h != nil {
+		w.h.Reset()
+	}
+	w.hashing = w.idx < len(w.frames) && w.algoOK && w.frames[w.idx].Checksum != ""
 }
 
 // validateFrameTiling checks that the frame index covers the whole object with

--- a/pkg/manifest/frame_index_test.go
+++ b/pkg/manifest/frame_index_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -56,11 +58,15 @@ func buildStdlibFramedChunk(t *testing.T, entries []framedFile, frameSize int64)
 	var frameStartU, frameStartC int64
 
 	appendFrame := func() {
+		// #439: per-frame checksum over the frame's compressed bytes (what a
+		// ranged GET returns), mirroring the archiver's framer.
+		sum := sha256.Sum256(out.Bytes()[frameStartC:cwC.n])
 		frames = append(frames, FrameEntry{
 			CompressedOffset:   frameStartC,
 			CompressedSize:     cwC.n - frameStartC,
 			UncompressedOffset: frameStartU,
 			UncompressedSize:   cwU.n - frameStartU,
+			Checksum:           hex.EncodeToString(sum[:]),
 		})
 	}
 
@@ -252,6 +258,50 @@ func TestDeepVerifyFrameIndex(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, fres.Passed(), "a wrong archive_offset must fail file verify")
 	assert.Positive(t, fres.Mismatched)
+
+	// Wrong per-frame checksum (#439): fails the chunk check even though the
+	// bytes and the whole-object checksum are intact.
+	badFrame := framedManifest(key, files, frames, offsets)
+	badFrame.ChecksumAlgorithm = ChecksumAlgorithmSHA256
+	badFrame.Chunks[0].Checksum = sha256hexIndep(chunkBytes)
+	badFrame.Chunks[0].Frames[0].Checksum = "deadbeef"
+	res2, err := NewDeepVerifier(badFrame, dl).SetBucket("test-bucket").VerifyChunks(context.Background())
+	require.NoError(t, err)
+	assert.False(t, res2.Passed(), "a wrong per-frame checksum must fail chunk verify")
+}
+
+// TestFrameChecksumCatchesTamperedRange proves the #439 protection: when a
+// (hostile or corrupt) backend serves changed bytes for a frame's range, the
+// reader rejects them via the per-frame checksum BEFORE decoding, rather than
+// trusting the ETag — so nothing corrupt is written.
+func TestFrameChecksumCatchesTamperedRange(t *testing.T) {
+	files := []framedFile{
+		{"d/a", bytes.Repeat([]byte("a"), 20000)},
+		{"d/b", bytes.Repeat([]byte("b"), 20000)},
+		{"d/c", bytes.Repeat([]byte("c"), 20000)},
+	}
+	key := "backups/uploads/20260910-frame/shard-0/chunk-0.tar.zst"
+	chunkBytes, frames, offsets := buildStdlibFramedChunk(t, files, 16*1024)
+	require.NotEmpty(t, frames[0].Checksum, "helper must record per-frame checksums")
+	m := framedManifest(key, files, frames, offsets)
+
+	// Corrupt one byte inside file c's frame in the served object; leave the
+	// manifest (and its frame checksum) intact — the endpoint is lying.
+	cFrame := findFrame(frames, offsets["d/c"], int64(len(files[2].content)))
+	require.NotNil(t, cFrame)
+	tampered := append([]byte(nil), chunkBytes...)
+	tampered[cFrame.CompressedOffset+cFrame.CompressedSize-1] ^= 0xFF
+
+	dl := &rangeDownloader{object: tampered, honorRange: true}
+	se := NewSelectiveExtractor(m, dl, 0).SetBucket("test-bucket")
+
+	dest := t.TempDir()
+	stats, err := se.BatchRestore(context.Background(), []string{"d/c"}, dest)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.Restored, "tampered frame must not be restored")
+	assert.Equal(t, int64(1), stats.Failed)
+	_, statErr := os.Stat(filepath.Join(dest, "d", "c"))
+	assert.True(t, os.IsNotExist(statErr), "no corrupt file should be written")
 }
 
 // TestSelectiveExtractorFrameRestoreRangeIgnored proves the reader still restores

--- a/pkg/manifest/schema.json
+++ b/pkg/manifest/schema.json
@@ -108,7 +108,8 @@
         "compressed_offset": { "type": "integer" },
         "compressed_size": { "type": "integer" },
         "uncompressed_offset": { "type": "integer" },
-        "uncompressed_size": { "type": "integer" }
+        "uncompressed_size": { "type": "integer" },
+        "checksum": { "type": "string", "description": "SHA-256 (hex) of the frame's compressed bytes, for incremental ranged verification (#439)." }
       }
     },
     "shardEntry": {

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -293,6 +293,14 @@ type FrameEntry struct {
 	UncompressedOffset int64 `json:"uncompressed_offset"`
 	// UncompressedSize is the frame's length after decompression.
 	UncompressedSize int64 `json:"uncompressed_size"`
+	// Checksum is the SHA-256 (hex) of the frame's *compressed* bytes — exactly
+	// the bytes a ranged GET of [CompressedOffset, CompressedOffset+CompressedSize)
+	// returns (#439). It lets a reader verify a single frame it fetched, before
+	// decoding, without downloading the whole object — the strong per-range
+	// content witness the mount/random-access path needs (an S3 ETag is not one).
+	// Empty when checksums were disabled at upload; the algorithm is the
+	// manifest's ChecksumAlgorithm.
+	Checksum string `json:"checksum,omitempty"`
 }
 
 // ShardEntry represents a shard (S3 prefix) in the manifest

--- a/pkg/pipeline/archiver.go
+++ b/pkg/pipeline/archiver.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"runtime"
@@ -23,16 +24,21 @@ import (
 // countingWriter counts the bytes written through it, forwarding to w. It is the
 // byte-offset source for the format-2.1 frame index (#436): one instance wraps
 // the tar stream (uncompressed offsets), another wraps the pipe (compressed
-// offsets). Only the single archive goroutine writes through it, so it needs no
-// locking.
+// offsets). When h is set (the compressed side), it also hashes the bytes so the
+// framer can record a per-frame content checksum (#439). Only the single archive
+// goroutine writes through it, so it needs no locking.
 type countingWriter struct {
 	w io.Writer
 	n int64
+	h hash.Hash // optional: per-frame content hash of the compressed bytes (#439)
 }
 
 func (c *countingWriter) Write(p []byte) (int, error) {
 	n, err := c.w.Write(p)
 	c.n += int64(n)
+	if c.h != nil {
+		_, _ = c.h.Write(p[:n])
+	}
 	return n, err
 }
 
@@ -80,14 +86,7 @@ func (f *framer) maybeCut() error {
 	if err := f.encoder.Close(); err != nil { // write this frame's epilogue into cwC→pw
 		return fmt.Errorf("close zstd frame: %w", err)
 	}
-	f.frames = append(f.frames, manifest.FrameEntry{
-		CompressedOffset:   f.frameStartC,
-		CompressedSize:     f.cwC.n - f.frameStartC,
-		UncompressedOffset: f.frameStartU,
-		UncompressedSize:   f.cwU.n - f.frameStartU,
-	})
-	f.frameStartC = f.cwC.n
-	f.frameStartU = f.cwU.n
+	f.appendFrame()
 	f.encoder.Reset(f.cwC) // begin the next independent frame on the same pipe
 	return nil
 }
@@ -98,12 +97,29 @@ func (f *framer) finalize() {
 	if !f.active() {
 		return
 	}
+	f.appendFrame()
+}
+
+// appendFrame records the current frame (the span since the last cut) and, when
+// the compressed-side hasher is present, its per-frame content checksum (#439),
+// then advances the frame-start marks and resets the hasher for the next frame.
+// The compressed-frame bytes are complete in cwC at every call site (after an
+// encoder.Close), so the sum covers exactly the bytes a ranged GET returns.
+func (f *framer) appendFrame() {
+	sum := ""
+	if f.cwC.h != nil {
+		sum = hex.EncodeToString(f.cwC.h.Sum(nil))
+		f.cwC.h.Reset()
+	}
 	f.frames = append(f.frames, manifest.FrameEntry{
 		CompressedOffset:   f.frameStartC,
 		CompressedSize:     f.cwC.n - f.frameStartC,
 		UncompressedOffset: f.frameStartU,
 		UncompressedSize:   f.cwU.n - f.frameStartU,
+		Checksum:           sum,
 	})
+	f.frameStartC = f.cwC.n
+	f.frameStartU = f.cwU.n
 }
 
 // EncoderPool manages a pool of reusable zstd encoders
@@ -640,9 +656,9 @@ func (s *ArchiverStage) Process(ctx context.Context, job *Job) error {
 		var fr *framer
 
 		if useCompression {
-			// cwC counts compressed bytes into the pipe; cwU counts the
-			// uncompressed tar position. tw → cwU → encoder → cwC → pw.
-			cwC := &countingWriter{w: pw}
+			// cwC counts (and hashes, #439) compressed bytes into the pipe; cwU
+			// counts the uncompressed tar position. tw → cwU → encoder → cwC → pw.
+			cwC := &countingWriter{w: pw, h: sha256.New()}
 			encoder.Reset(cwC)
 			cwU := &countingWriter{w: encoder}
 			tw = tar.NewWriter(cwU)

--- a/pkg/pipeline/archiver_test.go
+++ b/pkg/pipeline/archiver_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -693,10 +695,14 @@ func TestArchiverStage_Process_Frames(t *testing.T) {
 	require.Greater(t, len(frames), 1, "small frame size must cut multiple frames")
 	require.Len(t, out.FileArchiveOffsets(), nFiles)
 
-	// Frames tile the compressed object contiguously and cover it entirely.
+	// Frames tile the compressed object contiguously, cover it entirely, and each
+	// carries a correct per-frame content checksum (#439).
 	var next int64
 	for i, f := range frames {
 		assert.Equal(t, next, f.CompressedOffset, "frame %d must be contiguous", i)
+		require.NotEmpty(t, f.Checksum, "frame %d must carry a checksum", i)
+		want := sha256.Sum256(raw[f.CompressedOffset : f.CompressedOffset+f.CompressedSize])
+		assert.Equal(t, hex.EncodeToString(want[:]), f.Checksum, "frame %d checksum must match its bytes", i)
 		next += f.CompressedSize
 	}
 	assert.Equal(t, int64(len(raw)), next, "frames must cover the whole object")

--- a/pkg/pipeline/framer_test.go
+++ b/pkg/pipeline/framer_test.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"archive/tar"
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
@@ -17,7 +19,7 @@ import (
 // goroutine does: tw → cwU → encoder → cwC → buf.
 func newTestFramer(t *testing.T, buf *bytes.Buffer, frameSize int64) *framer {
 	t.Helper()
-	cwC := &countingWriter{w: buf}
+	cwC := &countingWriter{w: buf, h: sha256.New()}
 	enc, err := zstd.NewWriter(cwC)
 	require.NoError(t, err)
 	cwU := &countingWriter{w: enc}
@@ -60,10 +62,14 @@ func TestFramerCutsFramesAndRecordsOffsets(t *testing.T) {
 	offsets := job.FileArchiveOffsets()
 	require.Len(t, offsets, len(files))
 
-	// Frames tile the compressed stream contiguously and cover the whole object.
+	// Frames tile the compressed stream contiguously and cover the whole object,
+	// and each carries a correct per-frame content checksum (#439).
 	var next int64
+	obj := buf.Bytes()
 	for i, fe := range fr.frames {
 		assert.Equal(t, next, fe.CompressedOffset, "frame %d must start where the previous ended", i)
+		want := sha256.Sum256(obj[fe.CompressedOffset : fe.CompressedOffset+fe.CompressedSize])
+		assert.Equal(t, hex.EncodeToString(want[:]), fe.Checksum, "frame %d checksum must match its compressed bytes", i)
 		next += fe.CompressedSize
 	}
 	assert.Equal(t, int64(buf.Len()), next, "frames must cover the whole object")


### PR DESCRIPTION
## Summary

Adds `FrameEntry.checksum` — the SHA-256 of a frame's **compressed** bytes (exactly what a ranged `GET` of `[compressed_offset, compressed_size)` returns) — so a random-access reader (e.g. the **lith** mount layer, #439) can verify a single fetched frame against the manifest *before decoding*, instead of trusting a weak S3 ETag (a multipart ETag isn't a content hash).

Purely **additive within the unreleased 2.1 format** — a 2.1 archive written without it still reads. This lands before 2.1's first release (v0.24.0) so the shipped format is complete for the mount use-case (no 2.2 needed).

## Changes
- **Producer** (`pkg/pipeline/archiver.go`): the framer's compressed-side counter now also hashes each frame; the sum is recorded per `FrameEntry`.
- **Reader** (`pkg/manifest/batch_restore.go`): `BatchRestore`'s frame fast path verifies the fetched compressed bytes against `FrameEntry.checksum` before decoding (only when the Range was honored — the range-ignored fallback path is unaffected).
- **verify --deep** (`pkg/manifest/deep_verify.go`): the streaming per-chunk pass now checks each frame's checksum against its bytes (`frameStreamVerifier`), alongside the existing magic + tiling checks — no extra download, no buffering.
- **Docs**: schema + drift test + format spec updated; a new **content-integrity contract** section documents the whole-file / whole-object / per-frame hashes and the fallbacks (single-frame chunks, pre-2.1, pre-checksum archives) — the direct answer to #439's ask.

## Testing
- Per-frame checksums round-trip (stdlib helper + the real archiver assert the recorded checksum matches `sha256` of the compressed frame bytes).
- **A tampered frame range is rejected before decode** — nothing corrupt is written (the #439 protection).
- A wrong per-frame checksum fails `verify --deep`.
- Emulator torture `frames_random_access` still byte-identical; coverage above floors (manifest 76.7, pipeline 56.4).

Answers #439 (integrity contract + per-frame hashes for the mount path). Builds on the Format 2.1 frame index (#436/#438).