### PR TITLE
fix(manifest): make ResolveObjectKey idempotent when bucket-strip exposes a scheme

### DIFF
--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -161,25 +161,8 @@ func ResolveObjectKey(prefix, bucket, s3Key string) string {
 	// leading position. Found by FuzzResolveObjectKey.
 	key := strings.TrimLeft(s3Key, "/")
 
-	// Strip a scheme://host/ prefix if S3Key was stored as a full URL. Only a
-	// "://" in true scheme position counts: S3 permits ':' in object keys, so
-	// matching "://" anywhere would mangle a legitimate key (a file named
-	// "weird://name.txt" once resolved to just the bare prefix). Looped, with a
-	// re-trim each pass, so a doubly-wrapped URL can't leave a scheme behind.
-	// Found by FuzzResolveObjectKey.
-	for {
-		i := strings.Index(key, "://")
-		if i <= 0 || !isURLScheme(key[:i]) {
-			break
-		}
-		rest := key[i+3:]
-		slash := strings.Index(rest, "/")
-		if slash < 0 {
-			key = ""
-			break
-		}
-		key = strings.TrimLeft(rest[slash+1:], "/") // drop host, keep path
-	}
+	// Strip a scheme://host/ prefix if S3Key was stored as a full URL.
+	key = stripURLScheme(key)
 
 	// The prefix is trimmed of surrounding slashes: a manifest written from a
 	// user-typed "s3://bucket/archives/" carries a trailing slash, and joining
@@ -202,11 +185,37 @@ func ResolveObjectKey(prefix, bucket, s3Key string) string {
 		key = strings.TrimLeft(strings.TrimPrefix(key, bucket+"/"), "/")
 	}
 
+	// Re-run the scheme strip: dropping the bucket segment can expose a
+	// scheme-like leading token (e.g. "0/A://" -> "A://"), which a second
+	// resolve pass would strip — leaving the output non-idempotent unless we
+	// normalize it to the same fixed point here. Found by FuzzResolveObjectKey.
+	key = stripURLScheme(key)
+
 	// Prepend the manifest Prefix unless it's already there (or empty).
 	if prefix != "" && key != prefix && !strings.HasPrefix(key, prefix+"/") {
 		key = prefix + "/" + key
 	}
 	return key
+}
+
+// stripURLScheme removes a leading scheme://host/ from an S3 key stored as a
+// full URL. Only a "://" in true scheme position counts: S3 permits ':' in
+// object keys, so matching "://" anywhere would mangle a legitimate key (a file
+// named "weird://name.txt"). Looped, re-trimming each pass, so a doubly-wrapped
+// URL can't leave a scheme behind. Found by FuzzResolveObjectKey.
+func stripURLScheme(key string) string {
+	for {
+		i := strings.Index(key, "://")
+		if i <= 0 || !isURLScheme(key[:i]) {
+			return key
+		}
+		rest := key[i+3:]
+		slash := strings.Index(rest, "/")
+		if slash < 0 {
+			return ""
+		}
+		key = strings.TrimLeft(rest[slash+1:], "/") // drop host, keep path
+	}
 }
 
 // isURLScheme reports whether s is a plausible URI scheme per RFC 3986:

--- a/pkg/manifest/fuzz_test.go
+++ b/pkg/manifest/fuzz_test.go
@@ -233,6 +233,10 @@ func FuzzResolveObjectKey(f *testing.F) {
 	f.Add("p", "b", "://nohost")
 	f.Add("prefix", "prefix", "prefix/prefix/k")
 	f.Add("prefix", "bucket", "prefix/uploads/x/weird://name.txt")
+	// Regression: stripping the bucket ("0/") exposed "A://", which a second
+	// resolve pass mangled to "" — resolution was not idempotent for an empty
+	// prefix. Found by FuzzResolveObjectKey.
+	f.Add("", "0", "0/A://")
 
 	f.Fuzz(func(t *testing.T, prefix, bucket, s3Key string) {
 		// A manifest Prefix is an S3 key prefix, never a URL — only the stored


### PR DESCRIPTION
## What

`FuzzResolveObjectKey` (short-burst lane, 500000x) found a non-idempotency bug — surfaced while running CI on an unrelated PR:

```
not idempotent: prefix="" bucket="0" s3Key="0/A://" -> "A://" -> ""
```

Stripping the leading `"bucket/"` (`"0/"`) exposed `"A://"`, which a **second** resolve pass then treated as a URL and mangled to `""` (the scheme strip only ran at the front). Resolution must be idempotent — a key passes through layers (verify → restore) that each resolve it, and a non-fixed-point key can be silently dropped.

## Fix

Extract the scheme strip into `stripURLScheme` and re-run it **after** the bucket strip, so the result never carries a leading `scheme://` and a second pass is a no-op. This aligns `resolve("0/A://")` with the already-existing `resolve("A://") == ""`.

## Tests

Failing input added as a regression seed (`f.Add("", "0", "0/A://")`). Verified: seed passes, and the target is clean at **5,000,000x** locally. Independent of the pipeline/harness work — this is a pre-existing latent bug the fuzzer happened to reach.