### PR TITLE
refactor(context): remove the dead agent context and command entries (v0.20.0 leftover)

### DIFF
--- a/cmd/cargoship/cmd/context.go
+++ b/cmd/cargoship/cmd/context.go
@@ -19,15 +19,14 @@ func NewContextCmd() *cobra.Command {
 
 Context determines the operational mode:
 - local: Local filesystem operations and archive creation
-- agent: Launch agent monitoring and management
 - repl:  Interactive shell mode with command discovery
 
 The current context is cached in ~/.cargoship-context and persists between sessions.`,
 		Example: `  # Show current context
   cargoship context
 
-  # Switch to agent context
-  cargoship context switch agent
+  # Switch to repl context
+  cargoship context switch repl
 
   # List available contexts
   cargoship context list
@@ -71,10 +70,8 @@ func newContextSwitchCmd() *cobra.Command {
 
 Available contexts:
 - local: Local filesystem operations and archive creation
-- agent: Launch agent monitoring and management
 - repl:  Interactive shell mode with command discovery`,
 		Example: `  cargoship context switch local
-  cargoship context switch agent
   cargoship context switch repl`,
 		Args: cobra.ExactArgs(1),
 		RunE: switchContext,
@@ -252,15 +249,8 @@ func showContextTips(ctx context.ExecutionContext) {
 	switch ctx {
 	case context.ContextLocal:
 		fmt.Println("💡 Local context tips:")
-		fmt.Println("   cargoship create suitcase /path/to/data")
+		fmt.Println("   cargoship create upload /path/to/data")
 		fmt.Println("   cargoship analyze /path/to/data")
-		fmt.Println("   cargoship wizard  # Interactive setup")
-
-	case context.ContextAgent:
-		fmt.Println("💡 Agent context tips:")
-		fmt.Println("   cargoship agent status")
-		fmt.Println("   cargoship agent logs")
-		fmt.Println("   cargoship agent config reload")
 
 	case context.ContextREPL:
 		fmt.Println("💡 REPL context tips:")

--- a/cmd/cargoship/cmd/root.go
+++ b/cmd/cargoship/cmd/root.go
@@ -68,7 +68,7 @@ func NewRootCmdWithVersion(lo io.Writer, versionInfo string) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&runtimeProfile, "pprof", false, "Enable runtime profiling HTTP endpoint at localhost:6060")
 	cmd.PersistentFlags().String("pprof-addr", "localhost:6060", "Address for runtime profiling HTTP endpoint")
 	cmd.PersistentFlags().String("memory-limit", "", "Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.")
-	cmd.PersistentFlags().String("context", "", "Override execution context (local, agent, repl)")
+	cmd.PersistentFlags().String("context", "", "Override execution context (local, repl)")
 	cmd.SetVersionTemplate("{{ .Version }}\n")
 
 	// Create stuff

--- a/docs/gen/cli/cargoship.md
+++ b/docs/gen/cli/cargoship.md
@@ -12,7 +12,7 @@ Enterprise data archiving for AWS
 ### Options
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
   -h, --help                  help for cargoship
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_alerts.md
+++ b/docs/gen/cli/cargoship_alerts.md
@@ -58,7 +58,7 @@ cargoship alerts [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_alerts_config.md
+++ b/docs/gen/cli/cargoship_alerts_config.md
@@ -34,7 +34,7 @@ cargoship alerts config [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_alerts_configure.md
+++ b/docs/gen/cli/cargoship_alerts_configure.md
@@ -52,7 +52,7 @@ cargoship alerts configure [channel] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_alerts_disable.md
+++ b/docs/gen/cli/cargoship_alerts_disable.md
@@ -33,7 +33,7 @@ cargoship alerts disable [channel] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_alerts_enable.md
+++ b/docs/gen/cli/cargoship_alerts_enable.md
@@ -33,7 +33,7 @@ cargoship alerts enable [channel] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_alerts_test.md
+++ b/docs/gen/cli/cargoship_alerts_test.md
@@ -35,7 +35,7 @@ cargoship alerts test [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_analyze.md
+++ b/docs/gen/cli/cargoship_analyze.md
@@ -50,7 +50,7 @@ cargoship analyze <s3://bucket[/prefix]> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_balance.md
+++ b/docs/gen/cli/cargoship_balance.md
@@ -48,7 +48,7 @@ cargoship balance <s3://bucket/prefix/uploads/upload-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_benchmark.md
+++ b/docs/gen/cli/cargoship_benchmark.md
@@ -40,7 +40,7 @@ cargoship benchmark [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_browse.md
+++ b/docs/gen/cli/cargoship_browse.md
@@ -52,7 +52,7 @@ cargoship browse S3_URL [OUTPUT_DIR] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_budget.md
+++ b/docs/gen/cli/cargoship_budget.md
@@ -51,7 +51,7 @@ cargoship budget [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_budget_list.md
+++ b/docs/gen/cli/cargoship_budget_list.md
@@ -34,7 +34,7 @@ cargoship budget list [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_budget_remove.md
+++ b/docs/gen/cli/cargoship_budget_remove.md
@@ -26,7 +26,7 @@ cargoship budget remove <project-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_budget_set.md
+++ b/docs/gen/cli/cargoship_budget_set.md
@@ -51,7 +51,7 @@ cargoship budget set <project-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_budget_status.md
+++ b/docs/gen/cli/cargoship_budget_status.md
@@ -41,7 +41,7 @@ cargoship budget status <project-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_config.md
+++ b/docs/gen/cli/cargoship_config.md
@@ -53,7 +53,7 @@ cargoship config [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_context.md
+++ b/docs/gen/cli/cargoship_context.md
@@ -8,7 +8,6 @@ Manage CargoShip execution context to control which commands are available.
 
 Context determines the operational mode:
 - local: Local filesystem operations and archive creation
-- agent: Launch agent monitoring and management
 - repl:  Interactive shell mode with command discovery
 
 The current context is cached in ~/.cargoship-context and persists between sessions.
@@ -23,8 +22,8 @@ cargoship context [flags]
   # Show current context
   cargoship context
 
-  # Switch to agent context
-  cargoship context switch agent
+  # Switch to repl context
+  cargoship context switch repl
 
   # List available contexts
   cargoship context list
@@ -45,7 +44,7 @@ cargoship context [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_context_list.md
+++ b/docs/gen/cli/cargoship_context_list.md
@@ -19,7 +19,7 @@ cargoship context list [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_context_reset.md
+++ b/docs/gen/cli/cargoship_context_reset.md
@@ -21,7 +21,7 @@ cargoship context reset [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_context_show.md
+++ b/docs/gen/cli/cargoship_context_show.md
@@ -20,7 +20,7 @@ cargoship context show [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_context_switch.md
+++ b/docs/gen/cli/cargoship_context_switch.md
@@ -8,7 +8,6 @@ Switch to a different execution context.
 
 Available contexts:
 - local: Local filesystem operations and archive creation
-- agent: Launch agent monitoring and management
 - repl:  Interactive shell mode with command discovery
 
 ```
@@ -19,7 +18,6 @@ cargoship context switch <context> [flags]
 
 ```
   cargoship context switch local
-  cargoship context switch agent
   cargoship context switch repl
 ```
 
@@ -32,7 +30,7 @@ cargoship context switch <context> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_cost.md
+++ b/docs/gen/cli/cargoship_cost.md
@@ -42,7 +42,7 @@ cargoship cost [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_cost_benchmark-compare.md
+++ b/docs/gen/cli/cargoship_cost_benchmark-compare.md
@@ -47,7 +47,7 @@ cargoship cost benchmark-compare [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_budget.md
+++ b/docs/gen/cli/cargoship_cost_budget.md
@@ -51,7 +51,7 @@ cargoship cost budget [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_budget_list.md
+++ b/docs/gen/cli/cargoship_cost_budget_list.md
@@ -34,7 +34,7 @@ cargoship cost budget list [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_cost_budget_remove.md
+++ b/docs/gen/cli/cargoship_cost_budget_remove.md
@@ -26,7 +26,7 @@ cargoship cost budget remove <project-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_budget_set.md
+++ b/docs/gen/cli/cargoship_cost_budget_set.md
@@ -51,7 +51,7 @@ cargoship cost budget set <project-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_budget_status.md
+++ b/docs/gen/cli/cargoship_cost_budget_status.md
@@ -41,7 +41,7 @@ cargoship cost budget status <project-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_cost_burnrate.md
+++ b/docs/gen/cli/cargoship_cost_burnrate.md
@@ -42,7 +42,7 @@ cargoship cost burnrate [PROJECT_ID] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_estimate.md
+++ b/docs/gen/cli/cargoship_cost_estimate.md
@@ -38,7 +38,7 @@ cargoship cost estimate [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_exhaustion.md
+++ b/docs/gen/cli/cargoship_cost_exhaustion.md
@@ -46,7 +46,7 @@ cargoship cost exhaustion [PROJECT_ID] --budget AMOUNT [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_forecast.md
+++ b/docs/gen/cli/cargoship_cost_forecast.md
@@ -47,7 +47,7 @@ cargoship cost forecast [PROJECT_ID] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_history.md
+++ b/docs/gen/cli/cargoship_cost_history.md
@@ -34,7 +34,7 @@ cargoship cost history [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_pricing.md
+++ b/docs/gen/cli/cargoship_cost_pricing.md
@@ -35,7 +35,7 @@ cargoship cost pricing [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_project.md
+++ b/docs/gen/cli/cargoship_cost_project.md
@@ -38,7 +38,7 @@ cargoship cost project PROJECT_ID [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_projects.md
+++ b/docs/gen/cli/cargoship_cost_projects.md
@@ -30,7 +30,7 @@ cargoship cost projects [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_report.md
+++ b/docs/gen/cli/cargoship_cost_report.md
@@ -47,7 +47,7 @@ cargoship cost report [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_summary.md
+++ b/docs/gen/cli/cargoship_cost_summary.md
@@ -32,7 +32,7 @@ cargoship cost summary [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_cost_upload.md
+++ b/docs/gen/cli/cargoship_cost_upload.md
@@ -40,7 +40,7 @@ cargoship cost upload [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --json                  Output as JSON
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_create.md
+++ b/docs/gen/cli/cargoship_create.md
@@ -16,7 +16,7 @@ cargoship create [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_create_keys.md
+++ b/docs/gen/cli/cargoship_create_keys.md
@@ -31,7 +31,7 @@ cargoship create keys [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
   -d, --destination string    Directory to write files in to. Defaults to the current directory
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_create_upload.md
+++ b/docs/gen/cli/cargoship_create_upload.md
@@ -62,7 +62,7 @@ cargoship create upload SOURCE_DIR... [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
   -d, --destination string    Directory to write files in to. Defaults to the current directory
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060

--- a/docs/gen/cli/cargoship_dashboard.md
+++ b/docs/gen/cli/cargoship_dashboard.md
@@ -43,7 +43,7 @@ cargoship dashboard [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_delete.md
+++ b/docs/gen/cli/cargoship_delete.md
@@ -47,7 +47,7 @@ cargoship delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_download.md
+++ b/docs/gen/cli/cargoship_download.md
@@ -59,7 +59,7 @@ cargoship download S3_URL OUTPUT_DIR [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_dvc.md
+++ b/docs/gen/cli/cargoship_dvc.md
@@ -19,7 +19,7 @@ information from dvc.yaml before using these commands.
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_dvc_export.md
+++ b/docs/gen/cli/cargoship_dvc_export.md
@@ -18,7 +18,7 @@ cargoship dvc export S3_URL [OUTPUT_DIR] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_dvc_stages.md
+++ b/docs/gen/cli/cargoship_dvc_stages.md
@@ -17,7 +17,7 @@ cargoship dvc stages S3_URL [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_dvc_status.md
+++ b/docs/gen/cli/cargoship_dvc_status.md
@@ -18,7 +18,7 @@ cargoship dvc status LOCAL_PATH S3_URL [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_estimate.md
+++ b/docs/gen/cli/cargoship_estimate.md
@@ -37,7 +37,7 @@ cargoship estimate [path] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_info.md
+++ b/docs/gen/cli/cargoship_info.md
@@ -52,7 +52,7 @@ cargoship info [s3://bucket/prefix/uploads/upload-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_lifecycle.md
+++ b/docs/gen/cli/cargoship_lifecycle.md
@@ -46,7 +46,7 @@ cargoship lifecycle [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_list.md
+++ b/docs/gen/cli/cargoship_list.md
@@ -39,7 +39,7 @@ cargoship list [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_metrics.md
+++ b/docs/gen/cli/cargoship_metrics.md
@@ -32,7 +32,7 @@ cargoship metrics [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_migrate.md
+++ b/docs/gen/cli/cargoship_migrate.md
@@ -55,7 +55,7 @@ cargoship migrate SOURCE_ARCHIVE DESTINATION [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_profile.md
+++ b/docs/gen/cli/cargoship_profile.md
@@ -43,7 +43,7 @@ Examples:
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_profile_collect.md
+++ b/docs/gen/cli/cargoship_profile_collect.md
@@ -31,7 +31,7 @@ cargoship profile collect [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_profile_list.md
+++ b/docs/gen/cli/cargoship_profile_list.md
@@ -20,7 +20,7 @@ cargoship profile list [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_profile_stats.md
+++ b/docs/gen/cli/cargoship_profile_stats.md
@@ -20,7 +20,7 @@ cargoship profile stats [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_restore.md
+++ b/docs/gen/cli/cargoship_restore.md
@@ -69,7 +69,7 @@ cargoship restore S3_URL OUTPUT_DIR [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_restore_jobs.md
+++ b/docs/gen/cli/cargoship_restore_jobs.md
@@ -20,7 +20,7 @@ track the job and trigger the download once the objects are ready.
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_restore_jobs_check.md
+++ b/docs/gen/cli/cargoship_restore_jobs_check.md
@@ -21,7 +21,7 @@ cargoship restore jobs check [job-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_restore_jobs_clean.md
+++ b/docs/gen/cli/cargoship_restore_jobs_clean.md
@@ -20,7 +20,7 @@ cargoship restore jobs clean [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_restore_jobs_download.md
+++ b/docs/gen/cli/cargoship_restore_jobs_download.md
@@ -21,7 +21,7 @@ cargoship restore jobs download <job-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_restore_jobs_list.md
+++ b/docs/gen/cli/cargoship_restore_jobs_list.md
@@ -15,7 +15,7 @@ cargoship restore jobs list [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_resume.md
+++ b/docs/gen/cli/cargoship_resume.md
@@ -41,7 +41,7 @@ cargoship resume [upload-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_resume_clean.md
+++ b/docs/gen/cli/cargoship_resume_clean.md
@@ -39,7 +39,7 @@ cargoship resume clean [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_resume_list.md
+++ b/docs/gen/cli/cargoship_resume_list.md
@@ -29,7 +29,7 @@ cargoship resume list [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_scuttle.md
+++ b/docs/gen/cli/cargoship_scuttle.md
@@ -61,7 +61,7 @@ cargoship scuttle [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_setup.md
+++ b/docs/gen/cli/cargoship_setup.md
@@ -36,7 +36,7 @@ cargoship setup [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_shell.md
+++ b/docs/gen/cli/cargoship_shell.md
@@ -40,7 +40,7 @@ cargoship shell [S3_URL] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_sync.md
+++ b/docs/gen/cli/cargoship_sync.md
@@ -61,7 +61,7 @@ cargoship sync SOURCE_DIR S3_URL [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_upload.md
+++ b/docs/gen/cli/cargoship_upload.md
@@ -113,7 +113,7 @@ cargoship upload SOURCE_DIR DESTINATION [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/gen/cli/cargoship_verify.md
+++ b/docs/gen/cli/cargoship_verify.md
@@ -56,7 +56,7 @@ cargoship verify [s3://bucket/prefix/uploads/upload-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string        Override execution context (local, agent, repl)
+      --context string        Override execution context (local, repl)
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")

--- a/docs/guides/config/contexts.md
+++ b/docs/guides/config/contexts.md
@@ -1,29 +1,28 @@
 # Execution contexts
 
 A CargoShip **context** determines which commands are available and how the tool
-operates. Most users stay in `local` and never think about it; contexts matter
-when you run CargoShip as part of the [distributed setup](/enterprise/). The
-current context is cached in `~/.cargoship-context` and persists between
-sessions.
+operates. Most users stay in `local` and never think about it. The current
+context is cached in `~/.cargoship-context` and persists between sessions.
 
-## The three contexts
+## The two contexts
 
 | Context | Purpose |
 |---------|---------|
 | `local` | Local filesystem operations and archive creation (the default). |
-| `agent` | Distributed-agent monitoring and management. |
 | `repl` | Interactive shell mode with command discovery. |
 
-The `controller` context was removed in v0.20.0 along with the controller itself
-([#340](https://github.com/scttfrdmn/cargoship/issues/340)). If it is still
-cached in your `~/.cargoship-context`, run `cargoship context reset`.
+The `agent` context was removed along with the agent/controller runtime in
+v0.20.0 ([#340](https://github.com/scttfrdmn/cargoship/issues/340)); it filtered
+to commands that no longer exist. The `controller` context was removed at the
+same time. If either is still cached in your `~/.cargoship-context`, run
+`cargoship context reset`.
 
 ## Managing the context
 
 ```bash
 cargoship context                    # show current context
 cargoship context list               # list available contexts
-cargoship context switch agent       # switch and cache a new context
+cargoship context switch repl        # switch and cache a new context
 cargoship context show               # show current context with details
 cargoship context reset              # back to the default (local)
 ```
@@ -37,7 +36,7 @@ Use the global `--context` flag to override the cached context for one invocatio
 without changing the stored default:
 
 ```bash
-cargoship --context agent <command>
+cargoship --context repl <command>
 ```
 
 ## Automatic detection
@@ -46,17 +45,12 @@ When no context is cached, CargoShip infers one from environment variables:
 
 | Variable | Resulting context |
 |----------|-------------------|
-| `CARGOSHIP_AGENT_MODE` set | `agent` |
 | `CARGOSHIP_REPL_MODE` set | `repl` |
 | *(none set)* | `local` |
 
-This makes contexts work naturally inside agent deployments, where those
-variables are already present. See
-[Environment variables](/reference/environment-variables) for the full list.
+See [Environment variables](/reference/environment-variables) for the full list.
 
 ## See also
 
-- [Distributed / Enterprise overview](/enterprise/).
-- [ghost-ship](/enterprise/ghost-ship).
 - Reference: [Configuration & context commands](/reference/commands/config).
 - Reference: [Environment variables](/reference/environment-variables).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -61,8 +61,12 @@ Force the [execution context](/guides/config/contexts) instead of auto-detecting
 
 | Variable | Effect |
 |----------|--------|
-| `CARGOSHIP_AGENT_MODE` | Run as an agent. |
 | `CARGOSHIP_REPL_MODE` | Run in REPL context. |
+
+`CARGOSHIP_AGENT_MODE` was read here to select the `agent` context, which was
+removed with the agent/controller runtime in v0.20.0
+([#340](https://github.com/scttfrdmn/cargoship/issues/340)); nothing reads it
+now.
 
 ### Config-key variables (limited)
 

--- a/pkg/context/filter.go
+++ b/pkg/context/filter.go
@@ -61,9 +61,6 @@ func (cf *CommandFilter) GetContextDescription(ctx ExecutionContext) string {
 	case ContextLocal:
 		return "Full CargoShip functionality: archive creation, analysis, configuration, and infrastructure management"
 
-	case ContextAgent:
-		return "Agent operations: configuration management, monitoring, and status reporting"
-
 	case ContextREPL:
 		return "Interactive mode: all commands available with enhanced discovery and help"
 
@@ -100,10 +97,7 @@ func (cf *CommandFilter) getContextCommands(ctx ExecutionContext) map[string]boo
 			// Core archive operations
 			"create":   true,
 			"analyze":  true,
-			"find":     true,
-			"tree":     true,
 			"estimate": true,
-			"wizard":   true,
 
 			// File operations
 			"benchmark": true,
@@ -112,59 +106,30 @@ func (cf *CommandFilter) getContextCommands(ctx ExecutionContext) map[string]boo
 			"config":    true,
 			"lifecycle": true,
 			"metrics":   true,
-			"retier":    true,
 			"context":   true,
-
-			// Infrastructure (can be started from local)
-			"travelagent": true,
-			"shell":       true,
-
-			// Utilities and documentation
-			"schema": true,
-			"man":    true,
-			"mddocs": true,
-		}
-
-	case ContextAgent:
-		return map[string]bool{
-			// Agent-specific operations (future commands)
-			"agent": true, // Future: agent status, logs, config reload
-
-			// Configuration management
-			"config":  true,
-			"context": true,
-
-			// Monitoring
-			"metrics": true,
 
 			// Interactive mode
 			"shell": true,
 
-			// Documentation
-			"schema": true,
+			// Utilities and documentation
 			"man":    true,
+			"mddocs": true,
 		}
 
 	case ContextREPL:
 		// REPL mode provides access to all commands through interactive discovery
 		return map[string]bool{
-			"create":      true,
-			"analyze":     true,
-			"find":        true,
-			"tree":        true,
-			"estimate":    true,
-			"wizard":      true,
-			"benchmark":   true,
-			"config":      true,
-			"lifecycle":   true,
-			"metrics":     true,
-			"retier":      true,
-			"context":     true,
-			"travelagent": true,
-			"shell":       true,
-			"schema":      true,
-			"man":         true,
-			"mddocs":      true,
+			"create":    true,
+			"analyze":   true,
+			"estimate":  true,
+			"benchmark": true,
+			"config":    true,
+			"lifecycle": true,
+			"metrics":   true,
+			"context":   true,
+			"shell":     true,
+			"man":       true,
+			"mddocs":    true,
 		}
 
 	default:

--- a/pkg/context/integration.go
+++ b/pkg/context/integration.go
@@ -16,7 +16,7 @@ func EnhanceRootCommand(cmd *cobra.Command, logger *slog.Logger) {
 	cmd.Long = originalLong + "\n\n" + getContextHelpText()
 
 	// Add context flag for explicit context switching
-	cmd.PersistentFlags().String("context", "", "Override execution context (local, agent, repl)")
+	cmd.PersistentFlags().String("context", "", "Override execution context (local, repl)")
 
 	// Add pre-run hook to handle context
 	originalPreRun := cmd.PersistentPreRun
@@ -68,7 +68,6 @@ func getContextHelpText() string {
   
   Available contexts:
     local      - Local filesystem operations and archive creation
-    agent      - Launch agent monitoring and management
     repl       - Interactive shell mode with command discovery
   
   Use 'cargoship context' to view or change the current context.
@@ -81,7 +80,7 @@ func handleContextFlag(contextStr string, logger *slog.Logger) error {
 
 	// Validate context
 	if !isValidContext(targetContext) {
-		return fmt.Errorf("invalid context '%s'. Valid contexts: local, agent, repl", contextStr)
+		return fmt.Errorf("invalid context '%s'. Valid contexts: local, repl", contextStr)
 	}
 
 	manager := NewManager(logger)
@@ -119,62 +118,34 @@ func getAvailableCommands(ctx ExecutionContext) map[string]bool {
 			// Core local operations
 			"create":    true,
 			"analyze":   true,
-			"find":      true,
-			"tree":      true,
 			"estimate":  true,
-			"wizard":    true,
 			"benchmark": true,
 
 			// Management commands
 			"config":    true,
 			"lifecycle": true,
 			"metrics":   true,
-			"retier":    true,
 			"context":   true,
 
-			// Infrastructure (can start from local)
-			"travelagent": true,
-
 			// Utilities
-			"schema": true,
 			"man":    true,
 			"mddocs": true,
-		}
-
-	case ContextAgent:
-		return map[string]bool{
-			// Agent-specific operations
-			"agent":   true, // Future: agent status/management commands
-			"config":  true, // Config reload/view
-			"context": true,
-
-			// Monitoring and utilities
-			"metrics": true,
-			"schema":  true,
-			"man":     true,
 		}
 
 	case ContextREPL:
 		// REPL mode has access to all commands through interactive discovery
 		return map[string]bool{
-			"create":      true,
-			"analyze":     true,
-			"find":        true,
-			"tree":        true,
-			"estimate":    true,
-			"wizard":      true,
-			"benchmark":   true,
-			"config":      true,
-			"lifecycle":   true,
-			"metrics":     true,
-			"retier":      true,
-			"context":     true,
-			"travelagent": true,
-			"agent":       true,
-			"schema":      true,
-			"man":         true,
-			"mddocs":      true,
-			"shell":       true, // Future: REPL command
+			"create":    true,
+			"analyze":   true,
+			"estimate":  true,
+			"benchmark": true,
+			"config":    true,
+			"lifecycle": true,
+			"metrics":   true,
+			"context":   true,
+			"man":       true,
+			"mddocs":    true,
+			"shell":     true,
 		}
 
 	default:
@@ -196,8 +167,6 @@ func GetContextPrompt(logger *slog.Logger) string {
 	switch currentCtx {
 	case ContextLocal:
 		return "cargoship> "
-	case ContextAgent:
-		return "agent> "
 	case ContextREPL:
 		return "repl> "
 	default:
@@ -208,10 +177,6 @@ func GetContextPrompt(logger *slog.Logger) string {
 // DetectContextFromEnvironment attempts to detect context from environment variables
 func DetectContextFromEnvironment() ExecutionContext {
 	// Check for common environment variables that indicate context
-	if os.Getenv("CARGOSHIP_AGENT_MODE") != "" {
-		return ContextAgent
-	}
-
 	if os.Getenv("CARGOSHIP_REPL_MODE") != "" {
 		return ContextREPL
 	}

--- a/pkg/context/manager.go
+++ b/pkg/context/manager.go
@@ -17,7 +17,6 @@ type ExecutionContext string
 
 const (
 	ContextLocal ExecutionContext = "local" // Local filesystem operations
-	ContextAgent ExecutionContext = "agent" // Launch agent environment
 	ContextREPL  ExecutionContext = "repl"  // Interactive shell mode
 )
 
@@ -164,7 +163,9 @@ func (m *Manager) Current() ExecutionContext {
 	return ctx.Current
 }
 
-// SetEndpoint updates the connection endpoint for the agent context
+// SetEndpoint updates the connection endpoint for the current context.
+// No remaining context supports endpoints, so this always returns an error;
+// the method is retained for API stability.
 func (m *Manager) SetEndpoint(endpoint string) error {
 	if m.current == nil {
 		if _, err := m.Load(); err != nil {
@@ -172,28 +173,13 @@ func (m *Manager) SetEndpoint(endpoint string) error {
 		}
 	}
 
-	switch m.current.Current {
-	case ContextAgent:
-		m.current.AgentEndpoint = endpoint
-	default:
-		return fmt.Errorf("endpoints not applicable for context: %s", m.current.Current)
-	}
-
-	return m.Save()
+	return fmt.Errorf("endpoints not applicable for context: %s", m.current.Current)
 }
 
-// GetEndpoint returns the current endpoint for the agent context
+// GetEndpoint returns the current endpoint. No remaining context supports
+// endpoints, so this always returns an empty string.
 func (m *Manager) GetEndpoint() string {
-	if m.current == nil {
-		return ""
-	}
-
-	switch m.current.Current {
-	case ContextAgent:
-		return m.current.AgentEndpoint
-	default:
-		return ""
-	}
+	return ""
 }
 
 // IsFirstRun checks if this is the first time CargoShip is being run
@@ -243,7 +229,7 @@ func (m *Manager) createDefaultContext() (*ContextInfo, error) {
 // isValidContext validates if a context string is valid
 func isValidContext(ctx ExecutionContext) bool {
 	switch ctx {
-	case ContextLocal, ContextAgent, ContextREPL:
+	case ContextLocal, ContextREPL:
 		return true
 	default:
 		return false
@@ -254,7 +240,6 @@ func isValidContext(ctx ExecutionContext) bool {
 func GetAvailableContexts() []ExecutionContext {
 	return []ExecutionContext{
 		ContextLocal,
-		ContextAgent,
 		ContextREPL,
 	}
 }
@@ -264,8 +249,6 @@ func FormatContext(ctx ExecutionContext) string {
 	switch ctx {
 	case ContextLocal:
 		return "Local filesystem operations and archive creation"
-	case ContextAgent:
-		return "Launch agent monitoring and management"
 	case ContextREPL:
 		return "Interactive shell mode with command discovery"
 	default:

--- a/pkg/context/manager_test.go
+++ b/pkg/context/manager_test.go
@@ -60,21 +60,21 @@ func TestContextSwitching(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ContextLocal, ctx.Current)
 
-	// Switch to agent context
-	err = manager.SwitchTo(ContextAgent)
-	assert.NoError(t, err)
-	assert.Equal(t, ContextAgent, manager.Current())
-
 	// Switch to repl context
 	err = manager.SwitchTo(ContextREPL)
 	assert.NoError(t, err)
 	assert.Equal(t, ContextREPL, manager.Current())
 
+	// Switch back to local context
+	err = manager.SwitchTo(ContextLocal)
+	assert.NoError(t, err)
+	assert.Equal(t, ContextLocal, manager.Current())
+
 	// Invalid context should fail
 	err = manager.SwitchTo("invalid")
 	assert.Error(t, err)
-	// Should remain in repl context
-	assert.Equal(t, ContextREPL, manager.Current())
+	// Should remain in local context
+	assert.Equal(t, ContextLocal, manager.Current())
 }
 
 func TestContextPersistence(t *testing.T) {
@@ -87,7 +87,7 @@ func TestContextPersistence(t *testing.T) {
 	manager1 := NewManager(logger)
 	manager1.contextFile = contextFile
 
-	err := manager1.SwitchTo(ContextAgent)
+	err := manager1.SwitchTo(ContextREPL)
 	require.NoError(t, err)
 
 	// Create second manager (simulating new CLI invocation)
@@ -97,8 +97,8 @@ func TestContextPersistence(t *testing.T) {
 	// Should load the same context
 	ctx, err := manager2.Load()
 	require.NoError(t, err)
-	assert.Equal(t, ContextAgent, ctx.Current)
-	assert.Equal(t, ContextAgent, manager2.Current())
+	assert.Equal(t, ContextREPL, ctx.Current)
+	assert.Equal(t, ContextREPL, manager2.Current())
 }
 
 func TestEndpointManagement(t *testing.T) {
@@ -112,21 +112,15 @@ func TestEndpointManagement(t *testing.T) {
 	_, err := manager.Load()
 	require.NoError(t, err)
 
-	// Switch to agent context and set endpoint
-	err = manager.SwitchTo(ContextAgent)
-	require.NoError(t, err)
+	// No remaining context supports endpoints (the agent context that did was
+	// removed with the v0.20.0 controller runtime).
+	for _, ctx := range GetAvailableContexts() {
+		require.NoError(t, manager.SwitchTo(ctx))
 
-	err = manager.SetEndpoint("ws://agent.example.com:8080")
-	assert.NoError(t, err)
-	assert.Equal(t, "ws://agent.example.com:8080", manager.GetEndpoint())
-
-	// Local context shouldn't support endpoints
-	err = manager.SwitchTo(ContextLocal)
-	require.NoError(t, err)
-
-	err = manager.SetEndpoint("invalid")
-	assert.Error(t, err)
-	assert.Empty(t, manager.GetEndpoint())
+		err = manager.SetEndpoint("ws://agent.example.com:8080")
+		assert.Error(t, err, "endpoints must not be applicable for context %s", ctx)
+		assert.Empty(t, manager.GetEndpoint())
+	}
 }
 
 func TestContextValidation(t *testing.T) {
@@ -136,8 +130,8 @@ func TestContextValidation(t *testing.T) {
 		expected bool
 	}{
 		{"valid local", ContextLocal, true},
-		{"valid agent", ContextAgent, true},
 		{"valid repl", ContextREPL, true},
+		{"removed agent", "agent", false},
 		{"invalid empty", "", false},
 		{"invalid unknown", "unknown", false},
 	}
@@ -203,7 +197,7 @@ func TestReset(t *testing.T) {
 	manager.contextFile = filepath.Join(tempDir, ".cargoship-context")
 
 	// Create and switch context
-	err := manager.SwitchTo(ContextAgent)
+	err := manager.SwitchTo(ContextREPL)
 	require.NoError(t, err)
 
 	// Verify file exists
@@ -227,7 +221,6 @@ func TestGetAvailableContexts(t *testing.T) {
 
 	expected := []ExecutionContext{
 		ContextLocal,
-		ContextAgent,
 		ContextREPL,
 	}
 
@@ -240,7 +233,6 @@ func TestFormatContext(t *testing.T) {
 		expected string
 	}{
 		{ContextLocal, "Local filesystem operations and archive creation"},
-		{ContextAgent, "Launch agent monitoring and management"},
 		{ContextREPL, "Interactive shell mode with command discovery"},
 		{"unknown", "Unknown context"},
 	}

--- a/pkg/repl/shell.go
+++ b/pkg/repl/shell.go
@@ -105,8 +105,6 @@ func (s *Shell) getPrompt() string {
 	switch currentCtx {
 	case context.ContextLocal:
 		return "cargoship> "
-	case context.ContextAgent:
-		return "agent> "
 	case context.ContextREPL:
 		return "repl> "
 	default:
@@ -320,7 +318,7 @@ func (s *Shell) handleContextCommand(args []string) {
 	case "switch", "sw":
 		if len(args) < 2 {
 			fmt.Println("Usage: context switch <context>")
-			fmt.Println("Available contexts: local, agent, repl")
+			fmt.Println("Available contexts: local, repl")
 			return
 		}
 
@@ -372,27 +370,19 @@ func (s *Shell) getAvailableCommands(ctx context.ExecutionContext) map[string]bo
 	switch ctx {
 	case context.ContextLocal:
 		return map[string]bool{
-			"create": true, "analyze": true, "find": true, "tree": true,
-			"estimate": true, "wizard": true, "benchmark": true,
-			"config": true, "lifecycle": true, "metrics": true, "retier": true,
-			"context": true, "travelagent": true,
-			"schema": true, "man": true, "mddocs": true,
-		}
-
-	case context.ContextAgent:
-		return map[string]bool{
-			"config": true, "context": true, "metrics": true,
-			"schema": true, "man": true,
+			"create": true, "analyze": true, "estimate": true,
+			"benchmark": true, "config": true, "lifecycle": true,
+			"metrics": true, "context": true,
+			"man": true, "mddocs": true,
 		}
 
 	case context.ContextREPL:
 		// REPL has access to all commands
 		return map[string]bool{
-			"create": true, "analyze": true, "find": true, "tree": true,
-			"estimate": true, "wizard": true, "benchmark": true,
-			"config": true, "lifecycle": true, "metrics": true, "retier": true,
-			"context": true, "travelagent": true,
-			"schema": true, "man": true, "mddocs": true,
+			"create": true, "analyze": true, "estimate": true,
+			"benchmark": true, "config": true, "lifecycle": true,
+			"metrics": true, "context": true, "shell": true,
+			"man": true, "mddocs": true,
 		}
 
 	default:

--- a/pkg/repl/shell_test.go
+++ b/pkg/repl/shell_test.go
@@ -37,7 +37,6 @@ func TestGetPrompt(t *testing.T) {
 		expected string
 	}{
 		{context.ContextLocal, "cargoship> "},
-		{context.ContextAgent, "agent> "},
 		{context.ContextREPL, "repl> "},
 	}
 
@@ -152,7 +151,6 @@ func TestGetAvailableCommands(t *testing.T) {
 		hasConfig bool
 	}{
 		{context.ContextLocal, true, true},
-		{context.ContextAgent, false, true},
 		{context.ContextREPL, true, true},
 	}
 
@@ -176,4 +174,38 @@ func TestStop(t *testing.T) {
 	shell.Stop()
 
 	assert.False(t, shell.running)
+}
+
+// TestDisplayHelpers exercises the print-only display helpers to ensure they
+// run without panicking across the remaining contexts.
+func TestDisplayHelpers(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	rootCmd := &cobra.Command{Use: "test"}
+	sub := &cobra.Command{Use: "create", Short: "Create something"}
+	rootCmd.AddCommand(sub)
+	shell := NewShell(rootCmd, logger)
+
+	// Populate history so showHistory covers the loop body.
+	shell.addToHistory("create /tmp")
+
+	assert.NotPanics(t, func() {
+		shell.showWelcome()
+		shell.showGoodbye()
+		shell.clearScreen()
+		shell.showHistory()
+		shell.showCurrentContext()
+		shell.showAvailableContexts()
+	})
+
+	// createCommandInstance returns the wrapped root command.
+	assert.Equal(t, rootCmd, shell.createCommandInstance())
+
+	// handleContextCommand routes: no args -> current, "list" -> available,
+	// and an unknown subcommand falls through to current.
+	assert.NotPanics(t, func() {
+		shell.handleContextCommand(nil)
+		shell.handleContextCommand([]string{"list"})
+		shell.handleContextCommand([]string{"ls"})
+		shell.handleContextCommand([]string{"unknown"})
+	})
 }


### PR DESCRIPTION
## What & why

The agent/controller runtime was deleted in **v0.20.0** (#340), but the CLI's
execution-context surface still advertised an `agent` context. Switching to it
filtered the command set down to commands that no longer exist. Several context
command-maps also listed other removed/nonexistent commands. This makes the
context surface honest.

## Removed
- The `agent` execution context, end-to-end (const, all switch cases, help text,
  examples, tips, prompt, validation, `GetAvailableContexts`, `FormatContext`).
- `CARGOSHIP_AGENT_MODE` environment-based context detection.
- Dead command-map entries in every context map: `agent`, `travelagent`,
  `wizard`, `schema`, and the never-registered top-level names `find`, `tree`,
  `retier`.
- Endpoints are no longer applicable to any remaining context (`SetEndpoint`
  always errors, `GetEndpoint` always returns "").

## Fixed
- `local` context tips now reference real commands: `cargoship create upload`
  and `cargoship analyze` (dropped the removed `wizard` tip; the previous
  `create suitcase` command does not exist — the real subcommand is
  `create upload`).
- Global `--context` flag help corrected to `(local, repl)`.

## Kept
- The real `local` and `repl` contexts.

## Docs
- `docs/guides/config/contexts.md` and `docs/reference/environment-variables.md`
  rewritten to state the `agent` context / `CARGOSHIP_AGENT_MODE` were removed.
- Regenerated all 75 CLI doc fragments (`docs/gen/cli/`).

## Tests & verification
- `go build ./...`, `go vet`, `gofmt -l`, `staticcheck` all clean.
- `go test ./pkg/context/... ./pkg/repl/... ./cmd/cargoship/cmd/...` pass.
- `scripts/ci/check-no-theater.sh` green.
- Coverage: **pkg/context 40.1%** (floor 40), **pkg/repl 57.0%** (floor 41).
  Added a repl display-helper test to hold the ratio after removing dead code +
  its tests.