### PR TITLE
fix(estimate): don't bill upload data transfer — S3 ingress is free (#451)

### DIFF
--- a/cmd/cargoship/cmd/estimate.go
+++ b/cmd/cargoship/cmd/estimate.go
@@ -312,8 +312,9 @@ func outputTable(estimate *costs.CostEstimate, parallelOpt *s3.PrefixOptimizatio
 		)
 	}
 
-	// Transfer costs
-	fmt.Printf("\n🌐 Data Transfer Cost: $%.2f (one-time)\n", estimate.TransferCosts.Standard)
+	// Transfer + request costs. #451: S3 data transfer IN is free, so upload
+	// incurs no transfer charge — the one-time upload cost is the PUT requests.
+	fmt.Printf("\n🌐 Upload Data Transfer: $%.2f (S3 ingress is free)\n", estimate.TransferCosts.Standard)
 	fmt.Printf("📋 Request Costs: $%.2f (one-time)\n", estimate.RequestCosts.Standard)
 
 	// Summary

--- a/pkg/aws/costs/calculator.go
+++ b/pkg/aws/costs/calculator.go
@@ -104,7 +104,12 @@ func (c *Calculator) EstimateArchives(ctx context.Context, archives []s3.Archive
 		config.StorageClassDeepArchive,
 	} {
 		storageCost := c.calculateStorageCost(ctx, estimate.TotalSizeGB, storageClass)
-		transferCost := c.calculateTransferCost(ctx, estimate.TotalSizeGB)
+		// #451: S3 data transfer IN (upload/ingress) is FREE — only storage,
+		// requests, and transfer OUT (egress/retrieval) are billed. The upload
+		// estimate must not charge for ingress; egress is modeled separately for
+		// the retrieval path (calculateRestoreCost). The one-time upload cost is
+		// the PUT request cost alone.
+		transferCost := 0.0
 		requestCost := c.calculateRequestCost(ctx, len(archives), storageClass)
 
 		switch storageClass {

--- a/pkg/aws/costs/calculator_test.go
+++ b/pkg/aws/costs/calculator_test.go
@@ -286,6 +286,16 @@ func TestEstimateArchives(t *testing.T) {
 		t.Error("TotalAnnualCost should be 12x TotalMonthlyCost")
 	}
 
+	// #451: S3 upload/ingress is free — the estimate must not bill transfer for
+	// the upload, and the one-time upload cost is the PUT request cost alone.
+	if estimate.TransferCosts.Total != 0 {
+		t.Errorf("Expected upload transfer cost = 0 (S3 ingress is free), got %v", estimate.TransferCosts.Total)
+	}
+	if estimate.TotalUploadCost != estimate.RequestCosts.Standard {
+		t.Errorf("Expected TotalUploadCost = RequestCosts.Standard (%v), got %v",
+			estimate.RequestCosts.Standard, estimate.TotalUploadCost)
+	}
+
 	// Timestamp should be recent
 	if time.Since(estimate.CalculatedAt) > time.Minute {
 		t.Error("CalculatedAt timestamp should be recent")


### PR DESCRIPTION
`cargoship estimate` charged a one-time "Data Transfer Cost" for the upload at the \$0.09/GB **egress** rate — but S3 data transfer **in (ingress) is free**. Only storage, requests, and transfer **out** (egress/retrieval) are billed. This overstated upload cost and undercut the cost-efficiency story.

**Fix:** `EstimateArchives` sets upload transfer to \$0 (matching the sibling migration estimator, which already zeroes it — `s3_analyzer.go:365`); the one-time upload cost is now the PUT request cost alone. `calculateTransferCost` is kept (it's the egress-rate helper for retrieval modeling, still unit-tested) — just no longer misapplied to uploads. Output relabels the line to "Upload Data Transfer: \$0.00 (S3 ingress is free)".

Regression test asserts `TransferCosts.Total == 0` and `TotalUploadCost == RequestCosts.Standard`.

Prerequisite for the comparative speed/cost harness (which reuses this cost engine). Closes #451.