### PR TITLE
fix(bench): correct harness metrics on the direct-upload path

### DIFF
--- a/pkg/benchharness/harness.go
+++ b/pkg/benchharness/harness.go
@@ -36,6 +36,9 @@ type Options struct {
 }
 
 // Phase captures the speed + request counts of one leg (upload or restore).
+// MBPerSec is EFFECTIVE throughput over the source bytes (the user's data
+// moved per second, crediting compression) — the metric comparable to a raw
+// 1:1 mover — not wire bytes. Bytes is the source-byte count for the leg.
 type Phase struct {
 	Duration time.Duration  `json:"duration_ms"`
 	Bytes    int64          `json:"bytes"`
@@ -57,7 +60,7 @@ type RunResult struct {
 	Profile       string `json:"profile"`
 	Files         int    `json:"files"`
 	SourceBytes   int64  `json:"source_bytes"`
-	StoredBytes   int64  `json:"stored_bytes"` // sum of chunk CompressedSize (what S3 holds)
+	StoredBytes   int64  `json:"stored_bytes"` // bytes S3 holds: chunk CompressedSize sum, or source bytes for direct upload
 	Chunks        int    `json:"chunks"`
 	Upload        Phase  `json:"upload"`
 	Restore       Phase  `json:"restore"`
@@ -124,8 +127,8 @@ func Run(ctx context.Context, opts Options) (*RunResult, error) {
 	for _, c := range m.Chunks {
 		storedBytes += c.CompressedSize
 	}
-	if storedBytes == 0 { // direct-upload manifests have no chunks
-		storedBytes = res.TotalBytes
+	if len(m.Chunks) == 0 { // direct upload: objects stored 1:1, uncompressed
+		storedBytes = srcBytes
 	}
 
 	// --- Restore leg (whole corpus) ---
@@ -157,17 +160,20 @@ func Run(ctx context.Context, opts Options) (*RunResult, error) {
 		SourceBytes: srcBytes,
 		StoredBytes: storedBytes,
 		Chunks:      len(m.Chunks),
+		// Effective throughput over source bytes — robust across the direct and
+		// chunked paths (the pipeline's TotalBytes/RestoreStats.Bytes are not
+		// populated on the direct-upload path) and comparable to a raw 1:1 mover.
 		Upload: Phase{
-			Duration: upDur, Bytes: res.TotalBytes,
-			MBPerSec: mbPerSec(res.TotalBytes, upDur), OpCounts: uploadCounts,
+			Duration: upDur, Bytes: srcBytes,
+			MBPerSec: mbPerSec(srcBytes, upDur), OpCounts: uploadCounts,
 		},
 		Restore: Phase{
-			Duration: rDur, Bytes: stats.Bytes,
-			MBPerSec: mbPerSec(stats.Bytes, rDur), OpCounts: restoreCounts,
+			Duration: rDur, Bytes: srcBytes,
+			MBPerSec: mbPerSec(srcBytes, rDur), OpCounts: restoreCounts,
 		},
 		ByteIdentical: byteIdentical,
 	}
-	rr.Cost = computeCost(storedBytes, stats.Bytes, uploadCounts, restoreCounts)
+	rr.Cost = computeCost(storedBytes, uploadCounts, restoreCounts)
 	return rr, nil
 }
 
@@ -218,8 +224,10 @@ func requestTier(op string) string {
 
 // computeCost models the STANDARD-class S3 bill from measured counts + stored
 // bytes. Ingress (upload data transfer) is free (#451); storage is monthly;
-// restore includes GET-tier requests + egress ($0.09/GB).
-func computeCost(storedBytes, restoreBytes int64, upload, restore map[string]int) Cost {
+// restore includes GET-tier requests + egress ($0.09/GB). Egress is billed on
+// the bytes that physically leave S3 — the stored (compressed) chunk bytes we
+// download, not the decompressed size — so compression cuts egress cost too.
+func computeCost(storedBytes int64, upload, restore map[string]int) Cost {
 	const std = config.StorageClassStandard
 	reqUSD := func(counts map[string]int) float64 {
 		var usd float64
@@ -229,11 +237,10 @@ func computeCost(storedBytes, restoreBytes int64, upload, restore map[string]int
 		return usd
 	}
 	storedGB := float64(storedBytes) / (1024 * 1024 * 1024)
-	restoreGB := float64(restoreBytes) / (1024 * 1024 * 1024)
 	return Cost{
 		UploadRequestsUSD:  reqUSD(upload),
 		MonthlyStorageUSD:  storedGB * pricingfallback.StoragePrice(std),
 		RestoreRequestsUSD: reqUSD(restore),
-		RestoreEgressUSD:   restoreGB * 0.09, // $0.09/GB egress
+		RestoreEgressUSD:   storedGB * 0.09, // $0.09/GB egress on the bytes leaving S3
 	}
 }

--- a/pkg/benchharness/harness_test.go
+++ b/pkg/benchharness/harness_test.go
@@ -42,9 +42,8 @@ func TestComputeCost(t *testing.T) {
 	upload := map[string]int{"PutObject": 1, "CreateMultipartUpload": 1, "UploadPart": 5, "CompleteMultipartUpload": 1}
 	restore := map[string]int{"GetObject": 3}
 	const storedBytes = 25 * 1024 * 1024
-	const restoreBytes = 24 * 1024 * 1024
 
-	got := computeCost(storedBytes, restoreBytes, upload, restore)
+	got := computeCost(storedBytes, upload, restore)
 
 	// Upload requests: 8 PUT-tier ops, priced from the canonical fallback table.
 	wantUpload := (8.0 / 1000.0) * pricingfallback.RequestPrice("PUT", std)
@@ -55,11 +54,12 @@ func TestComputeCost(t *testing.T) {
 	assert.InDelta(t, wantRestoreReq, got.RestoreRequestsUSD, 1e-12)
 
 	// Monthly storage from stored (compressed) bytes.
-	wantStorage := (float64(storedBytes) / (1024 * 1024 * 1024)) * pricingfallback.StoragePrice(std)
+	storedGB := float64(storedBytes) / (1024 * 1024 * 1024)
+	wantStorage := storedGB * pricingfallback.StoragePrice(std)
 	assert.InDelta(t, wantStorage, got.MonthlyStorageUSD, 1e-12)
 
-	// Egress at $0.09/GB.
-	wantEgress := (float64(restoreBytes) / (1024 * 1024 * 1024)) * 0.09
+	// Egress at $0.09/GB on the bytes leaving S3 (stored/compressed bytes).
+	wantEgress := storedGB * 0.09
 	assert.InDelta(t, wantEgress, got.RestoreEgressUSD, 1e-12)
 
 	// #451: upload data transfer (ingress) is never billed — only requests appear.


### PR DESCRIPTION
## What

The first real-AWS synthetic run (all 4 profiles, us-west-2) surfaced a harness bug: on the **direct-upload path** (small datasets — `many-tiny`, `hostile`) the pipeline doesn't populate `Result.TotalBytes` / `RestoreStats.Bytes`, so the harness reported `stored=0 B`, `$0.00/mo` storage, and `0.0 MB/s` throughput — even though the round-trip verified **byte-identical**.

## Fix

Measure from the bytes we planted (source bytes) instead — robust across the direct and chunked paths, and the honest, competitor-comparable metric:
- **Throughput** = effective source-data-moved/sec (credits compression; comparable to a raw 1:1 mover), not wire bytes.
- **Stored bytes** = chunk `CompressedSize` sum, or source bytes for a direct upload (objects stored 1:1).
- **Egress** billed on the bytes that physically leave S3 (stored/compressed bytes downloaded), so compression cuts egress too.

## Verified (real S3, LA → us-west-2, STANDARD)

Corrected numbers, all byte-identical ✅:

| profile | files | source | stored | up MB/s | restore MB/s | upload-req $ |
|---|---|---|---|---|---|---|
| many-tiny | 5000 | 9.9 MiB | 9.9 MiB | 4.8 | ~0 (5000 serial GETs) | **0.025** |
| few-large | 4 | 46 MiB | 46 MiB | 38.4 | 66.0 | 0.000065 |
| mixed | 4 | 24 MiB | 24 MiB | 24.8 | 46.0 | 0.000040 |
| hostile | 10 | 1 MiB | 1 MiB | 2.6 | 1.6 | 0.000055 |

(Before the fix `many-tiny`/`hostile` showed `stored=0`, `0.0 MB/s`, `$0` storage.)

Unit + emulator integration tests updated and green; gofmt/vet clean.