### PR TITLE
docs(bench): round-trip speed+cost harness methodology + crossover sweep

### DIFF
--- a/cmd/cargoship-bench/main.go
+++ b/cmd/cargoship-bench/main.go
@@ -40,6 +40,8 @@ func run() error {
 		prefix      = flag.String("prefix", "", "S3 key prefix (default bench-<timestamp>)")
 		endpoint    = flag.String("endpoint", "", "S3 endpoint override (emulator/LocalStack); enables path-style")
 		mode        = flag.String("mode", "auto", "upload path: auto|direct|packed")
+		files       = flag.Int("files", 0, "if >0, use a synthetic corpus of N uniform files (overrides --profile) — for the #466 crossover sweep")
+		fileSize    = flag.Int("file-size", 65536, "bytes per file when --files is set")
 		asJSON      = flag.Bool("json", false, "emit JSON results")
 	)
 	flag.Parse()
@@ -59,7 +61,10 @@ func run() error {
 	}
 
 	profiles := corpus.Profiles()
-	if *profileName != "all" {
+	switch {
+	case *files > 0:
+		profiles = []corpus.Profile{corpus.UniformProfile(*files, *fileSize)}
+	case *profileName != "all":
 		p, ok := corpus.ProfileByName(*profileName)
 		if !ok {
 			return fmt.Errorf("unknown profile %q (have: %s)", *profileName, profileNames())

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -121,6 +121,96 @@ version, and settings**; a faster laptop is not a faster CargoShip.
   content. A tree of already-compressed media behaves nothing like a tree of
   source code or CSV. Benchmark with a sample that resembles your real data.
 
+## Round-trip speed + cost harness (`cargoship-bench`)
+
+The Go microbenchmarks above measure the upload code path in isolation. The
+`cargoship-bench` harness measures the **end-to-end** picture on real S3: it
+plants a reproducible corpus, uploads it through the real pipeline, restores it,
+verifies the round-trip is **byte-identical**, and reports throughput plus the
+full S3 **dollar** cost computed from **exact, middleware-counted** requests —
+not estimates.
+
+```bash
+# All reproducible profiles against a real bucket (writes objects; clean up after)
+cargoship-bench --bucket my-bucket --region us-west-2
+
+# One profile, forcing the upload path (auto|direct|packed), JSON output
+cargoship-bench --bucket my-bucket --region us-west-2 --profile mixed --mode packed --json
+
+# Parametric corpus: N uniform files of a fixed size (the crossover sweep)
+cargoship-bench --bucket my-bucket --region us-west-2 --files 1000 --file-size 65536 --mode direct
+```
+
+It leaves its objects in place (delete them yourself, as with the real-AWS
+torture procedure). Point `--endpoint` at an emulator for a free correctness run;
+emulator numbers validate the round-trip but are meaningless for throughput.
+
+### Reproducible corpora
+
+Each named profile seeds its own RNG from a fixed seed, so it plants
+byte-identical content on every run and machine — the property that lets a
+published number be independently reproduced:
+
+| Profile | Shape | Exercises |
+|---|---|---|
+| `many-tiny` | 5000 files, ~2 KB each | request/small-object overhead |
+| `few-large` | 4 files, 6–20 MiB | multipart uploads |
+| `mixed` | compressible + already-compressed | both chunk kinds in one upload |
+| `hostile` | awkward names/sizes/nesting | edge cases, direct-upload path |
+
+### What the numbers mean
+
+- **Effective throughput** = source bytes moved per second (`source_bytes ÷
+  wall-clock`), crediting compression — the figure comparable to a raw 1:1 mover,
+  not wire bytes. Reported for both the upload and restore legs.
+- **Request counts** are captured by an aws-sdk middleware that tallies each
+  logical S3 operation (including every multipart `UploadPart`), so the request
+  bill is measured, not derived from the manifest.
+- **Cost** is modeled at the STANDARD class: **upload data transfer is free** (S3
+  ingress), monthly storage is billed on the stored (compressed) bytes, and
+  restore is GET-tier requests + egress ($0.09/GB) on the bytes that physically
+  leave S3.
+
+### Recorded baseline (2026-09-10, macOS → `us-west-2`, STANDARD)
+
+Provenance matters as much here as for the microbenchmarks — these are one
+machine's numbers on one network path, recorded for reference, not a portable
+"CargoShip does X MB/s" claim:
+
+| Profile | Files / size | Upload MB/s | Restore MB/s |
+|---|---|---|---|
+| `few-large` | 4 / 46 MiB | 38.4 | 66.0 |
+| `mixed` | 4 / 24 MiB | 24.8 | 46.0 |
+
+### Direct vs. packed: the crossover sweep (#466)
+
+CargoShip auto-selects a direct-upload fast path (one S3 object per file) for
+small datasets and packs everything else into chunks. Sweeping file count at a
+fixed 64 KB file size, direct vs. forced-packed on real S3:
+
+| Files | Upload MB/s (direct / packed) | Restore MB/s (direct / packed) | Upload requests (direct / packed) |
+|---|---|---|---|
+| 50 | 8.7 / 6.3 | 1.2 / 12.2 | 51 / 2 |
+| 500 | 61.2 / 30.2 | 1.2 / 57.2 | 501 / 2 |
+| 1000 | 71.2 / 45.0 | 1.2 / 68.5 | 1001 / 2 |
+| 2000 | 72.6 / 44.9 | 1.1 / 67.3 | 2001 / 3 |
+
+There is no single-axis crossover: **direct uploads faster** for medium-small
+files (parallel PUTs, no archive CPU), but **packing restores far faster and
+costs far fewer requests** at every count. Direct restore is a flat ~1.2 MB/s
+because [`BatchRestore` downloads serially](https://github.com/scttfrdmn/cargoship/issues/472);
+packing amortizes that across a few chunk GETs. CargoShip therefore packs once a
+dataset exceeds a conservative file-count cap (`DirectUploadMaxFiles`, default
+1000), reserving direct upload for genuinely small sets — see
+[#466](https://github.com/scttfrdmn/cargoship/issues/466).
+
+::: warning "Fastest" and "cheapest" are goals, not verified claims
+These are CargoShip's own numbers. Head-to-head comparisons against `aws s3 cp`,
+`s5cmd`, and `rclone` on the same corpus/bucket/hardware are future work; until
+that harness exists, the [capability matrix](/project/verification) marks
+performance and cost **Aspirational**.
+:::
+
 ## See also
 
 - [Performance tuning](/guides/features/optimization) — the throughput knobs

--- a/pkg/corpus/corpus.go
+++ b/pkg/corpus/corpus.go
@@ -112,6 +112,25 @@ func PlantManyFiles(root string, rng *rand.Rand, n int) ([]File, error) {
 	return out, nil
 }
 
+// PlantUniform writes n incompressible (random) files of exactly size bytes
+// each, with unique basenames spread across subdirectories. It's the parametric
+// corpus for the direct-vs-packed crossover sweep (#466): fix the file size and
+// vary n to find the file count at which packing overtakes direct upload.
+func PlantUniform(root string, rng *rand.Rand, n, size int) ([]File, error) {
+	out := make([]File, 0, n)
+	for i := 0; i < n; i++ {
+		rel := filepath.Join(fmt.Sprintf("d%04d", i/500), fmt.Sprintf("u%07d.dat", i))
+		content := make([]byte, size)
+		_, _ = rng.Read(content)
+		f, err := write(root, rel, content)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
 // PlantSized writes one incompressible (random) file per requested size, with
 // unique basenames. Size 0 yields an empty file.
 func PlantSized(root string, rng *rand.Rand, sizes []int) ([]File, error) {

--- a/pkg/corpus/corpus_test.go
+++ b/pkg/corpus/corpus_test.go
@@ -66,3 +66,26 @@ func TestProfileByNameUnknown(t *testing.T) {
 	_, ok := ProfileByName("does-not-exist")
 	assert.False(t, ok)
 }
+
+// TestUniformProfile plants exactly n files of the requested size and is
+// byte-reproducible — the parametric corpus for the #466 crossover sweep.
+func TestUniformProfile(t *testing.T) {
+	p := UniformProfile(37, 4096)
+	a, err := p.Plant(t.TempDir())
+	require.NoError(t, err)
+	b, err := p.Plant(t.TempDir())
+	require.NoError(t, err)
+
+	require.Len(t, a, 37)
+	for _, f := range a {
+		assert.Equal(t, 4096, f.Size, "every uniform file is the requested size")
+	}
+	sums := func(fs []File) map[string]string {
+		m := make(map[string]string, len(fs))
+		for _, f := range fs {
+			m[f.RelPath] = f.Sum
+		}
+		return m
+	}
+	assert.Equal(t, sums(a), sums(b), "uniform profile must be byte-reproducible")
+}

--- a/pkg/corpus/profiles.go
+++ b/pkg/corpus/profiles.go
@@ -1,6 +1,9 @@
 package corpus
 
-import "math/rand" // nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- non-crypto: reproducible synthetic corpus content, seeded for determinism
+import (
+	"fmt"
+	"math/rand" // nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- non-crypto: reproducible synthetic corpus content, seeded for determinism
+)
 
 // Profile is a named, reproducible corpus. Plant writes it under root and
 // returns the planted files. Each profile seeds its own RNG from a fixed seed,
@@ -55,6 +58,18 @@ func Profiles() []Profile {
 			Name: "hostile", Desc: "awkward names/sizes/nesting, tiny edge cases", seed: 0x686F7374,
 			gen: func(root string, rng *rand.Rand) ([]File, error) { return PlantHostile(root, rng, 0) },
 		},
+	}
+}
+
+// UniformProfile returns a reproducible profile of n files each exactly size
+// bytes (incompressible). Used by the #466 direct-vs-packed crossover sweep to
+// vary file count at a fixed file size.
+func UniformProfile(n, size int) Profile {
+	return Profile{
+		Name: fmt.Sprintf("uniform-%dx%dB", n, size),
+		Desc: fmt.Sprintf("%d incompressible files of %d bytes each", n, size),
+		seed: 0x53574550, // "SWEP"
+		gen:  func(root string, rng *rand.Rand) ([]File, error) { return PlantUniform(root, rng, n, size) },
 	}
 }
 


### PR DESCRIPTION
## What

Documents the `cargoship-bench` round-trip harness in `docs/reference/benchmarks.md` and adds the parametric corpus the crossover sweep needs.

**Doc section** covers: how to run the harness (real S3 / emulator), the reproducible corpora + seeds, how each metric and cost line is measured (effective throughput, middleware-counted requests, ingress-free cost model), a recorded dated baseline with provenance, and the #466 direct-vs-packed crossover sweep. "Fastest/cheapest" stays flagged **Aspirational** pending a competitor comparison.

**Tooling:** `corpus.PlantUniform` / `UniformProfile` (N files of a fixed size, byte-reproducible) + `cargoship-bench --files/--file-size`, so the crossover measurement is repeatable.

## Crossover sweep result (real S3, 64 KB files)

No single-axis crossover — direct uploads faster for medium-small files, but packing restores far faster and costs far fewer requests at every count. Direct restore is a flat ~1.2 MB/s because `BatchRestore` downloads serially (filed **#472**); the conservative `DirectUploadMaxFiles=1000` cap (#466) is validated as a reasonable default.

## Notes on "regression baselines"

The harness is a **manual, real-AWS** measurement whose numbers depend on network path and region, so a strict CI regression gate would be flaky (same reason `perf-regression-check` is chunking-only/non-blocking). The doc records the baseline (dated, with provenance) for manual comparison, and the `--json` output supports saving/diffing your own; CI-stable regression stays with the existing microbenchmark suite + `benchstat`.

Adds `TestUniformProfile`; capabilities guard passes.