### PR TITLE
fix(pipeline): direct upload only for few files — pack many small files (#466)

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -139,7 +139,10 @@ func NewPipeline(config *PipelineConfig) (*Pipeline, error) {
 		config.DirectUploadThresholdMB = 500 // Default: 500MB max for direct upload
 	}
 	if config.DirectUploadMaxFiles == 0 {
-		config.DirectUploadMaxFiles = 50000 // Default: 50k files max for direct upload
+		// #466: direct upload only pays off for a small number of files; beyond
+		// this, packing is faster and far cheaper (measured on real S3). This is a
+		// conservative cap — a measured crossover sweep can refine it later.
+		config.DirectUploadMaxFiles = 1000
 	}
 	if config.DirectUploadAvgSizeMB == 0 {
 		config.DirectUploadAvgSizeMB = 5.0 // Default: 5MB average file size threshold
@@ -411,14 +414,19 @@ func (p *Pipeline) shouldUseDirectUpload(fileCount int64, totalSize int64) bool 
 	// Calculate total size in MB
 	totalSizeMB := totalSize / (1024 * 1024)
 
-	// Use direct upload if:
-	// 1. Total size is under threshold AND
-	// 2. Average file size is small (under threshold) OR file count is high
+	// Direct upload stores one S3 object per file — cheap and low-latency only for
+	// a SMALL number of files. #466 measured (real S3, 5000 tiny files) that with
+	// many files packing wins on every axis: it collapses thousands of PUTs into a
+	// handful of chunk objects (~830× cheaper request cost) and turns a slow
+	// serial-GET restore into a few chunk downloads, at ~5× the upload throughput.
+	// So gate direct upload on a LOW file count — never route many files to it,
+	// regardless of how small each one is. (A prior heuristic did the opposite,
+	// forcing >1000 small files to direct.)
 	underSizeThreshold := totalSizeMB < int64(p.config.DirectUploadThresholdMB)
+	underFileCount := fileCount <= int64(p.config.DirectUploadMaxFiles)
 	smallAvgSize := avgFileSizeMB < p.config.DirectUploadAvgSizeMB
-	manySmallFiles := fileCount > 1000 && avgFileSizeMB < 10.0 // Many files under 10MB each
 
-	return underSizeThreshold && (smallAvgSize || manySmallFiles)
+	return underSizeThreshold && underFileCount && smallAvgSize
 }
 
 // startStages initializes and starts all pipeline stages

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -664,15 +664,32 @@ func TestPipeline_ShouldUseDirectUpload(t *testing.T) {
 			expectedDirectMode: true,
 		},
 		{
-			name: "auto_detect_small_avg_file_size",
+			// #466: many small files must PACK, not go direct — even though the
+			// average size is tiny, 10000 files exceeds the direct file-count cap.
+			name: "auto_many_small_files_packs",
 			config: &PipelineConfig{
 				S3Bucket:                "test-bucket",
 				EnableAutoDirectUpload:  true,
 				DirectUploadThresholdMB: 500,
+				DirectUploadMaxFiles:    1000,
 				DirectUploadAvgSizeMB:   5.0,
 			},
 			fileCount:          10000,
 			totalSize:          400 * 1024 * 1024, // 400MB total, 0.04MB avg
+			expectedDirectMode: false,
+		},
+		{
+			// Few small files: direct upload is fine (low per-file overhead).
+			name: "auto_few_small_files_direct",
+			config: &PipelineConfig{
+				S3Bucket:                "test-bucket",
+				EnableAutoDirectUpload:  true,
+				DirectUploadThresholdMB: 500,
+				DirectUploadMaxFiles:    1000,
+				DirectUploadAvgSizeMB:   5.0,
+			},
+			fileCount:          100,
+			totalSize:          100 * 1024 * 1024, // 100MB total, 1MB avg
 			expectedDirectMode: true,
 		},
 		{
@@ -704,12 +721,13 @@ func TestPipeline_ShouldUseDirectUpload(t *testing.T) {
 			config: &PipelineConfig{
 				S3Bucket:                "test-bucket",
 				DirectUploadThresholdMB: 500,
+				DirectUploadMaxFiles:    1000,
 				DirectUploadAvgSizeMB:   5.0,
 				// EnableAutoDirectUpload not set - should default to true
 			},
-			fileCount:          10000,
-			totalSize:          100 * 1024 * 1024, // 100MB total, 0.01MB avg
-			expectedDirectMode: true,              // Should auto-enable due to small avg file size
+			fileCount:          500,
+			totalSize:          100 * 1024 * 1024, // 100MB total, 0.2MB avg, few files
+			expectedDirectMode: true,              // auto-enables: small files, under the count cap
 		},
 		{
 			name: "zero_files",
@@ -749,7 +767,7 @@ func TestNewPipeline_DirectUploadDefaults(t *testing.T) {
 
 	// Verify defaults were applied
 	assert.Equal(t, 500, pipeline.config.DirectUploadThresholdMB)
-	assert.Equal(t, 50000, pipeline.config.DirectUploadMaxFiles)
+	assert.Equal(t, 1000, pipeline.config.DirectUploadMaxFiles) // #466: conservative cap
 	assert.Equal(t, 5.0, pipeline.config.DirectUploadAvgSizeMB)
 	assert.Equal(t, 256, pipeline.config.DirectUploadWorkers)
 	assert.True(t, pipeline.config.EnableAutoDirectUpload)


### PR DESCRIPTION
## What

Fixes the direct-upload auto heuristic surfaced by the benchmark harness. It routed **many small files** to direct upload (one S3 object per file), which #466 measured (real S3, 5000 files) to be worse on every axis than packing:

| metric | direct (old) | packed (new default) |
|---|---|---|
| upload | 3.5 MB/s | **13–17 MB/s** |
| restore | ~0 (5000 serial GETs) | **8.5 MB/s** (5 GETs) |
| upload requests | 5001 PUTs → **$0.025** | 6 PUTs → **$0.00003** |

The old rule even had `manySmallFiles := fileCount > 1000` that *forced* many files to direct — exactly backwards.

## Fix

Gate direct upload on a **low file count**: wire the previously-unused `DirectUploadMaxFiles` into `shouldUseDirectUpload` and lower its default to a conservative **1000**. Direct now requires small total size **AND** few files **AND** small average size; many files pack regardless of how small each is.

## Confirmed on real S3

`--mode auto` on `many-tiny` (5000 files) now **packs** — 5 chunks, 6 PUTs, $0.00003, byte-identical — where it previously took the 5001-PUT direct path. The exact crossover file count can be refined with a measured sweep (noted in code).

## Tests

`TestPipeline_ShouldUseDirectUpload` updated: many small files pack, few small files still go direct; default `DirectUploadMaxFiles` assertion updated to 1000. Full pipeline unit + emulator integration suites green.

Fixes #466