### PR TITLE
docs(verification): fill the v0.24.2 report row

### DIFF
--- a/docs/project/verification-reports.md
+++ b/docs/project/verification-reports.md
@@ -34,7 +34,7 @@ release assets to find the evidence.
 
 | Version | Date | Files | Bytes | Paths | Suites | Result | Report |
 |---------|------|-------|-------|-------|--------|--------|--------|
-| v0.24.2 | 2026-09-10 | — | — | direct, chunked | — | ⏳ Run in progress | (attached to the release by the real-AWS lane) |
+| v0.24.2 | 2026-09-10 | 20 | 61.01 MB | direct, chunked | 42 / 0 | ✅ Passed | [`v0.24.2-2026-09-10.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.24.2/v0.24.2-2026-09-10.md) |
 | v0.24.1 | 2026-09-10 | — | — | direct, chunked | — | ⚠️ Lane failed on CI infra ([#459](https://github.com/scttfrdmn/cargoship/issues/459)) | No report attached: the tagged real-AWS lane failed on the CloudWatch metrics tests (not the data path). Fixed in v0.24.2; data path verified via the emulator lane + a real-S3 dog-food. |
 | v0.24.0 | 2026-09-10 | — | — | direct, chunked | — | ⚠️ Lane failed on CI infra ([#459](https://github.com/scttfrdmn/cargoship/issues/459)) | No report attached: same CloudWatch CI issue as v0.24.1; resolved in v0.24.2. Data path verified separately. |
 | v0.23.0 | 2026-08-04 | 20 | 61.01 MB | direct, chunked | 43 / 0 | ✅ Passed | [`v0.23.0-2026-08-04.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.23.0/v0.23.0-2026-08-04.md) |


### PR DESCRIPTION
Step 6 of the release: the v0.24.2 tagged real-AWS lane passed and attached its report, so fill the row — **20 files / 61.01 MB / direct+chunked / 42 suites / 0 failures / ✅ Passed** (42 vs v0.23.0's 43 = the pkg/monitoring package the trust campaign deleted). The v0.24.0/v0.24.1 rows remain honestly marked as CI-infra failures (#459), resolved here.