### PR TITLE
feat(bench): --mode auto|direct|packed to compare upload paths (#466)

### DIFF
--- a/cmd/cargoship-bench/main.go
+++ b/cmd/cargoship-bench/main.go
@@ -39,9 +39,16 @@ func run() error {
 		region      = flag.String("region", "us-east-1", "AWS region")
 		prefix      = flag.String("prefix", "", "S3 key prefix (default bench-<timestamp>)")
 		endpoint    = flag.String("endpoint", "", "S3 endpoint override (emulator/LocalStack); enables path-style")
+		mode        = flag.String("mode", "auto", "upload path: auto|direct|packed")
 		asJSON      = flag.Bool("json", false, "emit JSON results")
 	)
 	flag.Parse()
+
+	switch benchharness.Mode(*mode) {
+	case benchharness.ModeAuto, benchharness.ModeDirect, benchharness.ModePacked:
+	default:
+		return fmt.Errorf("invalid --mode %q (want auto|direct|packed)", *mode)
+	}
 
 	if *bucket == "" {
 		return fmt.Errorf("--bucket is required")
@@ -78,7 +85,7 @@ func run() error {
 		rr, err := benchharness.Run(ctx, benchharness.Options{
 			Profile: prof, Client: client, Counter: counter,
 			Bucket: *bucket, Prefix: fmt.Sprintf("%s/%s", pfx, prof.Name), Region: *region,
-			SrcDir: srcDir, RestoreDir: restoreDir,
+			SrcDir: srcDir, RestoreDir: restoreDir, Mode: benchharness.Mode(*mode),
 		})
 		_ = os.RemoveAll(srcDir)
 		_ = os.RemoveAll(restoreDir)
@@ -120,7 +127,7 @@ func printHuman(rr *benchharness.RunResult) {
 	if !rr.ByteIdentical {
 		ok = "❌ NOT byte-identical"
 	}
-	fmt.Printf("── %s %s\n", rr.Profile, ok)
+	fmt.Printf("── %s [%s] %s\n", rr.Profile, rr.Mode, ok)
 	fmt.Printf("   files=%d  source=%s  stored=%s  chunks=%d\n",
 		rr.Files, humanBytes(rr.SourceBytes), humanBytes(rr.StoredBytes), rr.Chunks)
 	fmt.Printf("   upload : %6.1f MB/s  %v\n", rr.Upload.MBPerSec, rr.Upload.OpCounts)

--- a/pkg/benchharness/harness.go
+++ b/pkg/benchharness/harness.go
@@ -23,6 +23,18 @@ import (
 	"github.com/scttfrdmn/cargoship/pkg/s3count"
 )
 
+// Mode selects the upload path under test.
+type Mode string
+
+const (
+	// ModeAuto lets the pipeline's heuristic pick direct vs packed (default).
+	ModeAuto Mode = "auto"
+	// ModeDirect forces the direct-upload fast path (one object per file).
+	ModeDirect Mode = "direct"
+	// ModePacked forces the archive/chunk path (packs files into chunks).
+	ModePacked Mode = "packed"
+)
+
 // Options configures one benchmark run.
 type Options struct {
 	Profile    corpus.Profile
@@ -33,6 +45,7 @@ type Options struct {
 	Region     string
 	SrcDir     string // where to plant the corpus (caller owns cleanup)
 	RestoreDir string // where to restore (caller owns cleanup)
+	Mode       Mode   // upload path to force; "" == ModeAuto
 }
 
 // Phase captures the speed + request counts of one leg (upload or restore).
@@ -58,6 +71,7 @@ type Cost struct {
 // RunResult is the full record for one profile.
 type RunResult struct {
 	Profile       string `json:"profile"`
+	Mode          Mode   `json:"mode"`
 	Files         int    `json:"files"`
 	SourceBytes   int64  `json:"source_bytes"`
 	StoredBytes   int64  `json:"stored_bytes"` // bytes S3 holds: chunk CompressedSize sum, or source bytes for direct upload
@@ -82,6 +96,10 @@ func Run(ctx context.Context, opts Options) (*RunResult, error) {
 		srcBytes += int64(f.Size)
 	}
 
+	mode := opts.Mode
+	if mode == "" {
+		mode = ModeAuto
+	}
 	uploadID := fmt.Sprintf("%d-bench", time.Now().UnixNano())
 	pc := &pipeline.PipelineConfig{
 		ScannerWorkers: 4, ArchiverWorkers: 4, UploaderWorkers: 4,
@@ -89,6 +107,16 @@ func Run(ctx context.Context, opts Options) (*RunResult, error) {
 		UseRealS3: true, S3Client: opts.Client, S3PartSize: 5 * 1024 * 1024,
 		EnableManifest: true, SourcePath: opts.SrcDir, UploadID: uploadID,
 		EnableMultiPrefix: true, ShardCount: 4, FileChecksums: true,
+	}
+	switch mode {
+	case ModeDirect:
+		pc.ForceDirectUpload = true
+	case ModePacked:
+		// No config disables the direct fast path outright; a negative threshold
+		// makes the "under size" test always false, so the heuristic never picks
+		// direct regardless of dataset size. The Chunks>0 assertion below verifies
+		// the packed path actually engaged.
+		pc.DirectUploadThresholdMB = -1
 	}
 
 	// --- Upload leg ---
@@ -123,6 +151,13 @@ func Run(ctx context.Context, opts Options) (*RunResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse manifest: %w", err)
 	}
+	// Verify the forced mode actually engaged (chunks present == packed path).
+	switch {
+	case mode == ModePacked && len(m.Chunks) == 0:
+		return nil, fmt.Errorf("packed mode requested but upload took the direct path (no chunks) — dataset may be too small")
+	case mode == ModeDirect && len(m.Chunks) != 0:
+		return nil, fmt.Errorf("direct mode requested but upload produced %d chunks", len(m.Chunks))
+	}
 	var storedBytes int64
 	for _, c := range m.Chunks {
 		storedBytes += c.CompressedSize
@@ -156,6 +191,7 @@ func Run(ctx context.Context, opts Options) (*RunResult, error) {
 
 	rr := &RunResult{
 		Profile:     opts.Profile.Name,
+		Mode:        mode,
 		Files:       len(files),
 		SourceBytes: srcBytes,
 		StoredBytes: storedBytes,

--- a/pkg/benchharness/harness_integration_test.go
+++ b/pkg/benchharness/harness_integration_test.go
@@ -65,6 +65,56 @@ func TestHarnessRunOnEmulator(t *testing.T) {
 		rr.Files, rr.StoredBytes, rr.Upload.MBPerSec, up, rr.Restore.MBPerSec, rr.Cost.MonthlyStorageUSD)
 }
 
+// TestHarnessModesOnEmulator confirms the forced upload modes engage the path
+// they name: packed produces chunks, direct produces one object per file (no
+// chunks) — the head-to-head that answers #466. Both round-trip byte-identical.
+func TestHarnessModesOnEmulator(t *testing.T) {
+	url, cancel := launchSubstrate(t)
+	defer cancel()
+	const bucket = "cargoship-bench-modes"
+	require.NoError(t, createSubstrateBucket(url, bucket))
+
+	prof, ok := corpus.ProfileByName("many-tiny")
+	require.True(t, ok)
+
+	for _, tc := range []struct {
+		mode        Mode
+		wantChunked bool
+	}{
+		{ModePacked, true},
+		{ModeDirect, false},
+	} {
+		t.Run(string(tc.mode), func(t *testing.T) {
+			counter := s3count.New()
+			cfg := aws.Config{
+				Region:       "us-east-1",
+				BaseEndpoint: aws.String(url),
+				Credentials:  credentials.NewStaticCredentialsProvider("test", "test", ""),
+			}
+			counter.Instrument(&cfg)
+			client := awss3.NewFromConfig(cfg, func(o *awss3.Options) { o.UsePathStyle = true })
+
+			rr, err := Run(context.Background(), Options{
+				Profile: prof, Client: client, Counter: counter, Mode: tc.mode,
+				Bucket: bucket, Prefix: fmt.Sprintf("modes-%s-%d", tc.mode, time.Now().UnixNano()),
+				Region: "us-east-1", SrcDir: t.TempDir(), RestoreDir: t.TempDir(),
+			})
+			require.NoError(t, err)
+			assert.True(t, rr.ByteIdentical)
+			assert.Equal(t, tc.mode, rr.Mode)
+			if tc.wantChunked {
+				assert.Positive(t, rr.Chunks, "packed mode must produce chunks")
+				assert.Positive(t, rr.Upload.OpCounts["PutObject"]+rr.Upload.OpCounts["CreateMultipartUpload"])
+			} else {
+				assert.Zero(t, rr.Chunks, "direct mode must produce no chunks")
+				// One PutObject per file (5000) + the manifest.
+				assert.Greater(t, rr.Upload.OpCounts["PutObject"], 5000, "direct mode PUTs each file")
+			}
+			t.Logf("many-tiny [%s]: chunks=%d up=%v", tc.mode, rr.Chunks, rr.Upload.OpCounts)
+		})
+	}
+}
+
 // launchSubstrate starts an in-process Substrate S3 emulator (mirrors the
 // pipeline integration tests' bootstrap).
 func launchSubstrate(t *testing.T) (string, context.CancelFunc) {


### PR DESCRIPTION
## What

Adds a forced upload-path mode to the benchmark harness (and `cargoship-bench --mode`) so the direct-upload fast path and the archive/chunk path can be measured **head-to-head on the same corpus** — the experiment behind #466. `Run` verifies the path that actually engaged (chunks present == packed) and errors if the forced mode didn't take.

## Result (real S3, us-west-2, `many-tiny` = 5000 files)

| metric | packed | direct |
|---|---|---|
| upload | **17.0 MB/s** | 3.5 MB/s |
| restore | **8.9 MB/s** | ~0 (5000 serial GETs) |
| upload requests | 6 PUTs → **$0.000030** | 5001 PUTs → **$0.025** |

Packed wins on every axis → **#466** should flip the `>1000 files → direct` heuristic to prefer packing.

The packed modes test also served as the **end-to-end regression for the #467 data-loss fix** (byte-identical, 5 chunks across 5 batches).

## Tests

Emulator modes test (`-tags integration`) asserts packed→chunks and direct→one-object-per-file, both byte-identical. Depends on #468 (merged).