### PR TITLE
fix(s3): let a caller set Content-Encoding on uploaded objects (#353)

### DIFF
--- a/pkg/aws/s3/content_encoding_test.go
+++ b/pkg/aws/s3/content_encoding_test.go
@@ -1,0 +1,55 @@
+package s3
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+
+	awsconfig "github.com/scttfrdmn/cargoship/pkg/aws/config"
+)
+
+// TestTransporterContentEncoding is the #353 guard: an explicit
+// Archive.ContentEncoding becomes the object's HTTP Content-Encoding header, and
+// — crucially — CompressionType alone does NOT set it (that stays a private
+// x-amz-meta annotation), so CargoShip's own .tar.zst chunks are never stamped
+// with a header that would make HTTP clients auto-decompress them.
+func TestTransporterContentEncoding(t *testing.T) {
+	tr := &Transporter{config: awsconfig.S3Config{Bucket: "b"}}
+
+	// Explicit encoding → header set.
+	in := tr.putObjectInput(Archive{Key: "k", ContentEncoding: "zstd"}, types.StorageClassStandard)
+	if assert.NotNil(t, in.ContentEncoding, "explicit ContentEncoding must set the header") {
+		assert.Equal(t, "zstd", *in.ContentEncoding)
+	}
+
+	// CompressionType set but ContentEncoding empty → NO header (the bug #353 fixes),
+	// while the private compression annotation is still recorded in metadata.
+	in = tr.putObjectInput(Archive{Key: "k", CompressionType: "zstd"}, types.StorageClassStandard)
+	assert.Nil(t, in.ContentEncoding, "CompressionType must not leak into Content-Encoding")
+	assert.Equal(t, "zstd", in.Metadata["cargoship-compression-type"], "compression stays a private metadata annotation")
+}
+
+// TestOptimizedTransporterContentEncoding asserts the optimized path applies the
+// same #353 rule.
+func TestOptimizedTransporterContentEncoding(t *testing.T) {
+	tr := &OptimizedTransporter{config: awsconfig.S3Config{Bucket: "b"}}
+
+	in := tr.putObjectInput(&Archive{Key: "k", ContentEncoding: "gzip"})
+	if assert.NotNil(t, in.ContentEncoding) {
+		assert.Equal(t, "gzip", *in.ContentEncoding)
+	}
+
+	in = tr.putObjectInput(&Archive{Key: "k", CompressionType: "zstd"})
+	assert.Nil(t, in.ContentEncoding, "CompressionType must not leak into Content-Encoding")
+}
+
+// TestContentEncodingCargoShipChunksUnset documents the invariant that CargoShip's
+// own chunk archives (built by the pipeline) leave ContentEncoding empty, so the
+// header is never set on .tar.zst objects — the zero value guarantees it.
+func TestContentEncodingCargoShipChunksUnset(t *testing.T) {
+	var a Archive // as the pipeline builds it: ContentEncoding never assigned
+	assert.Empty(t, a.ContentEncoding)
+	assert.False(t, strings.Contains(a.ContentEncoding, "zstd"))
+}

--- a/pkg/aws/s3/optimized_transporter.go
+++ b/pkg/aws/s3/optimized_transporter.go
@@ -85,6 +85,33 @@ func NewOptimizedTransporter(ctx context.Context, s3Client *s3.Client, config aw
 	return transporter, nil
 }
 
+// putObjectInput builds the S3 PutObjectInput for an archive. Extracted from
+// Upload so the header mapping — notably the #353 Content-Encoding rule — is
+// unit-testable without a live S3 client.
+func (t *OptimizedTransporter) putObjectInput(archive *Archive) *s3.PutObjectInput {
+	input := &s3.PutObjectInput{
+		Bucket:       aws.String(t.config.Bucket),
+		Key:          aws.String(archive.Key),
+		Body:         archive.Reader,
+		StorageClass: types.StorageClass(archive.StorageClass),
+		Metadata:     archive.Metadata,
+	}
+
+	// #353: honor an explicit, caller-set Content-Encoding (empty for CargoShip's
+	// own chunks; see Archive.ContentEncoding) — CompressionType is NOT used here.
+	if archive.ContentEncoding != "" {
+		input.ContentEncoding = aws.String(archive.ContentEncoding)
+	}
+
+	// Add KMS encryption if configured
+	if t.config.KMSKeyID != "" {
+		input.ServerSideEncryption = types.ServerSideEncryptionAwsKms
+		input.SSEKMSKeyId = aws.String(t.config.KMSKeyID)
+	}
+
+	return input
+}
+
 // Upload performs an optimized CargoShip archive upload using manager.Uploader
 func (t *OptimizedTransporter) Upload(ctx context.Context, archive *Archive) (*UploadResult, error) {
 	if archive == nil {
@@ -100,20 +127,8 @@ func (t *OptimizedTransporter) Upload(ctx context.Context, archive *Archive) (*U
 		LastUpdated: time.Now(),
 	})
 
-	// Convert CargoShip archive to S3 input for manager.Uploader
-	input := &s3.PutObjectInput{
-		Bucket:       aws.String(t.config.Bucket),
-		Key:          aws.String(archive.Key),
-		Body:         archive.Reader,
-		StorageClass: types.StorageClass(archive.StorageClass),
-		Metadata:     archive.Metadata,
-	}
-
-	// Add KMS encryption if configured
-	if t.config.KMSKeyID != "" {
-		input.ServerSideEncryption = types.ServerSideEncryptionAwsKms
-		input.SSEKMSKeyId = aws.String(t.config.KMSKeyID)
-	}
+	// Convert CargoShip archive to S3 input (extracted for unit testing).
+	input := t.putObjectInput(archive)
 
 	// Use manager.Uploader which handles Content-Length automatically
 	result, err := t.uploader.Upload(ctx, input)

--- a/pkg/aws/s3/transporter.go
+++ b/pkg/aws/s3/transporter.go
@@ -38,6 +38,19 @@ type Archive struct {
 	CompressionType string                 // Compression algorithm used
 	AccessPattern   string                 // Expected access pattern
 	RetentionDays   int                    // Expected retention period
+
+	// ContentEncoding, when non-empty, is set as the object's HTTP
+	// `Content-Encoding` header (e.g. "zstd", "gzip") so a standards-conforming
+	// reader — aws s3 cp, boto3, a browser fetch — knows to decode the body
+	// (#353). It is an EXPLICIT signal a caller sets when it hands CargoShip a
+	// body it has already content-encoded; it is deliberately NOT derived from
+	// CompressionType. CargoShip's own chunk objects leave this empty on purpose:
+	// a .tar.zst chunk is addressed by its key extension and read as raw bytes
+	// (and, for format-2.1 random access, via byte-range GETs), so stamping
+	// Content-Encoding on it would make HTTP clients auto-decompress the whole
+	// object and break ranged reads. CompressionType remains a private
+	// x-amz-meta-* annotation, unchanged.
+	ContentEncoding string
 }
 
 // UploadResult contains the result of an S3 upload
@@ -75,6 +88,34 @@ func (t *Transporter) SetTracer(tracer *tracing.S3Tracer) {
 	t.tracer = tracer
 }
 
+// putObjectInput builds the S3 PutObjectInput for an archive. Extracted from
+// Upload so the header/metadata mapping — notably the #353 Content-Encoding
+// rule — is unit-testable without a live S3 client.
+func (t *Transporter) putObjectInput(archive Archive, storageClass types.StorageClass) *s3.PutObjectInput {
+	input := &s3.PutObjectInput{
+		Bucket:       aws.String(t.config.Bucket),
+		Key:          aws.String(archive.Key),
+		Body:         archive.Reader,
+		StorageClass: storageClass,
+		Metadata:     t.buildMetadata(archive),
+	}
+
+	// #353: set the HTTP Content-Encoding header when the caller pre-encoded the
+	// body, so standards-conforming readers decode it. Empty for CargoShip's own
+	// chunks (see Archive.ContentEncoding) — CompressionType is NOT used here.
+	if archive.ContentEncoding != "" {
+		input.ContentEncoding = aws.String(archive.ContentEncoding)
+	}
+
+	// Add KMS encryption if configured
+	if t.config.KMSKeyID != "" {
+		input.ServerSideEncryption = types.ServerSideEncryptionAwsKms
+		input.SSEKMSKeyId = aws.String(t.config.KMSKeyID)
+	}
+
+	return input
+}
+
 // Upload uploads an archive to S3 with intelligent storage class selection
 func (t *Transporter) Upload(ctx context.Context, archive Archive) (*UploadResult, error) {
 	startTime := time.Now()
@@ -93,20 +134,8 @@ func (t *Transporter) Upload(ctx context.Context, archive Archive) (*UploadResul
 		t.tracer.AddStorageClass(span, string(storageClass))
 	}
 
-	// Prepare upload input
-	input := &s3.PutObjectInput{
-		Bucket:       aws.String(t.config.Bucket),
-		Key:          aws.String(archive.Key),
-		Body:         archive.Reader,
-		StorageClass: storageClass,
-		Metadata:     t.buildMetadata(archive),
-	}
-
-	// Add KMS encryption if configured
-	if t.config.KMSKeyID != "" {
-		input.ServerSideEncryption = types.ServerSideEncryptionAwsKms
-		input.SSEKMSKeyId = aws.String(t.config.KMSKeyID)
-	}
+	// Prepare upload input (extracted for unit testing — see putObjectInput).
+	input := t.putObjectInput(archive, storageClass)
 
 	// Perform upload
 	result, err := t.uploader.Upload(ctx, input)


### PR DESCRIPTION
## Summary

Neither transporter set the HTTP `Content-Encoding` header, so an object whose body a caller had already compressed came back to a standards-conforming reader (`aws s3 cp`, boto3, a browser fetch) as **raw compressed bytes** — silent corruption for external consumers (ObjectFS hit exactly this). `CompressionType` was only ever a private `x-amz-meta-*` annotation, which no HTTP client keys decompression off.

## Fix
- New **explicit** `Archive.ContentEncoding` field, set as the object's `Content-Encoding` when non-empty, in both `Transporter` and `OptimizedTransporter`.
- Deliberately **not** derived from `CompressionType`: CargoShip's own `.tar.zst` chunks leave it empty and are addressed by key extension / read via byte-range GETs — stamping `Content-Encoding: zstd` on them would make HTTP clients auto-decompress whole objects and **break the format-2.1 ranged-frame reads** (#436/#439). `CompressionType` stays a private metadata annotation, unchanged.
- Extracted a testable `putObjectInput` seam in each transporter.

## Testing
Unit tests assert: the header is set when `ContentEncoding` is set; it is **not** set from `CompressionType` alone (the bug), while the compression annotation still lands in private metadata; and CargoShip's own chunk archives leave it empty by construction. `pkg/aws/s3` coverage 75.1% (floor 74).

Closes #353.