### PR TITLE
fix(manifest): record the true compressed chunk size, not the uncompressed estimate

### DIFF
--- a/pkg/pipeline/checksum_reader.go
+++ b/pkg/pipeline/checksum_reader.go
@@ -15,6 +15,7 @@ import (
 type hashingReadCloser struct {
 	rc     io.ReadCloser
 	hasher hash.Hash
+	n      int64 // total bytes read = the true compressed archive size (#353/CompressedSize)
 }
 
 // newHashingReadCloser wraps rc so that reads feed a SHA-256 hasher. Passing a
@@ -33,8 +34,16 @@ func (h *hashingReadCloser) Read(p []byte) (int, error) {
 	n, err := h.rc.Read(p)
 	if n > 0 {
 		_, _ = h.hasher.Write(p[:n])
+		h.n += int64(n)
 	}
 	return n, err
+}
+
+// BytesRead returns the total number of bytes read through the wrapper. Once the
+// stream is fully consumed (after upload), this is the object's true compressed
+// size — the exact byte count PUT to S3.
+func (h *hashingReadCloser) BytesRead() int64 {
+	return h.n
 }
 
 // Close closes the underlying stream.

--- a/pkg/pipeline/checksum_reader_test.go
+++ b/pkg/pipeline/checksum_reader_test.go
@@ -25,10 +25,27 @@ func TestHashingReadCloser_HashesStreamedBytes(t *testing.T) {
 	assert.NoError(t, h.Close())
 
 	assert.Equal(t, hex.EncodeToString(want[:]), h.Sum())
+	// BytesRead is the true compressed size — the exact bytes streamed to S3.
+	assert.Equal(t, int64(len(data)), h.BytesRead())
 }
 
 func TestHashingReadCloser_NilPassthrough(t *testing.T) {
 	assert.Nil(t, newHashingReadCloser(nil))
+}
+
+// TestJob_ArchiveCompressedSize verifies the accessor is 0 without a hasher and
+// the exact streamed byte count once one is attached and consumed (the value
+// that replaces the uncompressed-total estimate in ChunkEntry.CompressedSize).
+func TestJob_ArchiveCompressedSize(t *testing.T) {
+	j := &Job{}
+	assert.Equal(t, int64(0), j.ArchiveCompressedSize(), "no hasher => 0")
+
+	data := bytes.Repeat([]byte("z"), 4096)
+	j.archiveHasher = newHashingReadCloser(io.NopCloser(bytes.NewReader(data)))
+	j.Archive = j.archiveHasher
+	_, err := io.Copy(io.Discard, j.Archive)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(data)), j.ArchiveCompressedSize())
 }
 
 func TestHashingReadCloser_EmptyStream(t *testing.T) {

--- a/pkg/pipeline/s3_multiprefix_uploader.go
+++ b/pkg/pipeline/s3_multiprefix_uploader.go
@@ -412,6 +412,16 @@ func (s *S3MultiPrefixUploaderStage) processJob(ctx context.Context, job *Job, p
 				builder.AddFormatFeature(manifest.FormatFeatureFrames)
 			}
 
+			// The true compressed size is the exact byte count read off the
+			// upload stream by the hashing wrapper. ArchiveSize is only an
+			// uncompressed-total estimate, so it made CompressedSize wrong (and
+			// "space saved" report as 0%). Fall back to the estimate when the
+			// hasher wasn't wired (e.g. a code path that didn't wrap the stream).
+			compressedSize := job.ArchiveCompressedSize()
+			if compressedSize == 0 {
+				compressedSize = atomic.LoadInt64(&job.ArchiveSize)
+			}
+
 			// Add chunk entry (#271: record the SHA-256 of the uploaded archive)
 			builder.AddChunk(manifest.ChunkEntry{
 				ID:               job.Chunk.ID,
@@ -420,7 +430,7 @@ func (s *S3MultiPrefixUploaderStage) processJob(ctx context.Context, job *Job, p
 				FileCount:        len(job.Chunk.Files),
 				FilePaths:        filePaths,
 				UncompressedSize: job.Chunk.TotalSize,
-				CompressedSize:   atomic.LoadInt64(&job.ArchiveSize),
+				CompressedSize:   compressedSize,
 				CreatedAt:        job.StartTime,
 				UploadedAt:       job.EndTime,
 				Checksum:         job.ArchiveChecksum(),
@@ -433,7 +443,7 @@ func (s *S3MultiPrefixUploaderStage) processJob(ctx context.Context, job *Job, p
 				job.S3Key,
 				int64(len(job.Chunk.Files)),
 				job.Chunk.TotalSize,
-				atomic.LoadInt64(&job.ArchiveSize),
+				compressedSize,
 			)
 
 			s.pipeline.manifestMu.Unlock()

--- a/pkg/pipeline/torture_test.go
+++ b/pkg/pipeline/torture_test.go
@@ -141,6 +141,20 @@ func TestTorture(t *testing.T) {
 		for _, f := range m.Files {
 			require.Positive(t, f.ArchiveOffset, "file %s must have a recorded archive offset", f.Path)
 		}
+		// CompressedSize is now the true streamed byte count, not the uncompressed
+		// estimate — for this highly-compressible corpus it must be well under the
+		// uncompressed size, and equal the sum of the chunk's frame sizes.
+		for _, c := range m.Chunks {
+			require.Positive(t, c.CompressedSize)
+			require.Less(t, c.CompressedSize, c.UncompressedSize, "compressible chunk must record a real (smaller) compressed size")
+			if len(c.Frames) > 0 {
+				var framesTotal int64
+				for _, fr := range c.Frames {
+					framesTotal += fr.CompressedSize
+				}
+				require.Equal(t, c.CompressedSize, framesTotal, "chunk compressed size must equal the sum of its frame sizes")
+			}
+		}
 
 		// Single-file restore exercises the ranged frame fast path end-to-end.
 		region := tortureEnv("AWS_REGION", "us-east-1")

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -140,6 +140,16 @@ func (j *Job) ArchiveChecksum() string {
 	return j.archiveHasher.Sum()
 }
 
+// ArchiveCompressedSize returns the true compressed size of the uploaded archive
+// (the exact bytes PUT to S3), or 0 if the hashing wrapper wasn't wired. Call
+// only after upload completes. Unlike ArchiveSize, this is not an estimate.
+func (j *Job) ArchiveCompressedSize() int64 {
+	if j.archiveHasher == nil {
+		return 0
+	}
+	return j.archiveHasher.BytesRead()
+}
+
 // Stage represents a pipeline stage
 type Stage interface {
 	// Name returns the stage name for logging/metrics


### PR DESCRIPTION
## Summary

`ChunkEntry.CompressedSize` (and the shard rollup) stored `job.ArchiveSize` — the **uncompressed total**, an acknowledged estimate — so `cargoship info` reported "Compressed Size" equal to the original and "Space Saved" as ~0% even when zstd compressed the data heavily.

## Fix
The hashing wrapper that already reads the whole upload stream (for the archive SHA-256) now also **counts its bytes** — exactly the compressed size PUT to S3. Recorded via a new `Job.ArchiveCompressedSize()`, falling back to the estimate only when the wrapper wasn't wired. For a framed 2.1 chunk this equals the sum of the per-frame compressed sizes (write side and read side agree).

## Testing
- Unit: `hashingReadCloser.BytesRead` and `Job.ArchiveCompressedSize`.
- Torture (`frames_random_access`): asserts `CompressedSize < UncompressedSize` for compressible data **and** equals the sum of the chunk's frame sizes.
- Full torture + integration green; pipeline coverage 56.4% (floor 56).

This is the "CompressedSize accuracy" item selected for v0.24.0.