### PR TITLE
docs(project): capability verification matrix + CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Check no simulated/roadmap packages reach the CLI
         run: bash scripts/ci/check-no-dead-imports.sh
 
+      # Capability-verification guard: every evidence token in the capability
+      # matrix (docs/project/verification.md) must resolve to a real test/guard/
+      # command/report, and invocations of removed commands must not reappear in
+      # the user docs — so "does what it says" can't drift from its proof.
+      - name: Check capability matrix evidence resolves
+        run: bash scripts/ci/check-capabilities.sh
+
   e2e-quickstart:
     name: Quick Start E2E (emulator)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Full documentation lives at **[cargoship.app](https://cargoship.app)**.
 ### Project
 - [Architecture](https://cargoship.app/project/architecture) — system design
 - [Project Maturity & Compatibility](https://cargoship.app/project/maturity) — what's stable vs. beta
+- [Capability Verification](https://cargoship.app/project/verification) — every capability mapped to the evidence that proves it (CI-checked)
 - [Roadmap — removed & deferred capabilities](https://cargoship.app/project/roadmap) — candidate future work, not shipping features
 - [Comparison](https://cargoship.app/reference/comparison) — CargoShip vs. other tools
 - [Contributing](CONTRIBUTING.md) — how to get involved

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -183,6 +183,7 @@ const sidebar = {
       items: [
         { text: 'Architecture', link: '/project/architecture' },
         { text: 'Project maturity & compatibility', link: '/project/maturity' },
+        { text: 'Capability verification', link: '/project/verification' },
         { text: 'Roadmap (removed & deferred)', link: '/project/roadmap' },
         { text: 'Security model', link: '/project/security' },
         { text: 'Integrity model', link: '/project/integrity' },

--- a/docs/project/maturity.md
+++ b/docs/project/maturity.md
@@ -29,6 +29,10 @@ For capabilities that are **not** in CargoShip — those removed (some because t
 were non-functional or simulated) or deferred, and what a real version would
 take — see the [roadmap](/project/roadmap). Nothing there is a shipping feature.
 
+For the capabilities that *are* here, each is mapped to the evidence that proves
+it (and CI enforces those citations resolve) on the
+[capability verification](/project/verification) page.
+
 ## Component maturity
 
 | Capability | Status | What that means |

--- a/docs/project/verification.md
+++ b/docs/project/verification.md
@@ -1,0 +1,75 @@
+# Capability Verification
+
+Trust is CargoShip's first priority: the tool must do exactly what it says. This
+page is the machine-checked ledger of that promise — every user-facing capability
+mapped to the **evidence** that proves it, with an honest **status**. It is not
+marketing; a claim with no backing evidence does not belong here as "Verified."
+
+**Status legend**
+
+- **Verified** — proven by a test, guard, or the per-release real-AWS
+  verification report cited in the Evidence column. CI enforces that every cited
+  artifact actually exists (`scripts/ci/check-capabilities.sh`).
+- **Experimental** — present in the tree but not wired into the shipping CLI
+  (a guard keeps it off).
+- **Roadmap** — not built; see [the roadmap](/project/roadmap).
+- **Aspirational** — a stated goal we have **not yet measured**. Per the trust
+  priority, we do not advertise it as fact until evidence exists.
+
+**Evidence tokens** (checked by CI): `` `test:Name` `` a Go test that must exist;
+`` `make:target` `` a Makefile target; `` `script:path` `` a repo script;
+`` `cmd:name` `` a CLI command; `` `report` `` the per-release real-AWS
+[verification report](/project/verification-reports).
+
+## Integrity & correctness (priority 1: trust)
+
+| Capability | Status | Evidence |
+|---|---|---|
+| Byte-exact round-trip: upload → restore preserves bytes | Verified | `` `make:torture` ``, `` `report` ``, `` `test:TestArchiverStage_Process_NoTruncation` `` |
+| Single-file random access via the 2.1 frame index (one ranged GET) | Verified | `` `test:TestFrameIndexRandomAccess` ``, `` `test:TestSelectiveExtractorFrameRestore` ``, `` `make:torture` `` |
+| Data-level integrity check (`verify --deep`: chunk + file + frame) | Verified | `` `cmd:verify` ``, `` `test:TestDeepVerifyFrameIndex` `` |
+| Per-frame content integrity — a tampered ranged fetch is rejected before decode | Verified | `` `test:TestFrameChecksumCatchesTamperedRange` ``, `` `test:TestArchiverStage_Process_Frames` `` |
+| Open, portable format (2.1) readable with stdlib + zstd only | Verified | `` `test:TestIndependentReader` ``, `` `test:TestSchemaMatchesStructs` ``, `` `test:TestVersionFixturesParseAndValidate` `` |
+| True compressed size recorded in the manifest | Verified | `` `test:TestHashingReadCloser_HashesStreamedBytes` ``, `` `test:TestJob_ArchiveCompressedSize` `` |
+| Content-Encoding honored for caller-pre-encoded objects | Verified | `` `test:TestTransporterContentEncoding` `` |
+| KMS envelope encryption of the manifest | Verified | `` `test:TestEncryptDecryptLargeManifest` `` |
+| No advertised feature is theater; roadmap/simulated code stays off the CLI | Verified | `` `script:scripts/ci/check-no-theater.sh` ``, `` `script:scripts/ci/check-no-dead-imports.sh` `` |
+
+Releases are signed (cosign keyless) with SBOMs and a published per-release
+real-AWS verification report — see [Security](/project/security) and
+[verification reports](/project/verification-reports).
+
+## Throughput & scale (priority 2: performance)
+
+| Capability | Status | Evidence |
+|---|---|---|
+| Multi-prefix sharding (parallel prefixes) | Verified | `` `make:torture` ``, `` `test:TestAdaptiveShardCalculator_CalculateOptimalShardCount_Integration` `` |
+| Content-aware compression + Magika detection | Verified | `` `test:TestArchiverStage_AnalyzeChunkContentTypesWithMagika` `` |
+| Real congestion control (BBR/CUBIC) moves bytes intact | Verified | `` `make:torture` `` |
+| Resumable uploads (skip already-uploaded chunks) | Verified | `` `cmd:resume` ``, `` `test:TestNewResumePipelineConfig_EnablesResume` ``, `` `make:torture` `` |
+| Internal throughput benchmarks | Verified | `` `cmd:benchmark` `` |
+| **Fastest mover in class** — faster than `aws s3 cp`, `s5cmd`, `rclone` for the same data | **Aspirational** | **Not yet measured.** No head-to-head benchmark exists. Tracked as a v0.25.0 workstream (a comparative harness); until it lands, CargoShip does **not** claim to be the fastest. |
+
+## Cost efficiency (priority 3, tied to performance)
+
+| Capability | Status | Evidence |
+|---|---|---|
+| Cost estimation before upload | Verified | `` `cmd:estimate` ``, `` `test:TestAnalyzeBurnRate_IncreasingPattern` `` |
+| Budgets & volume quotas | Verified | `` `cmd:budget` ``, `` `test:TestAlertCooldownPeriod` `` |
+| Packing many files into archives → far fewer S3 requests | Verified | `` `make:torture` `` (the pipeline packs; round-trip proves it) |
+| **Most cost-efficient mover in class** — lowest total S3 cost to move + store the same data | **Aspirational** | **Not yet measured.** Needs the comparative harness to also count requests / bytes transferred / bytes stored → dollars. Until then, not claimed. |
+
+## Experimental / not shipping
+
+| Capability | Status | Evidence |
+|---|---|---|
+| Multi-region orchestration (`pkg/multiregion`) | Experimental | Off the CLI by design; `` `script:scripts/ci/check-no-dead-imports.sh` `` enforces it stays off until genuinely wired. See [the roadmap](/project/roadmap). |
+| Removed / deferred capabilities (agent+controller, web UI, autonomous archival, …) | Roadmap | [the roadmap](/project/roadmap) |
+
+---
+
+*Maintainers:* when you add a user-facing capability, add a row here with a real
+evidence token, or CI (`check-capabilities.sh`) will not fail — but the promise
+this page makes will be weaker. When you claim "fastest" or "most cost-efficient,"
+it must move from **Aspirational** to **Verified** with a comparative-benchmark
+citation, never before.

--- a/scripts/ci/check-capabilities.sh
+++ b/scripts/ci/check-capabilities.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Capability-verification guard (trust priority): every evidence token cited in
+# the capability matrix (docs/project/verification.md) must resolve to an
+# artifact that really exists — so a "Verified" claim can never drift from its
+# proof. Plus a surgical check that invocations of removed commands don't
+# reappear in the user-facing docs (the class of bug that left a dead `agent`
+# context documented after v0.20.0).
+#
+# Usage: scripts/ci/check-capabilities.sh
+# Exit 0 = every citation resolves and no removed-command invocations; 1 = drift.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+MATRIX="docs/project/verification.md"
+fail=0
+
+[ -f "$MATRIX" ] || { echo "::error::$MATRIX (capability matrix) not found"; exit 1; }
+
+# --- Check A: every evidence token resolves ----------------------------------
+# Tokens are backtick-wrapped: `test:Name`, `make:target`, `script:path`,
+# `cmd:name`, or `report`. Only parse table rows (lines starting with '|') so the
+# prose legend's placeholder examples aren't treated as real citations.
+mapfile -t tokens < <(grep '^|' "$MATRIX" | grep -oE '`(test|make|script|cmd):[^`]+`|`report`' | tr -d '`' | sort -u)
+
+if [ "${#tokens[@]}" -eq 0 ]; then
+  echo "::error file=$MATRIX::no evidence tokens found — the matrix must cite checkable evidence"
+  fail=1
+fi
+
+for tok in "${tokens[@]}"; do
+  kind="${tok%%:*}"
+  val="${tok#*:}"
+  case "$kind" in
+    test)
+      grep -rqE "func ${val}\b" --include='*_test.go' . \
+        || { echo "::error file=$MATRIX::evidence 'test:${val}' — no such test function"; fail=1; } ;;
+    make)
+      grep -qE "^${val}:" Makefile \
+        || { echo "::error file=$MATRIX::evidence 'make:${val}' — no such Makefile target"; fail=1; } ;;
+    script)
+      [ -f "${val}" ] \
+        || { echo "::error file=$MATRIX::evidence 'script:${val}' — file not found"; fail=1; } ;;
+    cmd)
+      grep -rqE "Use:[[:space:]]+\"${val}" cmd/ \
+        || { echo "::error file=$MATRIX::evidence 'cmd:${val}' — no such CLI command"; fail=1; } ;;
+    report)
+      grep -qE "Passed" docs/project/verification-reports.md 2>/dev/null \
+        || { echo "::error file=$MATRIX::evidence 'report' — no passed row in verification-reports.md"; fail=1; } ;;
+  esac
+done
+
+# --- Check B: removed-command invocations must not reappear in user docs ------
+# Surgical: only the direct-invocation form "cargoship [flags] <removed>" is
+# always wrong now. Prose that names these features historically lives in the
+# roadmap / maturity / this matrix and is excluded below.
+removed_cmds=(agent controller webui wizard travelagent schema launch-server)
+# Excluded: generated CLI docs, the build output, and the pages whose PURPOSE is
+# to document removed/deferred features honestly (roadmap, maturity, this matrix,
+# the verification-report log, and the enterprise migration note that tells users
+# the controller/webui/launch commands are gone).
+mapfile -t doc_files < <(git ls-files 'README.md' 'docs/**/*.md' \
+  | grep -vE '^docs/gen/|^docs/\.vitepress/dist/|^docs/project/roadmap\.md$|^docs/project/maturity\.md$|^docs/project/verification\.md$|^docs/project/verification-reports\.md$|^docs/enterprise/index\.md$')
+
+if [ "${#doc_files[@]}" -gt 0 ]; then
+  for c in "${removed_cmds[@]}"; do
+    hits="$(grep -rnE "cargoship( --?[a-z-]+)* ${c}\b" "${doc_files[@]}" 2>/dev/null || true)"
+    if [ -n "$hits" ]; then
+      echo "::error::invocation of removed command 'cargoship … ${c}' found in user docs:"
+      echo "$hits"
+      fail=1
+    fi
+  done
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "capability-verification: FAILED"
+  exit 1
+fi
+echo "capability-verification: OK (${#tokens[@]} evidence tokens resolve; no removed-command invocations in user docs)"


### PR DESCRIPTION
Builds the **Capability Verification Matrix + CI gate** (approved: "Matrix + CI gate"). For v0.25.0.

## What
- **`docs/project/verification.md`** — every user-facing capability → **status** → **evidence** (a test, guard, CLI command, or the per-release real-AWS report). Not marketing; a claim without backing evidence isn't listed as Verified.
- **`scripts/ci/check-capabilities.sh`** (wired into the Tests workflow beside the theater + reachability guards) enforces two things:
  - **A** — every evidence token cited in the matrix (`test:` / `make:` / `script:` / `cmd:` / `report`) resolves to an artifact that actually exists (no dangling citations). 27 tokens currently resolve.
  - **B** — invocations of removed commands (`agent`, `controller`, `webui`, `wizard`, `travelagent`, `schema`, `launch-server`) don't reappear in user docs — the exact class of bug that left a dead `agent` context documented after v0.20.0. (Honest migration/roadmap pages are excluded.)

## Honesty on performance & cost
Per the stated priorities (trust paramount; performance + cost close behind), the matrix records measured internals as **Verified**, but **"fastest / most cost-efficient in class"** is marked **Aspirational** — explicitly *not claimed* until a head-to-head speed+cost harness (vs `aws s3 cp` / `s5cmd` / `rclone`) measures it. That comparative harness is the natural next workstream.

Linked from the README, the maturity page, and the docs sidebar.