### PR TITLE
feat(bench): Phase-1 CargoShip speed + cost benchmark harness

### DIFF
--- a/.coverage-baseline
+++ b/.coverage-baseline
@@ -33,6 +33,7 @@
 # no unit test could exercise), and Start() became testable once it no longer
 # waited on that dial.
 cmd/cargoship 60
+cmd/cargoship-bench 0
 cmd/cargoship-cost 57
 cmd/cargoship-test 0
 cmd/cargoship/cmd 22
@@ -46,8 +47,10 @@ pkg/aws/lifecycle 90
 pkg/aws/metrics 100
 pkg/aws/pricing 90
 pkg/aws/s3 74
+pkg/benchharness 18
 pkg/benchmarks 0
 pkg/chunking 82
+pkg/corpus 85
 pkg/compression 92
 pkg/config 92
 pkg/context 40
@@ -69,6 +72,7 @@ pkg/progress 99
 pkg/repl 41
 pkg/restore 76
 pkg/resume 41
+pkg/s3count 92
 pkg/s3optimization 58
 pkg/staging 81
 pkg/testutils 76

--- a/cmd/cargoship-bench/main.go
+++ b/cmd/cargoship-bench/main.go
@@ -1,0 +1,154 @@
+// Command cargoship-bench runs the Phase-1 (CargoShip-only) speed + cost
+// benchmark: for each reproducible corpus profile it uploads and restores through
+// the real pipeline, measuring throughput and the exact S3 request bill from a
+// counting middleware. Point it at real S3 (default credential chain) or at an
+// emulator/LocalStack via --endpoint.
+//
+// It writes objects under --prefix and does NOT delete them — clean the bucket
+// yourself afterward (see the real-AWS torture procedure in project docs).
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/scttfrdmn/cargoship/pkg/benchharness"
+	"github.com/scttfrdmn/cargoship/pkg/corpus"
+	"github.com/scttfrdmn/cargoship/pkg/s3count"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "cargoship-bench:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		profileName = flag.String("profile", "all", "corpus profile to run, or 'all'")
+		bucket      = flag.String("bucket", "", "S3 bucket (required)")
+		region      = flag.String("region", "us-east-1", "AWS region")
+		prefix      = flag.String("prefix", "", "S3 key prefix (default bench-<timestamp>)")
+		endpoint    = flag.String("endpoint", "", "S3 endpoint override (emulator/LocalStack); enables path-style")
+		asJSON      = flag.Bool("json", false, "emit JSON results")
+	)
+	flag.Parse()
+
+	if *bucket == "" {
+		return fmt.Errorf("--bucket is required")
+	}
+	pfx := *prefix
+	if pfx == "" {
+		pfx = fmt.Sprintf("bench-%d", time.Now().UnixNano())
+	}
+
+	profiles := corpus.Profiles()
+	if *profileName != "all" {
+		p, ok := corpus.ProfileByName(*profileName)
+		if !ok {
+			return fmt.Errorf("unknown profile %q (have: %s)", *profileName, profileNames())
+		}
+		profiles = []corpus.Profile{p}
+	}
+
+	ctx := context.Background()
+	results := make([]*benchharness.RunResult, 0, len(profiles))
+	for _, prof := range profiles {
+		client, counter, err := newInstrumentedClient(ctx, *region, *endpoint)
+		if err != nil {
+			return err
+		}
+		srcDir, err := os.MkdirTemp("", "cargoship-bench-src-")
+		if err != nil {
+			return err
+		}
+		restoreDir, err := os.MkdirTemp("", "cargoship-bench-restore-")
+		if err != nil {
+			return err
+		}
+		rr, err := benchharness.Run(ctx, benchharness.Options{
+			Profile: prof, Client: client, Counter: counter,
+			Bucket: *bucket, Prefix: fmt.Sprintf("%s/%s", pfx, prof.Name), Region: *region,
+			SrcDir: srcDir, RestoreDir: restoreDir,
+		})
+		_ = os.RemoveAll(srcDir)
+		_ = os.RemoveAll(restoreDir)
+		if err != nil {
+			return fmt.Errorf("profile %s: %w", prof.Name, err)
+		}
+		results = append(results, rr)
+		if !*asJSON {
+			printHuman(rr)
+		}
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+	fmt.Fprintf(os.Stderr, "\nobjects left under s3://%s/%s — remember to clean up the bucket.\n", *bucket, pfx)
+	return nil
+}
+
+func newInstrumentedClient(ctx context.Context, region, endpoint string) (*awss3.Client, *s3count.Counter, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return nil, nil, fmt.Errorf("load AWS config: %w", err)
+	}
+	counter := s3count.New()
+	counter.Instrument(&cfg)
+	var opts []func(*awss3.Options)
+	if endpoint != "" {
+		cfg.BaseEndpoint = aws.String(endpoint)
+		opts = append(opts, func(o *awss3.Options) { o.UsePathStyle = true })
+	}
+	return awss3.NewFromConfig(cfg, opts...), counter, nil
+}
+
+func printHuman(rr *benchharness.RunResult) {
+	ok := "✅"
+	if !rr.ByteIdentical {
+		ok = "❌ NOT byte-identical"
+	}
+	fmt.Printf("── %s %s\n", rr.Profile, ok)
+	fmt.Printf("   files=%d  source=%s  stored=%s  chunks=%d\n",
+		rr.Files, humanBytes(rr.SourceBytes), humanBytes(rr.StoredBytes), rr.Chunks)
+	fmt.Printf("   upload : %6.1f MB/s  %v\n", rr.Upload.MBPerSec, rr.Upload.OpCounts)
+	fmt.Printf("   restore: %6.1f MB/s  %v\n", rr.Restore.MBPerSec, rr.Restore.OpCounts)
+	fmt.Printf("   cost   : upload-requests $%.6f  storage $%.6f/mo  restore(req $%.6f + egress $%.6f)\n",
+		rr.Cost.UploadRequestsUSD, rr.Cost.MonthlyStorageUSD, rr.Cost.RestoreRequestsUSD, rr.Cost.RestoreEgressUSD)
+}
+
+func humanBytes(b int64) string {
+	const u = 1024
+	if b < u {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(u), 0
+	for n := b / u; n >= u; n /= u {
+		div *= u
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func profileNames() string {
+	s := ""
+	for i, p := range corpus.Profiles() {
+		if i > 0 {
+			s += ", "
+		}
+		s += p.Name
+	}
+	return s
+}

--- a/pkg/benchharness/harness.go
+++ b/pkg/benchharness/harness.go
@@ -1,0 +1,239 @@
+// Package benchharness runs a CargoShip upload+restore of a reproducible corpus
+// and measures its speed and full S3 cost from EXACT, middleware-counted requests
+// — the Phase-1 (CargoShip-only) benchmark. Competitor tools are a later phase.
+package benchharness
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/aws/pricingfallback"
+	"github.com/scttfrdmn/cargoship/pkg/corpus"
+	"github.com/scttfrdmn/cargoship/pkg/manifest"
+	"github.com/scttfrdmn/cargoship/pkg/pipeline"
+	"github.com/scttfrdmn/cargoship/pkg/s3count"
+)
+
+// Options configures one benchmark run.
+type Options struct {
+	Profile    corpus.Profile
+	Client     *awss3.Client    // MUST already be instrumented by Counter (see Run)
+	Counter    *s3count.Counter // the counter wired into Client
+	Bucket     string
+	Prefix     string // S3 key prefix for this run (isolates it)
+	Region     string
+	SrcDir     string // where to plant the corpus (caller owns cleanup)
+	RestoreDir string // where to restore (caller owns cleanup)
+}
+
+// Phase captures the speed + request counts of one leg (upload or restore).
+type Phase struct {
+	Duration time.Duration  `json:"duration_ms"`
+	Bytes    int64          `json:"bytes"`
+	MBPerSec float64        `json:"mb_per_sec"`
+	OpCounts map[string]int `json:"op_counts"`
+}
+
+// Cost is the modeled S3 bill (USD), from measured counts + stored bytes, at the
+// STANDARD storage class. Ingress is free (#451); storage is monthly.
+type Cost struct {
+	UploadRequestsUSD  float64 `json:"upload_requests_usd"`
+	MonthlyStorageUSD  float64 `json:"monthly_storage_usd"`
+	RestoreRequestsUSD float64 `json:"restore_requests_usd"`
+	RestoreEgressUSD   float64 `json:"restore_egress_usd"`
+}
+
+// RunResult is the full record for one profile.
+type RunResult struct {
+	Profile       string `json:"profile"`
+	Files         int    `json:"files"`
+	SourceBytes   int64  `json:"source_bytes"`
+	StoredBytes   int64  `json:"stored_bytes"` // sum of chunk CompressedSize (what S3 holds)
+	Chunks        int    `json:"chunks"`
+	Upload        Phase  `json:"upload"`
+	Restore       Phase  `json:"restore"`
+	Cost          Cost   `json:"cost"`
+	ByteIdentical bool   `json:"byte_identical"`
+}
+
+// Run plants the profile, uploads it with the instrumented client, restores it,
+// verifies byte-identity, and computes speed + cost. The caller builds Client
+// with opts.Counter.Instrument applied before NewFromConfig, and owns bucket
+// lifecycle + SrcDir/RestoreDir cleanup.
+func Run(ctx context.Context, opts Options) (*RunResult, error) {
+	files, err := opts.Profile.Plant(opts.SrcDir)
+	if err != nil {
+		return nil, fmt.Errorf("plant corpus: %w", err)
+	}
+	var srcBytes int64
+	for _, f := range files {
+		srcBytes += int64(f.Size)
+	}
+
+	uploadID := fmt.Sprintf("%d-bench", time.Now().UnixNano())
+	pc := &pipeline.PipelineConfig{
+		ScannerWorkers: 4, ArchiverWorkers: 4, UploaderWorkers: 4,
+		S3Bucket: opts.Bucket, S3Prefix: opts.Prefix, S3Region: opts.Region,
+		UseRealS3: true, S3Client: opts.Client, S3PartSize: 5 * 1024 * 1024,
+		EnableManifest: true, SourcePath: opts.SrcDir, UploadID: uploadID,
+		EnableMultiPrefix: true, ShardCount: 4, FileChecksums: true,
+	}
+
+	// --- Upload leg ---
+	opts.Counter.Reset()
+	p, err := pipeline.NewPipeline(pc)
+	if err != nil {
+		return nil, fmt.Errorf("new pipeline: %w", err)
+	}
+	upStart := time.Now()
+	res, err := p.Run(ctx, opts.SrcDir)
+	upDur := time.Since(upStart)
+	if err != nil {
+		return nil, fmt.Errorf("upload run: %w", err)
+	}
+	if !res.Success {
+		return nil, fmt.Errorf("upload did not succeed (%d failed jobs)", len(res.FailedJobs))
+	}
+	uploadCounts := opts.Counter.Counts()
+
+	// Fetch + parse the manifest (the source of truth for stored bytes/chunks).
+	manifestKey := fmt.Sprintf("%s/uploads/%s/manifest.json.gz", opts.Prefix, uploadID)
+	obj, err := opts.Client.GetObject(ctx, &awss3.GetObjectInput{Bucket: aws.String(opts.Bucket), Key: aws.String(manifestKey)})
+	if err != nil {
+		return nil, fmt.Errorf("get manifest: %w", err)
+	}
+	mBytes, err := io.ReadAll(obj.Body)
+	_ = obj.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+	m, err := manifest.FromJSONCompressed(mBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	var storedBytes int64
+	for _, c := range m.Chunks {
+		storedBytes += c.CompressedSize
+	}
+	if storedBytes == 0 { // direct-upload manifests have no chunks
+		storedBytes = res.TotalBytes
+	}
+
+	// --- Restore leg (whole corpus) ---
+	opts.Counter.Reset()
+	se := manifest.NewSelectiveExtractor(m, opts.Client, 0)
+	targets := make([]string, len(files))
+	for i, f := range files {
+		targets[i] = f.RelPath
+	}
+	rStart := time.Now()
+	stats, err := se.BatchRestore(ctx, targets, opts.RestoreDir)
+	rDur := time.Since(rStart)
+	if err != nil {
+		return nil, fmt.Errorf("restore: %w", err)
+	}
+	restoreCounts := opts.Counter.Counts()
+	if stats.Failed != 0 {
+		return nil, fmt.Errorf("restore had %d failures", stats.Failed)
+	}
+
+	byteIdentical, err := verifyByteIdentical(files, opts.RestoreDir)
+	if err != nil {
+		return nil, err
+	}
+
+	rr := &RunResult{
+		Profile:     opts.Profile.Name,
+		Files:       len(files),
+		SourceBytes: srcBytes,
+		StoredBytes: storedBytes,
+		Chunks:      len(m.Chunks),
+		Upload: Phase{
+			Duration: upDur, Bytes: res.TotalBytes,
+			MBPerSec: mbPerSec(res.TotalBytes, upDur), OpCounts: uploadCounts,
+		},
+		Restore: Phase{
+			Duration: rDur, Bytes: stats.Bytes,
+			MBPerSec: mbPerSec(stats.Bytes, rDur), OpCounts: restoreCounts,
+		},
+		ByteIdentical: byteIdentical,
+	}
+	rr.Cost = computeCost(storedBytes, stats.Bytes, uploadCounts, restoreCounts)
+	return rr, nil
+}
+
+func mbPerSec(bytes int64, d time.Duration) float64 {
+	if d <= 0 {
+		return 0
+	}
+	return (float64(bytes) / (1024 * 1024)) / d.Seconds()
+}
+
+// verifyByteIdentical confirms every planted file restored with its exact bytes
+// (matched by basename, as BatchRestore flattens to the dataset-relative path).
+func verifyByteIdentical(files []corpus.File, restoreDir string) (bool, error) {
+	idx, err := corpus.IndexByBase(restoreDir)
+	if err != nil {
+		return false, err
+	}
+	for _, f := range files {
+		path, ok := idx[f.Base]
+		if !ok {
+			return false, nil
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			return false, err
+		}
+		sum := sha256.Sum256(got)
+		if hex.EncodeToString(sum[:]) != f.Sum {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// requestTier maps an S3 operation name to the fallback pricing request type.
+func requestTier(op string) string {
+	switch op {
+	case "PutObject", "CreateMultipartUpload", "UploadPart", "CompleteMultipartUpload", "CopyObject":
+		return "PUT"
+	case "ListObjectsV2", "ListObjects", "ListMultipartUploads", "ListParts":
+		return "LIST"
+	case "GetObject", "HeadObject", "HeadBucket":
+		return "GET"
+	default: // DeleteObject, AbortMultipartUpload, unknown → free tier
+		return "DELETE"
+	}
+}
+
+// computeCost models the STANDARD-class S3 bill from measured counts + stored
+// bytes. Ingress (upload data transfer) is free (#451); storage is monthly;
+// restore includes GET-tier requests + egress ($0.09/GB).
+func computeCost(storedBytes, restoreBytes int64, upload, restore map[string]int) Cost {
+	const std = config.StorageClassStandard
+	reqUSD := func(counts map[string]int) float64 {
+		var usd float64
+		for op, n := range counts {
+			usd += (float64(n) / 1000.0) * pricingfallback.RequestPrice(requestTier(op), std)
+		}
+		return usd
+	}
+	storedGB := float64(storedBytes) / (1024 * 1024 * 1024)
+	restoreGB := float64(restoreBytes) / (1024 * 1024 * 1024)
+	return Cost{
+		UploadRequestsUSD:  reqUSD(upload),
+		MonthlyStorageUSD:  storedGB * pricingfallback.StoragePrice(std),
+		RestoreRequestsUSD: reqUSD(restore),
+		RestoreEgressUSD:   restoreGB * 0.09, // $0.09/GB egress
+	}
+}

--- a/pkg/benchharness/harness_integration_test.go
+++ b/pkg/benchharness/harness_integration_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package benchharness
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	substrate "github.com/scttfrdmn/substrate/emulator"
+
+	"github.com/scttfrdmn/cargoship/pkg/corpus"
+	"github.com/scttfrdmn/cargoship/pkg/s3count"
+)
+
+// TestHarnessRunOnEmulator drives the full plant→upload→restore→cost loop against
+// the in-process Substrate S3 emulator, validating that the harness measures real
+// request counts, restores byte-identically, and produces a cost breakdown.
+func TestHarnessRunOnEmulator(t *testing.T) {
+	url, cancel := launchSubstrate(t)
+	defer cancel()
+	const bucket = "cargoship-bench-test"
+	require.NoError(t, createSubstrateBucket(url, bucket))
+
+	counter := s3count.New()
+	cfg := aws.Config{
+		Region:       "us-east-1",
+		BaseEndpoint: aws.String(url),
+		Credentials:  credentials.NewStaticCredentialsProvider("test", "test", ""),
+	}
+	counter.Instrument(&cfg)
+	client := awss3.NewFromConfig(cfg, func(o *awss3.Options) { o.UsePathStyle = true })
+
+	prof, ok := corpus.ProfileByName("mixed")
+	require.True(t, ok)
+
+	rr, err := Run(context.Background(), Options{
+		Profile: prof, Client: client, Counter: counter,
+		Bucket: bucket, Prefix: fmt.Sprintf("bench-%d", time.Now().UnixNano()),
+		Region: "us-east-1", SrcDir: t.TempDir(), RestoreDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	assert.True(t, rr.ByteIdentical, "corpus must restore byte-identically")
+	assert.Equal(t, 4, rr.Files, "mixed profile has 4 files")
+	assert.Positive(t, rr.StoredBytes)
+	// Exact, middleware-counted upload requests: at least one object was PUT.
+	up := rr.Upload.OpCounts
+	assert.Positive(t, up["PutObject"]+up["CreateMultipartUpload"], "upload should issue PUT-tier requests: %v", up)
+	// Restore issued GET-tier requests.
+	assert.Positive(t, rr.Restore.OpCounts["GetObject"], "restore should issue GET requests: %v", rr.Restore.OpCounts)
+	// Cost is modeled (storage is non-zero for real stored bytes).
+	assert.Positive(t, rr.Cost.MonthlyStorageUSD)
+	t.Logf("mixed: %d files, stored=%d B, up=%.1f MB/s (%v), restore=%.1f MB/s, storage=$%.6f/mo",
+		rr.Files, rr.StoredBytes, rr.Upload.MBPerSec, up, rr.Restore.MBPerSec, rr.Cost.MonthlyStorageUSD)
+}
+
+// launchSubstrate starts an in-process Substrate S3 emulator (mirrors the
+// pipeline integration tests' bootstrap).
+func launchSubstrate(t *testing.T) (string, context.CancelFunc) {
+	t.Helper()
+	cfg := substrate.DefaultConfig()
+	cfg.Server.Address = "127.0.0.1:0"
+	cfg.EventStore.Enabled = false
+	cfg.Log.Level = "error"
+
+	state := substrate.NewMemoryStateManager()
+	tc := substrate.NewTimeController(time.Now())
+	registry := substrate.NewPluginRegistry()
+	logger := substrate.NewDefaultLogger(slog.LevelError, false)
+	store := substrate.NewEventStore(cfg.EventStore.ToEventStoreConfig(), substrate.WithTimeController(tc))
+	require.NoError(t, substrate.RegisterDefaultPlugins(context.Background(), registry, state, tc, logger, store, nil))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	srv := substrate.NewServer(*cfg, registry, store, state, tc, logger)
+	srvCtx, cancel := context.WithCancel(context.Background())
+	go func() { _ = srv.Serve(srvCtx, ln) }()
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if resp, pingErr := http.Get(baseURL + "/health"); pingErr == nil { //nolint:noctx
+			_ = resp.Body.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return baseURL, cancel
+}
+
+func createSubstrateBucket(baseURL, bucket string) error {
+	cfg := aws.Config{
+		Region:       "us-east-1",
+		BaseEndpoint: aws.String(baseURL),
+		Credentials:  credentials.NewStaticCredentialsProvider("test", "test", ""),
+	}
+	client := awss3.NewFromConfig(cfg, func(o *awss3.Options) { o.UsePathStyle = true })
+	_, err := client.CreateBucket(context.Background(), &awss3.CreateBucketInput{Bucket: aws.String(bucket)})
+	return err
+}

--- a/pkg/benchharness/harness_test.go
+++ b/pkg/benchharness/harness_test.go
@@ -1,0 +1,68 @@
+package benchharness
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/aws/pricingfallback"
+)
+
+func TestRequestTier(t *testing.T) {
+	cases := map[string]string{
+		"PutObject":               "PUT",
+		"CreateMultipartUpload":   "PUT",
+		"UploadPart":              "PUT",
+		"CompleteMultipartUpload": "PUT",
+		"CopyObject":              "PUT",
+		"ListObjectsV2":           "LIST",
+		"ListParts":               "LIST",
+		"GetObject":               "GET",
+		"HeadObject":              "GET",
+		"DeleteObject":            "DELETE",
+		"AbortMultipartUpload":    "DELETE",
+		"WhoKnows":                "DELETE",
+	}
+	for op, want := range cases {
+		assert.Equal(t, want, requestTier(op), "op %s", op)
+	}
+}
+
+func TestMBPerSec(t *testing.T) {
+	assert.Equal(t, 0.0, mbPerSec(1<<20, 0), "zero duration is guarded")
+	assert.Equal(t, 0.0, mbPerSec(1<<20, -time.Second), "negative duration is guarded")
+	// 10 MiB in 1s == 10 MB/s (MiB-based, matching the harness).
+	assert.InDelta(t, 10.0, mbPerSec(10*(1<<20), time.Second), 1e-9)
+}
+
+func TestComputeCost(t *testing.T) {
+	const std = config.StorageClassStandard
+	upload := map[string]int{"PutObject": 1, "CreateMultipartUpload": 1, "UploadPart": 5, "CompleteMultipartUpload": 1}
+	restore := map[string]int{"GetObject": 3}
+	const storedBytes = 25 * 1024 * 1024
+	const restoreBytes = 24 * 1024 * 1024
+
+	got := computeCost(storedBytes, restoreBytes, upload, restore)
+
+	// Upload requests: 8 PUT-tier ops, priced from the canonical fallback table.
+	wantUpload := (8.0 / 1000.0) * pricingfallback.RequestPrice("PUT", std)
+	assert.InDelta(t, wantUpload, got.UploadRequestsUSD, 1e-12)
+
+	// Restore requests: 3 GET-tier ops.
+	wantRestoreReq := (3.0 / 1000.0) * pricingfallback.RequestPrice("GET", std)
+	assert.InDelta(t, wantRestoreReq, got.RestoreRequestsUSD, 1e-12)
+
+	// Monthly storage from stored (compressed) bytes.
+	wantStorage := (float64(storedBytes) / (1024 * 1024 * 1024)) * pricingfallback.StoragePrice(std)
+	assert.InDelta(t, wantStorage, got.MonthlyStorageUSD, 1e-12)
+
+	// Egress at $0.09/GB.
+	wantEgress := (float64(restoreBytes) / (1024 * 1024 * 1024)) * 0.09
+	assert.InDelta(t, wantEgress, got.RestoreEgressUSD, 1e-12)
+
+	// #451: upload data transfer (ingress) is never billed — only requests appear.
+	assert.Positive(t, got.UploadRequestsUSD)
+	assert.Positive(t, got.MonthlyStorageUSD)
+}

--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -1,0 +1,190 @@
+// Package corpus generates reproducible synthetic file corpora for the
+// benchmark harness. The generators are byte-for-byte deterministic given a
+// fixed seed, so a published benchmark number can be re-produced and verified by
+// anyone. They mirror the adversarial corpora the pipeline torture/round-trip
+// tests use (hostile paths, tiny files, incompressible vs compressible, mixed
+// chunk kinds), lifted out of the test files into an importable package.
+package corpus
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+)
+
+// File records one planted file: its path relative to the corpus root, its
+// basename (unique across a corpus, so a basename-flattened restore round-trips),
+// its SHA-256 (hex) content hash, and its size in bytes.
+type File struct {
+	RelPath string
+	Base    string
+	Sum     string
+	Size    int
+}
+
+// sha256Hex returns the hex SHA-256 of b.
+func sha256Hex(b []byte) string {
+	s := sha256.Sum256(b)
+	return hex.EncodeToString(s[:])
+}
+
+// write plants one file with the given content, creating parent dirs, and
+// returns its File record.
+func write(root, rel string, content []byte) (File, error) {
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return File{}, fmt.Errorf("mkdir for %s: %w", rel, err)
+	}
+	if err := os.WriteFile(abs, content, 0o644); err != nil {
+		return File{}, fmt.Errorf("write %s: %w", rel, err)
+	}
+	return File{RelPath: rel, Base: filepath.Base(filepath.FromSlash(rel)), Sum: sha256Hex(content), Size: len(content)}, nil
+}
+
+// PlantHostile writes a deliberately awkward set of files (empty, one-byte,
+// unicode/space/dotfile names, deep nesting, compressible + incompressible) with
+// unique basenames. baseSize pads every file up to that floor so the average
+// clears the direct-upload threshold and steers toward the chunked path; 0 keeps
+// the tiny edge sizes (direct upload). Random content uses rng for determinism.
+func PlantHostile(root string, rng *rand.Rand, baseSize int) ([]File, error) {
+	specs := []struct {
+		rel  string
+		size int
+		mode string // "zero", "random", "compressible"
+	}{
+		{"empty.dat", 0, "zero"},
+		{"one-byte.dat", 1, "random"},
+		{"small.txt", 4096, "compressible"},
+		{"incompressible.bin", 512 * 1024, "random"},
+		{"large-compressible.log", 512 * 1024, "compressible"},
+		{"nested/a/b/c/deep.txt", 2048, "compressible"},
+		{"unicode/日本語/файл.dat", 1024, "random"},
+		{"has spaces/my file (1).txt", 512, "compressible"},
+		{"dir/.hidden", 256, "random"},
+		{"dir2/UPPER.DAT", 3000, "random"},
+	}
+	seen := map[string]bool{}
+	out := make([]File, 0, len(specs))
+	for _, s := range specs {
+		base := filepath.Base(filepath.FromSlash(s.rel))
+		if seen[base] {
+			return nil, fmt.Errorf("duplicate basename %q: corpus basenames must be unique", base)
+		}
+		seen[base] = true
+
+		size := s.size
+		if baseSize > size {
+			size = baseSize
+		}
+		content := make([]byte, size)
+		switch s.mode {
+		case "random":
+			_, _ = rng.Read(content)
+		case "compressible":
+			fillPattern(content, "cargoship-roundtrip-")
+		}
+		f, err := write(root, s.rel, content)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// PlantManyFiles writes n small random files (1–4096 bytes) with unique
+// basenames spread across subdirectories so no single directory is enormous.
+func PlantManyFiles(root string, rng *rand.Rand, n int) ([]File, error) {
+	out := make([]File, 0, n)
+	for i := 0; i < n; i++ {
+		rel := filepath.Join(fmt.Sprintf("d%03d", i/500), fmt.Sprintf("f%06d.dat", i))
+		content := make([]byte, 1+rng.Intn(4096))
+		_, _ = rng.Read(content)
+		f, err := write(root, rel, content)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// PlantSized writes one incompressible (random) file per requested size, with
+// unique basenames. Size 0 yields an empty file.
+func PlantSized(root string, rng *rand.Rand, sizes []int) ([]File, error) {
+	out := make([]File, 0, len(sizes))
+	for i, sz := range sizes {
+		content := make([]byte, sz)
+		_, _ = rng.Read(content)
+		f, err := write(root, fmt.Sprintf("sized%02d.bin", i), content)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// PlantCompressible writes highly-compressible patterned .log files (steers the
+// zstd/frames path). Content is a deterministic repeating pattern per index, so
+// no rng is needed — fully reproducible.
+func PlantCompressible(root string, sizes []int) ([]File, error) {
+	out := make([]File, 0, len(sizes))
+	for i, sz := range sizes {
+		content := make([]byte, sz)
+		fillPattern(content, fmt.Sprintf("cargoship benchmark line %02d — the quick brown fox\n", i))
+		f, err := write(root, fmt.Sprintf("text%02d.log", i), content)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// PlantAlreadyCompressed writes random-content .zip files, which the compression
+// detector treats as already-compressed → the archiver writes them as plain
+// .tar chunks. Combined with PlantCompressible this yields both chunk kinds.
+func PlantAlreadyCompressed(root string, rng *rand.Rand, sizes []int) ([]File, error) {
+	out := make([]File, 0, len(sizes))
+	for i, sz := range sizes {
+		content := make([]byte, sz)
+		_, _ = rng.Read(content)
+		f, err := write(root, fmt.Sprintf("blob%02d.zip", i), content)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// fillPattern fills dst with a repeating ASCII pattern (deterministic).
+func fillPattern(dst []byte, pattern string) {
+	p := []byte(pattern)
+	for i := range dst {
+		dst[i] = p[i%len(p)]
+	}
+}
+
+// IndexByBase walks dir and maps each regular file's basename to its full path
+// (basenames are unique within a corpus).
+func IndexByBase(dir string) (map[string]string, error) {
+	out := map[string]string{}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			out[filepath.Base(path)] = path
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -10,7 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"math/rand"
+	"math/rand" // nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- non-crypto: reproducible synthetic corpus content, seeded for determinism
 	"os"
 	"path/filepath"
 )

--- a/pkg/corpus/corpus_test.go
+++ b/pkg/corpus/corpus_test.go
@@ -1,0 +1,68 @@
+package corpus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProfilesReproducible is the core guarantee: planting a profile twice
+// yields byte-identical content (same set of relpath→sha256), so a published
+// benchmark number can be independently reproduced.
+func TestProfilesReproducible(t *testing.T) {
+	for _, p := range Profiles() {
+		t.Run(p.Name, func(t *testing.T) {
+			a, err := p.Plant(t.TempDir())
+			require.NoError(t, err)
+			b, err := p.Plant(t.TempDir())
+			require.NoError(t, err)
+			require.NotEmpty(t, a)
+
+			sums := func(fs []File) map[string]string {
+				m := make(map[string]string, len(fs))
+				for _, f := range fs {
+					m[f.RelPath] = f.Sum
+				}
+				return m
+			}
+			assert.Equal(t, sums(a), sums(b), "profile %s must be byte-reproducible", p.Name)
+
+			// Basenames must be unique (basename-flattened restore).
+			bases := map[string]bool{}
+			for _, f := range a {
+				assert.False(t, bases[f.Base], "duplicate basename %q in profile %s", f.Base, p.Name)
+				bases[f.Base] = true
+			}
+		})
+	}
+}
+
+// TestPlantedFilesExistOnDisk confirms the records match what's written.
+func TestPlantedFilesExistOnDisk(t *testing.T) {
+	p, ok := ProfileByName("mixed")
+	require.True(t, ok)
+	root := t.TempDir()
+	files, err := p.Plant(root)
+	require.NoError(t, err)
+
+	idx, err := IndexByBase(root)
+	require.NoError(t, err)
+	for _, f := range files {
+		path, found := idx[f.Base]
+		require.True(t, found, "planted file %s missing from disk", f.Base)
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, int64(f.Size), info.Size(), "size mismatch for %s", f.Base)
+	}
+	assert.Equal(t, len(files), len(idx))
+	_ = filepath.Separator
+}
+
+// TestProfileByNameUnknown returns not-found for an unknown profile.
+func TestProfileByNameUnknown(t *testing.T) {
+	_, ok := ProfileByName("does-not-exist")
+	assert.False(t, ok)
+}

--- a/pkg/corpus/profiles.go
+++ b/pkg/corpus/profiles.go
@@ -1,6 +1,6 @@
 package corpus
 
-import "math/rand"
+import "math/rand" // nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- non-crypto: reproducible synthetic corpus content, seeded for determinism
 
 // Profile is a named, reproducible corpus. Plant writes it under root and
 // returns the planted files. Each profile seeds its own RNG from a fixed seed,

--- a/pkg/corpus/profiles.go
+++ b/pkg/corpus/profiles.go
@@ -1,0 +1,69 @@
+package corpus
+
+import "math/rand"
+
+// Profile is a named, reproducible corpus. Plant writes it under root and
+// returns the planted files. Each profile seeds its own RNG from a fixed seed,
+// so the same profile yields byte-identical content on every run and machine —
+// the property that lets a published benchmark number be independently verified.
+type Profile struct {
+	Name string
+	Desc string
+	// seed is the fixed RNG seed for this profile's random content.
+	seed int64
+	gen  func(root string, rng *rand.Rand) ([]File, error)
+}
+
+// Plant writes the profile under root with a freshly-seeded RNG.
+func (p Profile) Plant(root string) ([]File, error) {
+	return p.gen(root, rand.New(rand.NewSource(p.seed))) //nolint:gosec // deterministic corpus, not crypto
+}
+
+// Profiles returns the standard benchmark corpora, each reproducible.
+//
+//   - many-tiny:  request-count / small-object overhead (CargoShip's packing edge)
+//   - few-large:  multipart uploads (large, incompressible)
+//   - mixed:      both compressed (.tar.zst) and plain (.tar) chunks in one upload
+//   - hostile:    awkward names/sizes/nesting, tiny edge cases (direct-upload path)
+func Profiles() []Profile {
+	return []Profile{
+		{
+			Name: "many-tiny", Desc: "5000 small random files across subdirs", seed: 0x746E79,
+			gen: func(root string, rng *rand.Rand) ([]File, error) { return PlantManyFiles(root, rng, 5000) },
+		},
+		{
+			Name: "few-large", Desc: "large incompressible files (multipart)", seed: 0x6C617267,
+			gen: func(root string, rng *rand.Rand) ([]File, error) {
+				return PlantSized(root, rng, []int{12 << 20, 8 << 20, 20 << 20, 6 << 20})
+			},
+		},
+		{
+			Name: "mixed", Desc: "compressible + already-compressed → both chunk kinds", seed: 0x6D697865,
+			gen: func(root string, rng *rand.Rand) ([]File, error) {
+				comp, err := PlantCompressible(root, []int{6 << 20, 6 << 20})
+				if err != nil {
+					return nil, err
+				}
+				blob, err := PlantAlreadyCompressed(root, rng, []int{6 << 20, 6 << 20})
+				if err != nil {
+					return nil, err
+				}
+				return append(comp, blob...), nil
+			},
+		},
+		{
+			Name: "hostile", Desc: "awkward names/sizes/nesting, tiny edge cases", seed: 0x686F7374,
+			gen: func(root string, rng *rand.Rand) ([]File, error) { return PlantHostile(root, rng, 0) },
+		},
+	}
+}
+
+// ProfileByName returns the named profile and whether it exists.
+func ProfileByName(name string) (Profile, bool) {
+	for _, p := range Profiles() {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return Profile{}, false
+}

--- a/pkg/s3count/counter.go
+++ b/pkg/s3count/counter.go
@@ -1,0 +1,96 @@
+// Package s3count counts the S3 API operations an aws-sdk-go-v2 client issues,
+// via a smithy middleware. The benchmark harness uses it to attribute exact
+// request counts (PutObject, CreateMultipartUpload, UploadPart, GetObject,
+// ListObjectsV2, HeadObject, …) to an upload or restore, so the S3 request bill
+// can be computed from measured — not estimated — counts.
+package s3count
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/smithy-go/middleware"
+)
+
+// Counter tallies S3 operations by name. Safe for concurrent use (the pipeline
+// uploads from many goroutines).
+type Counter struct {
+	mu  sync.Mutex
+	ops map[string]int
+}
+
+// New returns an empty Counter.
+func New() *Counter {
+	return &Counter{ops: make(map[string]int)}
+}
+
+func (c *Counter) inc(op string) {
+	if op == "" {
+		op = "Unknown"
+	}
+	c.mu.Lock()
+	c.ops[op]++
+	c.mu.Unlock()
+}
+
+// Counts returns a copy of the per-operation tallies.
+func (c *Counter) Counts() map[string]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]int, len(c.ops))
+	for k, v := range c.ops {
+		out[k] = v
+	}
+	return out
+}
+
+// Total returns the sum of all operation counts.
+func (c *Counter) Total() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, v := range c.ops {
+		n += v
+	}
+	return n
+}
+
+// Names returns the operation names seen, sorted (stable output).
+func (c *Counter) Names() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	names := make([]string, 0, len(c.ops))
+	for k := range c.ops {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Reset clears the tallies (to measure a distinct phase, e.g. restore after
+// upload, with the same client).
+func (c *Counter) Reset() {
+	c.mu.Lock()
+	c.ops = make(map[string]int)
+	c.mu.Unlock()
+}
+
+// Instrument appends a counting middleware to cfg.APIOptions. It increments once
+// per logical operation (in the Initialize step, above the retry loop), so
+// multipart uploads count each CreateMultipartUpload / UploadPart /
+// CompleteMultipartUpload separately, and SDK retries of a single operation are
+// not double-counted. Apply before constructing the s3.Client from cfg.
+func (c *Counter) Instrument(cfg *aws.Config) {
+	cfg.APIOptions = append(cfg.APIOptions, func(stack *middleware.Stack) error {
+		return stack.Initialize.Add(
+			middleware.InitializeMiddlewareFunc("cargoship-s3count",
+				func(ctx context.Context, in middleware.InitializeInput, next middleware.InitializeHandler) (middleware.InitializeOutput, middleware.Metadata, error) {
+					c.inc(middleware.GetOperationName(ctx))
+					return next.HandleInitialize(ctx, in)
+				}),
+			middleware.Before,
+		)
+	})
+}

--- a/pkg/s3count/counter_test.go
+++ b/pkg/s3count/counter_test.go
@@ -1,0 +1,53 @@
+package s3count
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCounterMechanics(t *testing.T) {
+	c := New()
+	assert.Equal(t, 0, c.Total())
+
+	// Concurrent increments from many goroutines (mirrors the parallel uploader).
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); c.inc("PutObject") }()
+	}
+	wg.Wait()
+	c.inc("GetObject")
+	c.inc("")
+
+	counts := c.Counts()
+	assert.Equal(t, 50, counts["PutObject"])
+	assert.Equal(t, 1, counts["GetObject"])
+	assert.Equal(t, 1, counts["Unknown"], "empty op name is bucketed as Unknown")
+	assert.Equal(t, 52, c.Total())
+	assert.Equal(t, []string{"GetObject", "PutObject", "Unknown"}, c.Names())
+
+	c.Reset()
+	assert.Equal(t, 0, c.Total())
+	assert.Empty(t, c.Counts())
+}
+
+// TestInstrumentRegistersMiddleware confirms Instrument appends an APIOption
+// that registers the counting middleware in the Initialize step. (End-to-end
+// operation counting is validated by the harness runner against the emulator.)
+func TestInstrumentRegistersMiddleware(t *testing.T) {
+	c := New()
+	cfg := &aws.Config{}
+	c.Instrument(cfg)
+	require.Len(t, cfg.APIOptions, 1, "Instrument must append one APIOption")
+
+	stack := middleware.NewStack("test", smithyhttp.NewStackRequest)
+	require.NoError(t, cfg.APIOptions[0](stack))
+	assert.Contains(t, stack.Initialize.List(), "cargoship-s3count",
+		"the counting middleware must be registered in the Initialize step")
+}


### PR DESCRIPTION
## What

Phase 1 of the comparative speed + cost benchmark: instrument and measure **CargoShip's own** upload+restore on reproducible corpora, recording throughput and the full S3 **dollar** cost from **exact, middleware-counted** requests. This is the evidence-maker for the "fastest / cheapest in class" goals the capability matrix currently marks **Aspirational** — we don't flip those to Verified without measured numbers. Competitors (`aws s3 cp`, `s5cmd`, `rclone`) are Phase 2.

Approved plan: `warm-soaring-grove.md` (synthetic-reproducible corpora first, CargoShip-first).

## New packages

- **`pkg/corpus`** — importable, fixed-seed corpus generators + named profiles (`many-tiny`, `few-large`, `mixed`, `hostile`). Byte-reproducible across runs/machines, so a published benchmark number can be independently reproduced. (86% cov)
- **`pkg/s3count`** — aws-sdk-go-v2 Initialize-step middleware that counts logical S3 ops by name. Captures multipart `UploadPart`/`CreateMultipartUpload`/`CompleteMultipartUpload` and `HeadObject`/`GetObject`/`ListObjectsV2` that manifest-derivation can't see; SDK retries are not double-counted. (94% cov)
- **`pkg/benchharness`** — `Run()` plants a profile, uploads through the real pipeline with the instrumented client, restores, verifies byte-identity, and computes speed + a STANDARD-class cost breakdown (**ingress free per #451**, monthly storage from compressed bytes, restore requests + egress). Emulator integration test proves the whole loop round-trips byte-identical with real request counts.
- **`cmd/cargoship-bench`** — thin CLI (real S3 default creds, or `--endpoint` for the emulator; `--json`/human output).

## Verified

- Emulator integration test (`-tags integration`) on the `mixed` profile: byte-identical, exact counts `PutObject:1 CreateMultipartUpload:1 UploadPart:5 CompleteMultipartUpload:1 DeleteObject:1`, cost modeled.
- Unit tests: corpus reproducibility (same seed → same sha256 set), counter mechanics + middleware registration, cost helpers vs hand-computed tier prices, #451 ingress-free assertion.
- `gofmt`/`go vet`/theater/dead-imports/capabilities guards clean; coverage ratchet OK (project 60%).

Depends on #451 (ingress-free cost), already merged.

Part of the trust + performance work. Phase 2 (competitors + CloudWatch request-metric reader → comparison table) is scoped in the plan, not built here.