### PR TITLE
fix(pipeline): globally-unique chunk IDs — prevent S3 key collision & data loss (#467)

### DIFF
--- a/pkg/pipeline/scanner.go
+++ b/pkg/pipeline/scanner.go
@@ -41,6 +41,13 @@ type ScannerStage struct {
 	jobsProcessed  int64
 	bytesProcessed int64
 
+	// chunkIDSeq allocates globally-unique chunk IDs across batches. The chunker
+	// numbers chunks 0..k-1 within each batch, and batches are processed
+	// concurrently; without a global sequence, chunk IDs (and therefore the
+	// "chunk-{id}" S3 keys) collide across batches and later chunk objects
+	// overwrite earlier ones in S3, silently losing data on restore.
+	chunkIDSeq int64
+
 	// Error from run() method
 	runError error
 
@@ -391,6 +398,20 @@ func (s *ScannerStage) streamFiles(ctx context.Context, rootPath string) (<-chan
 	return fileChan, errChan
 }
 
+// assignGlobalChunkIDs rewrites batch-local chunk IDs (0..k-1) to a contiguous
+// range of globally-unique IDs, reserved atomically so concurrently-processed
+// batches never collide. This keeps every chunk's "chunk-{id}" S3 key unique and
+// each FileEntry.ChunkID consistent with the job that carries it.
+func (s *ScannerStage) assignGlobalChunkIDs(chunks []chunking.Chunk) {
+	if len(chunks) == 0 {
+		return
+	}
+	base := atomic.AddInt64(&s.chunkIDSeq, int64(len(chunks))) - int64(len(chunks))
+	for i := range chunks {
+		chunks[i].ID = int(base) + i
+	}
+}
+
 // processBatch processes a batch of files into chunks
 func (s *ScannerStage) processBatch(ctx context.Context, files []chunking.File, totalSize int64) error {
 	// Issue #30: Run Magika batch detection if enabled
@@ -414,6 +435,7 @@ func (s *ScannerStage) processBatch(ctx context.Context, files []chunking.File, 
 			return fmt.Errorf("failed to create compressed-aware chunks: %w", err)
 		}
 		chunks = result.Chunks
+		s.assignGlobalChunkIDs(chunks) // unique IDs/keys across concurrent batches
 
 		// Log chunking decision
 		fmt.Printf("Phase 3.3: Created %d chunks with %dMB target (total: %.2f GB compressed)\n",
@@ -485,6 +507,7 @@ func (s *ScannerStage) processBatch(ctx context.Context, files []chunking.File, 
 		if err != nil {
 			return fmt.Errorf("failed to group files into chunks: %w", err)
 		}
+		s.assignGlobalChunkIDs(chunks) // unique IDs/keys across concurrent batches
 
 		// Send chunks without target sizes
 		for i := range chunks {

--- a/pkg/pipeline/scanner_chunkid_test.go
+++ b/pkg/pipeline/scanner_chunkid_test.go
@@ -1,0 +1,61 @@
+package pipeline
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/scttfrdmn/cargoship/pkg/chunking"
+)
+
+// TestAssignGlobalChunkIDsUniqueAcrossConcurrentBatches guards the data-loss bug
+// where concurrently-processed scan batches each numbered their chunks 0..k-1,
+// so the "chunk-{id}" S3 keys collided across batches and later chunk objects
+// overwrote earlier ones in S3 (silently losing files on restore). Every chunk
+// ID — and therefore every S3 key — must be globally unique.
+func TestAssignGlobalChunkIDsUniqueAcrossConcurrentBatches(t *testing.T) {
+	s := &ScannerStage{}
+	const batches, perBatch = 64, 16
+
+	var wg sync.WaitGroup
+	got := make([][]int, batches)
+	for b := 0; b < batches; b++ {
+		wg.Add(1)
+		go func(b int) {
+			defer wg.Done()
+			// The chunker numbers each batch's chunks 0..perBatch-1 locally.
+			chunks := make([]chunking.Chunk, perBatch)
+			for i := range chunks {
+				chunks[i].ID = i
+			}
+			s.assignGlobalChunkIDs(chunks)
+			ids := make([]int, perBatch)
+			for i := range chunks {
+				ids[i] = chunks[i].ID
+			}
+			got[b] = ids
+		}(b)
+	}
+	wg.Wait()
+
+	seen := make(map[int]bool, batches*perBatch)
+	for _, ids := range got {
+		for _, id := range ids {
+			if seen[id] {
+				t.Fatalf("duplicate chunk ID %d across batches — S3 keys would collide", id)
+			}
+			seen[id] = true
+		}
+	}
+	if len(seen) != batches*perBatch {
+		t.Fatalf("expected %d unique chunk IDs, got %d", batches*perBatch, len(seen))
+	}
+}
+
+// TestAssignGlobalChunkIDsEmpty is a no-op guard (no allocation, no panic).
+func TestAssignGlobalChunkIDsEmpty(t *testing.T) {
+	s := &ScannerStage{}
+	s.assignGlobalChunkIDs(nil)
+	if s.chunkIDSeq != 0 {
+		t.Fatalf("empty batch must not consume IDs, got seq=%d", s.chunkIDSeq)
+	}
+}


### PR DESCRIPTION
## Severity: HIGH — silent data loss on restore

Surfaced by the Phase-1 benchmark harness (#464) while running the `many-tiny` profile through the packed/chunked path.

## Root cause

The scanner batches files 1000 at a time (`scanner.go`, `batchSize = 1000`) and submits each batch to a **concurrent** worker pool. Each `processBatch` runs the chunker independently, and the chunker numbers chunks **0..k-1 locally** (`ID: len(chunks)`). So every batch restarts chunk IDs at 0.

The chunk S3 key is `uploads/{id}/shard-{shard}/chunk-{chunk_id}{ext}` (`archiver.go:793`) — so chunk objects from different batches **collide on the same key and overwrite each other in S3**. The manifest records all chunks (correct sizes) but they point at colliding keys; restore silently recovers only the last-written chunk's files.

**Demonstrated:** 5000 tiny files → 5 batches → 5 chunk entries, all `id=0`, all keyed `shard-0/chunk-0.tar.zst`; restore wrote **1000 of 5000 files** with **0 reported failures**.

## Blast radius

Any **chunked** upload with **>1000 files** loses data. The many-small-files case is normally dodged only because the direct-upload fast path stores one object per file (#466); a large tree exceeds the direct threshold, takes the chunked path, and loses data. The planned 810K-file `~/src` dog-food would have lost data massively.

## Fix

`assignGlobalChunkIDs` — an atomic per-scanner sequence that rewrites batch-local chunk IDs to a globally-unique contiguous range, reserved atomically so concurrent batches never collide. Applied in **both** chunking branches before manifest `FileEntry`s are built and before jobs are dispatched, keeping every `chunk-{id}` S3 key unique and each `FileEntry.ChunkID` consistent with its job.

## Tests

- `TestAssignGlobalChunkIDsUniqueAcrossConcurrentBatches` — race-checked; **verified it fails without the fix** (duplicate ID 0) and passes with it.
- `TestAssignGlobalChunkIDsEmpty` — empty batch consumes no IDs.
- End-to-end: the benchharness emulator modes test restores packed `many-tiny` (5000 files / 5 chunks / 5 batches) **byte-identical** (lands in the follow-up harness `--mode` PR).

Real-AWS byte-path confirmation to follow before I consider this closed.

Fixes #467