### PR TITLE
fix(verify): key chunks by (ShardID, ID), not ID alone — multi-shard uploads (#455)

### DIFF
--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -487,26 +487,34 @@ func (dv *DeepVerifier) VerifyFiles(ctx context.Context) (*FilesVerifyResult, er
 		result.TotalFiles++
 	}
 
-	// Group files by chunk so we download each chunk object once.
-	byChunk := make(map[int]bool)
+	// Group files by chunk so we download each chunk object once. #455: key by
+	// the (ShardID, ChunkID) composite, not ChunkID alone — chunk IDs are unique
+	// only within a shard, so an ID-keyed lookup collapses distinct chunks across
+	// shards and resolves the wrong object.
+	byChunk := make(map[chunkIdent]bool)
 	for _, f := range dv.manifest.Files {
 		if !f.IsDuplicate {
-			byChunk[f.ChunkID] = true
+			byChunk[chunkIdent{f.ShardID, f.ChunkID}] = true
 		}
 	}
-	chunkIDs := make([]int, 0, len(byChunk))
-	for id := range byChunk {
-		chunkIDs = append(chunkIDs, id)
+	idents := make([]chunkIdent, 0, len(byChunk))
+	for k := range byChunk {
+		idents = append(idents, k)
 	}
-	sort.Ints(chunkIDs)
+	sort.Slice(idents, func(i, j int) bool {
+		if idents[i].shard != idents[j].shard {
+			return idents[i].shard < idents[j].shard
+		}
+		return idents[i].id < idents[j].id
+	})
 
 	seen := make(map[fileKey]bool)
 
-	for _, chunkID := range chunkIDs {
+	for _, ident := range idents {
 		if err := ctx.Err(); err != nil {
 			return result, err
 		}
-		chunk := dv.chunkByID(chunkID)
+		chunk := dv.chunkByIdent(ident)
 		if chunk == nil {
 			continue
 		}
@@ -514,9 +522,9 @@ func (dv *DeepVerifier) VerifyFiles(ctx context.Context) (*FilesVerifyResult, er
 		if err != nil {
 			// Chunk object unreadable: every file in it is missing.
 			for _, f := range dv.manifest.Files {
-				if f.ChunkID == chunkID && !f.IsDuplicate {
+				if f.ShardID == ident.shard && f.ChunkID == ident.id && !f.IsDuplicate {
 					result.Files = append(result.Files, FileVerifyResult{
-						Path: f.Path, ChunkID: chunkID, Status: ChunkVerifyMissing,
+						Path: f.Path, ChunkID: f.ChunkID, Status: ChunkVerifyMissing,
 					})
 					result.Missing++
 				}
@@ -553,10 +561,16 @@ func (dv *DeepVerifier) VerifyFiles(ctx context.Context) (*FilesVerifyResult, er
 	return result, nil
 }
 
-// chunkByID returns the chunk with the given ID, or nil.
-func (dv *DeepVerifier) chunkByID(id int) *ChunkEntry {
+// chunkIdent is a chunk's unique identity: (ShardID, ID). Chunk IDs repeat
+// across shards in a multi-prefix upload, so ID alone is not unique (#455).
+type chunkIdent struct {
+	shard, id int
+}
+
+// chunkByIdent returns the chunk with the given (ShardID, ID), or nil.
+func (dv *DeepVerifier) chunkByIdent(ident chunkIdent) *ChunkEntry {
 	for i := range dv.manifest.Chunks {
-		if dv.manifest.Chunks[i].ID == id {
+		if dv.manifest.Chunks[i].ShardID == ident.shard && dv.manifest.Chunks[i].ID == ident.id {
 			return &dv.manifest.Chunks[i]
 		}
 	}

--- a/pkg/manifest/mixed_compression_test.go
+++ b/pkg/manifest/mixed_compression_test.go
@@ -26,6 +26,44 @@ func TestChunkCompression(t *testing.T) {
 	assert.Equal(t, "none", chunkCompression("x/chunk-0", "none"))
 }
 
+// TestVerifyFilesDuplicateChunkIDsAcrossShards is the #455 regression guard:
+// chunk IDs repeat across shards in a multi-prefix upload, so verify must key on
+// the (ShardID, ID) composite. Keying on ID alone collapsed distinct chunks —
+// verify hashed files against the wrong object and flagged a bogus duplicate.
+func TestVerifyFilesDuplicateChunkIDsAcrossShards(t *testing.T) {
+	a := []byte("bytes that live in shard 0's chunk 0")
+	b := []byte("different bytes in shard 1's chunk 0")
+	c0 := makeTarZst(t, map[string][]byte{"a.txt": a})
+	c1 := makeTarZst(t, map[string][]byte{"b.txt": b})
+	dl := &fakeDownloader{objects: map[string][]byte{
+		"shard-0/chunk-0.tar.zst": c0,
+		"shard-1/chunk-0.tar.zst": c1,
+	}}
+	m := &Manifest{
+		Version: ManifestVersion, Bucket: "bkt",
+		CompressionType: "zstd", ChecksumAlgorithm: ChecksumAlgorithmSHA256,
+		ShardCount: 2, TotalChunks: 2,
+		Chunks: []ChunkEntry{
+			{ID: 0, ShardID: 0, S3Key: "shard-0/chunk-0.tar.zst"},
+			{ID: 0, ShardID: 1, S3Key: "shard-1/chunk-0.tar.zst"}, // SAME id, different shard
+		},
+		Files: []FileEntry{
+			{Path: "a.txt", ChunkID: 0, ShardID: 0, S3Key: "shard-0/chunk-0.tar.zst", Checksum: sha256hex(a)},
+			{Path: "b.txt", ChunkID: 0, ShardID: 1, S3Key: "shard-1/chunk-0.tar.zst", Checksum: sha256hex(b)},
+		},
+	}
+
+	// The composite identity means these are NOT duplicates.
+	require.True(t, NewValidator(m).Validate().Checks["chunk_consistency"],
+		"distinct shards with the same chunk id must not be flagged as duplicates")
+
+	// Each file must verify against ITS OWN chunk, not the first chunk with id 0.
+	res, err := NewDeepVerifier(m, dl).VerifyFiles(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.OK, "both files should verify against their correct chunk")
+	assert.True(t, res.Passed())
+}
+
 // TestRestoreDecodesPlainTarChunkInMixedUpload is the #452 regression guard: a
 // plain .tar chunk (incompressible content) must restore even when the manifest's
 // top-level compression_type is "zstd" — the mixed-upload case that made files in

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -232,18 +232,21 @@ func (v *Validator) validateChunkConsistency(result *ValidationResult) {
 		valid = false
 	}
 
-	// Validate each chunk
-	chunkIDsSeen := make(map[int]bool)
+	// Validate each chunk. #455: chunk IDs are unique only WITHIN a shard, not
+	// across a multi-prefix upload — the identity is (ShardID, ID) (see
+	// chunkIdent). Keying the duplicate check on ID alone flagged every
+	// multi-shard manifest as having "duplicate" chunks. Key on the composite.
+	chunkIDsSeen := make(map[chunkIdent]bool)
 	for i, chunk := range v.manifest.Chunks {
-		// Check for duplicate chunk IDs
-		if chunkIDsSeen[chunk.ID] {
+		ident := chunkIdent{chunk.ShardID, chunk.ID}
+		if chunkIDsSeen[ident] {
 			result.AddError(fmt.Sprintf("chunk[%d].id", i),
 				"unique",
-				fmt.Sprintf("%d (duplicate)", chunk.ID),
-				fmt.Sprintf("Duplicate chunk ID %d", chunk.ID))
+				fmt.Sprintf("shard %d / id %d (duplicate)", chunk.ShardID, chunk.ID),
+				fmt.Sprintf("Duplicate chunk (shard %d, id %d)", chunk.ShardID, chunk.ID))
 			valid = false
 		}
-		chunkIDsSeen[chunk.ID] = true
+		chunkIDsSeen[ident] = true
 
 		// Check shard ID is valid
 		if chunk.ShardID < 0 || chunk.ShardID >= v.manifest.ShardCount {

--- a/pkg/manifest/validate_test.go
+++ b/pkg/manifest/validate_test.go
@@ -231,7 +231,11 @@ func TestValidator_ChunkCountMismatch(t *testing.T) {
 // TestValidator_DuplicateChunkID tests duplicate chunk detection (Issue #91)
 func TestValidator_DuplicateChunkID(t *testing.T) {
 	m := createValidManifest()
-	m.Chunks[1].ID = 0 // Duplicate ID
+	// #455: chunk identity is (ShardID, ID) — a duplicate means both match, since
+	// IDs legitimately repeat across shards. Make chunk[1] a true duplicate of
+	// chunk[0].
+	m.Chunks[1].ShardID = m.Chunks[0].ShardID
+	m.Chunks[1].ID = m.Chunks[0].ID
 	validator := NewValidator(m)
 
 	result := validator.Validate()


### PR DESCRIPTION
Found dog-fooding a real backup. Chunk IDs are unique only **within a shard**, so a multi-prefix upload writes duplicate `ChunkEntry.ID`s (a real manifest had ids `[0,0,0,1,1,2,3,4,5,6]` across 5 shards). Two verify consequences:

- `validate`'s `chunk_consistency` flagged every multi-shard manifest with bogus **"duplicate chunk ID"** errors (the check keyed on `ID` alone).
- `DeepVerifier` grouped and looked up chunks by `ID`, **collapsing distinct chunks across shards** and hashing files against the wrong object.

Both now key on the `(ShardID, ID)` composite (`chunkIdent`): the duplicate check, and `VerifyFiles`' grouping + `chunkByIdent` lookup. Restore was already safe (it groups by the unique S3Key, per #452).

Test: `TestVerifyFilesDuplicateChunkIDsAcrossShards` (two shards, same chunk id — each file verifies against its own chunk); the duplicate-detection test now asserts the composite identity.

For v0.24.1, alongside #454.