### PR TITLE
fix(restore): decode chunks by key extension, not top-level compression_type (#452, #453)

### DIFF
--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -737,6 +737,41 @@ func (se *SelectiveExtractor) downloadChunk(ctx context.Context, s3Key string) (
 	return data, nil
 }
 
+// chunkCompression returns the decompression a chunk needs. The chunk's S3 key
+// extension is authoritative when present — the per-chunk signal the format spec
+// documents (#452) — because the manifest's top-level compression_type is a
+// single value even when an upload produced both compressed (.tar.zst) and plain
+// (.tar) chunks, so decoding by it wraps a zstd reader around a plain tar and
+// restores nothing. When the key carries no recognized archive extension, fall
+// back to the manifest's declared type (the historical behavior).
+func chunkCompression(s3Key, manifestType string) string {
+	switch {
+	case strings.HasSuffix(s3Key, ".tar.zst"), strings.HasSuffix(s3Key, ".zst"):
+		return "zstd"
+	case strings.HasSuffix(s3Key, ".tar.gz"), strings.HasSuffix(s3Key, ".gz"):
+		return "gzip"
+	case strings.HasSuffix(s3Key, ".tar"):
+		return "none"
+	default: // no recognized extension → trust the manifest's declared type
+		switch manifestType {
+		case "gzip", "gz":
+			return "gzip"
+		case "none":
+			return "none"
+		default: // "zstd" or "" → zstd, matching the historical reader default
+			return "zstd"
+		}
+	}
+}
+
+// chunkKeyOf returns the S3 key shared by a group of files from the same chunk.
+func chunkKeyOf(files []*FileEntry) string {
+	if len(files) == 0 {
+		return ""
+	}
+	return files[0].S3Key
+}
+
 // downloadChunkRange fetches just the byte range [offset, offset+length) of the
 // S3 object at s3Key (format-2.1 random access, #436). partial reports whether
 // the server honored the Range (HTTP 206 with a Content-Range header); a backend
@@ -782,7 +817,7 @@ func findFrame(frames []FrameEntry, offset, size int64) *FrameEntry {
 // split-file part (which needs reassembly via the whole-chunk path), or a file
 // no single frame covers — so the caller falls back to the whole-chunk path.
 func (se *SelectiveExtractor) tryFrameRestore(ctx context.Context, entry *FileEntry, chunk *ChunkEntry, root *os.Root, destDir string, stats *RestoreStats) (handled bool) {
-	if se.manifest.CompressionType != "zstd" || chunk == nil || len(chunk.Frames) == 0 {
+	if chunk == nil || len(chunk.Frames) == 0 || chunkCompression(chunk.S3Key, se.manifest.CompressionType) != "zstd" {
 		return false
 	}
 	if entry.TotalParts > 1 {
@@ -891,7 +926,11 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 	r := bytes.NewReader(data)
 	var tarReader *tar.Reader
 
-	switch se.manifest.CompressionType {
+	// #452: decode by the chunk's KEY EXTENSION, not the manifest's top-level
+	// compression_type. A mixed-compressibility upload holds both .tar.zst and
+	// plain .tar chunks under a single "zstd" compression_type, so decoding by
+	// that field wraps a zstd reader around a plain tar and restores nothing.
+	switch chunkCompression(chunkKeyOf(files), se.manifest.CompressionType) {
 	case "zstd":
 		dec, err := zstd.NewReader(r)
 		if err != nil {
@@ -899,17 +938,15 @@ func (se *SelectiveExtractor) extractFromChunkData(data []byte, files []*FileEnt
 		}
 		defer dec.Close()
 		tarReader = tar.NewReader(dec)
-	case "gzip", "gz":
+	case "gzip":
 		gz, err := gzip.NewReader(r)
 		if err != nil {
 			return 0, 0, fmt.Errorf("gzip reader: %w", err)
 		}
 		defer func() { _ = gz.Close() }()
 		tarReader = tar.NewReader(gz)
-	case "none", "":
+	default: // "none" — a plain .tar chunk
 		tarReader = tar.NewReader(r)
-	default:
-		return 0, 0, fmt.Errorf("unsupported compression type %q", se.manifest.CompressionType)
 	}
 
 	var restored int

--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -585,26 +585,26 @@ func (dv *DeepVerifier) verifyChunkFiles(ctx context.Context, chunk *ChunkEntry,
 	}
 	body := bytes.NewReader(objectBytes)
 
+	// #452: decode by the chunk's key extension, not the manifest's top-level
+	// compression_type — a mixed upload holds both .tar.zst and plain .tar chunks.
 	var decompressed io.Reader
-	switch dv.manifest.CompressionType {
-	case "zstd", "":
+	switch chunkCompression(chunk.S3Key, dv.manifest.CompressionType) {
+	case "zstd":
 		dec, err := zstd.NewReader(body)
 		if err != nil {
 			return nil, fmt.Errorf("zstd reader: %w", err)
 		}
 		defer dec.Close()
 		decompressed = dec
-	case "gzip", "gz":
+	case "gzip":
 		gz, err := gzip.NewReader(body)
 		if err != nil {
 			return nil, fmt.Errorf("gzip reader: %w", err)
 		}
 		defer func() { _ = gz.Close() }()
 		decompressed = gz
-	case "none":
+	default: // "none" — a plain .tar chunk
 		decompressed = body
-	default:
-		return nil, fmt.Errorf("unsupported compression type: %s", dv.manifest.CompressionType)
 	}
 
 	var results []FileVerifyResult

--- a/pkg/manifest/mixed_compression_test.go
+++ b/pkg/manifest/mixed_compression_test.go
@@ -1,0 +1,66 @@
+package manifest
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChunkCompression pins the per-chunk decode signal: the key extension wins
+// when present (regardless of the manifest's top-level type), and only an
+// extensionless key falls back to the manifest type.
+func TestChunkCompression(t *testing.T) {
+	// Extension is authoritative even when the manifest says otherwise.
+	assert.Equal(t, "zstd", chunkCompression("x/chunk-0.tar.zst", "none"))
+	assert.Equal(t, "gzip", chunkCompression("x/chunk-0.tar.gz", "zstd"))
+	assert.Equal(t, "none", chunkCompression("x/chunk-0.tar", "zstd")) // the #452 case
+	// No recognized extension → fall back to the manifest's declared type.
+	assert.Equal(t, "zstd", chunkCompression("x/chunk-0", "zstd"))
+	assert.Equal(t, "zstd", chunkCompression("x/chunk-0", "")) // historical default
+	assert.Equal(t, "none", chunkCompression("x/chunk-0", "none"))
+}
+
+// TestRestoreDecodesPlainTarChunkInMixedUpload is the #452 regression guard: a
+// plain .tar chunk (incompressible content) must restore even when the manifest's
+// top-level compression_type is "zstd" — the mixed-upload case that made files in
+// plain chunks unrestorable because the reader decoded by that field instead of
+// the chunk's key extension.
+func TestRestoreDecodesPlainTarChunkInMixedUpload(t *testing.T) {
+	content := []byte("bytes that live in a plain, uncompressed .tar chunk\n")
+
+	// Build a plain tar chunk with stdlib — no zstd wrapper.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "data/x.bin", Mode: 0644, Size: int64(len(content))}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	key := "backups/uploads/mixed/shard-0/chunk-0.tar" // .tar — a plain chunk
+	m := &Manifest{
+		Version:         ManifestVersion,
+		Bucket:          "test-bucket",
+		CompressionType: "zstd", // mixed upload: the top-level field says zstd...
+		Chunks:          []ChunkEntry{{ID: 0, S3Key: key, FileCount: 1, FilePaths: []string{"data/x.bin"}}},
+		Files:           []FileEntry{{Path: "data/x.bin", Size: int64(len(content)), S3Key: key, ChunkID: 0}},
+	}
+
+	dl := &rangeDownloader{object: buf.Bytes(), honorRange: false} // whole-object GET
+	se := NewSelectiveExtractor(m, dl, 0).SetBucket("test-bucket")
+
+	dest := t.TempDir()
+	stats, err := se.BatchRestore(context.Background(), []string{"data/x.bin"}, dest)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.Restored, "plain .tar chunk must restore even when manifest.compression_type is zstd")
+	require.Zero(t, stats.Failed)
+
+	got, err := os.ReadFile(filepath.Join(dest, "data", "x.bin"))
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -192,8 +192,11 @@ func (v *Validator) validateShardConsistency(result *ValidationResult) {
 				fmt.Sprintf("Shard %d has no chunks", shard.ID))
 		}
 
-		// Check shard sizes are consistent
-		if shard.CompressedSize > shard.UncompressedSize {
+		// Check shard sizes are consistent. #453: a plain .tar chunk's stored
+		// (archive) size legitimately exceeds the raw file-byte sum by tar
+		// headers + 512-byte padding, so only flag a shard whose chunks are ALL
+		// compressed — otherwise this is expected, not "unusual".
+		if shard.CompressedSize > shard.UncompressedSize && !hasUncompressedChunk(shard.ChunkKeys, v.manifest.CompressionType) {
 			result.AddWarning(fmt.Sprintf("shard[%d].size", i),
 				"compressed <= uncompressed",
 				fmt.Sprintf("compressed=%d > uncompressed=%d", shard.CompressedSize, shard.UncompressedSize),
@@ -202,6 +205,18 @@ func (v *Validator) validateShardConsistency(result *ValidationResult) {
 	}
 
 	result.Checks["shard_consistency"] = valid
+}
+
+// hasUncompressedChunk reports whether any of the shard's chunks is a plain
+// (uncompressed) .tar, whose stored size legitimately exceeds its raw content
+// (#453). Used to suppress the shard-level compressed>uncompressed warning.
+func hasUncompressedChunk(chunkKeys []string, manifestType string) bool {
+	for _, k := range chunkKeys {
+		if chunkCompression(k, manifestType) == "none" {
+			return true
+		}
+	}
+	return false
 }
 
 // validateChunkConsistency validates chunk data consistency (Issue #91 - criterion 4)
@@ -256,8 +271,11 @@ func (v *Validator) validateChunkConsistency(result *ValidationResult) {
 				fmt.Sprintf("Chunk %d has no files", chunk.ID))
 		}
 
-		// Check chunk sizes are consistent
-		if chunk.CompressedSize > chunk.UncompressedSize {
+		// Check chunk sizes are consistent. #453: only a COMPRESSED chunk that is
+		// larger than its raw content is unusual; a plain .tar chunk exceeding it
+		// by tar headers + padding is expected (its stored size is the real
+		// archive size since #445), so don't flag it.
+		if chunkCompression(chunk.S3Key, v.manifest.CompressionType) != "none" && chunk.CompressedSize > chunk.UncompressedSize {
 			result.AddWarning(fmt.Sprintf("chunk[%d].size", i),
 				"compressed <= uncompressed",
 				fmt.Sprintf("compressed=%d > uncompressed=%d", chunk.CompressedSize, chunk.UncompressedSize),

--- a/pkg/pipeline/torture_test.go
+++ b/pkg/pipeline/torture_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -174,6 +175,40 @@ func TestTorture(t *testing.T) {
 		got, err := os.ReadFile(filepath.Join(outDir, corpus[0].relPath))
 		require.NoError(t, err)
 		require.Equal(t, corpus[0].sum, sha256hex(got), "single-file frame restore must be byte-identical")
+	})
+
+	// #452: a MIXED-compressibility corpus produces both .tar.zst and plain .tar
+	// chunks under one manifest compression_type. Every file must round-trip —
+	// the bug (decoding by the top-level field) left files in the plain .tar
+	// chunks unrestorable, which homogeneous corpora never exposed.
+	t.Run("mixed_compressibility", func(t *testing.T) {
+		src := t.TempDir()
+		// Compressible (.log) + already-compressed extensions (.zip, which the
+		// detector skips → plain .tar). Files ~6 MiB with a 4 MiB forced chunk
+		// size → each file is its own chunk, so the upload yields BOTH .tar.zst
+		// (the .log files, which also set the manifest's top-level type to zstd)
+		// and plain .tar chunks (the .zip files) — the #452 mixed case.
+		corpus := plantCompressibleFiles(t, src, []int{6 * 1024 * 1024, 6 * 1024 * 1024})
+		corpus = append(corpus, plantAlreadyCompressedFiles(t, src, rng, []int{6 * 1024 * 1024, 6 * 1024 * 1024})...)
+		// tortureRoundTrip restores ALL files and asserts byte-identity, so if the
+		// chunker produces a plain .tar chunk under a zstd manifest (the #452
+		// shape), a regression there fails here. The deterministic guarantee of
+		// the decode-by-extension fix lives in the manifest unit test
+		// (TestRestoreDecodesPlainTarChunkInMixedUpload); the chunker's exact
+		// chunk-kind split isn't controllable from here, so we log it, not assert.
+		m := tortureRoundTrip(t, corpus, src, func(pc *PipelineConfig) {
+			pc.ForceChunkSizeMB = 4
+		})
+		var zst, plain int
+		for _, c := range m.Chunks {
+			switch {
+			case strings.HasSuffix(c.S3Key, ".tar.zst"):
+				zst++
+			case strings.HasSuffix(c.S3Key, ".tar"):
+				plain++
+			}
+		}
+		t.Logf("mixed corpus chunk kinds: %d compressed (.tar.zst), %d plain (.tar)", zst, plain)
 	})
 
 	// #119: resume must skip chunks already uploaded and never corrupt the data.
@@ -390,6 +425,24 @@ func plantCompressibleFiles(t *testing.T, root string, sizes []int) []genFile {
 		for j := range content {
 			content[j] = pattern[j%len(pattern)]
 		}
+		require.NoError(t, os.WriteFile(abs, content, 0644))
+		out = append(out, genFile{relPath: base, base: base, sum: sha256hex(content), size: sz})
+	}
+	return out
+}
+
+// plantAlreadyCompressedFiles writes random-content files with a .zip extension,
+// which the compression detector treats as already-compressed → the archiver
+// writes them as a plain .tar chunk (no zstd). Used to exercise the mixed
+// .tar.zst + .tar case (#452).
+func plantAlreadyCompressedFiles(t *testing.T, root string, rng *rand.Rand, sizes []int) []genFile {
+	t.Helper()
+	out := make([]genFile, 0, len(sizes))
+	for i, sz := range sizes {
+		base := fmt.Sprintf("blob%02d.zip", i)
+		abs := filepath.Join(root, base)
+		content := make([]byte, sz)
+		_, _ = rng.Read(content)
 		require.NoError(t, os.WriteFile(abs, content, 0644))
 		out = append(out, genFile{relPath: base, base: base, sum: sha256hex(content), size: sz})
 	}


### PR DESCRIPTION
**Found dog-fooding a real `~/Downloads` backup** (mixed compressibility) — and verified end-to-end on real S3.

## #452 (high — data restorability)
A mixed upload produces both `.tar.zst` and plain `.tar` chunks under a single top-level `compression_type` (`"zstd"`). Restore and `verify --deep` chose the decoder from that field, so they wrapped a zstd reader around a plain `.tar` chunk and restored/verified **nothing** — files in any plain chunk of a mixed upload were unrecoverable (6 of 10 chunks in the real backup were plain `.tar`).

**Fix:** `chunkCompression(key, manifestType)` decides by the **key extension** when present (`.tar.zst`→zstd, `.tar`→raw — the authoritative per-chunk signal the format spec documents), falling back to the manifest type only for an extensionless key. Applied in `extractFromChunkData`, the frame fast-path guard, and `verifyChunkFiles`.

## #453
Since #445 records the *true* compressed size, a plain `.tar` chunk's stored size legitimately exceeds its raw file-byte sum (tar headers + padding). `verify` no longer flags "compressed size exceeds uncompressed" for uncompressed chunks/shards.

## Tests
- `TestChunkCompression` + `TestRestoreDecodesPlainTarChunkInMixedUpload` (deterministic).
- `mixed_compressibility` torture round-trip.
- **Real S3:** the previously-failing file (in `chunk-4.tar`) now restores byte-identical.

For v0.24.1. (A separate finding — duplicate chunk IDs in multi-prefix manifests — is filed separately.)