### PR TITLE
fix(restore): resolve a file by its full path before basename ambiguity (#475)

### DIFF
--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -631,23 +631,34 @@ func (se *SelectiveExtractor) resolveEntry(target string) *FileEntry {
 		return entry
 	}
 	clean := filepath.Clean(target)
-	base := filepath.Base(clean)
-	var suffixMatch *FileEntry
-	for i := range se.manifest.Files {
-		p := se.manifest.Files[i].Path
-		// e.g. target "sub/greeting.txt" matching stored "/abs/root/sub/greeting.txt"
-		if p == clean || strings.HasSuffix(p, string(filepath.Separator)+clean) {
-			return &se.manifest.Files[i]
-		}
-		if filepath.Base(p) == base {
-			if suffixMatch != nil {
-				// Ambiguous basename; require a more specific target.
-				return nil
+	// When the target carries a path (not a bare basename), match it exactly or by
+	// path-suffix across ALL entries FIRST, so a unique suffix match always wins
+	// even when many files share the basename. (The previous single-pass resolver
+	// bailed on basename ambiguity before it could reach the target's suffix match,
+	// so a fully-qualified path failed whenever ≥2 other files shared its basename
+	// earlier in the manifest — 46% of a random ~/src sample, since source trees are
+	// full of repeated names like abort.d.ts / __init__.py.)
+	if strings.ContainsRune(clean, filepath.Separator) {
+		for i := range se.manifest.Files {
+			p := se.manifest.Files[i].Path
+			if p == clean || strings.HasSuffix(p, string(filepath.Separator)+clean) {
+				return &se.manifest.Files[i]
 			}
-			suffixMatch = &se.manifest.Files[i]
 		}
 	}
-	return suffixMatch
+	// Bare basename (e.g. `--file greeting.txt`), or a path with no suffix match:
+	// resolve by basename, but only when it is unambiguous.
+	base := filepath.Base(clean)
+	var basenameMatch *FileEntry
+	for i := range se.manifest.Files {
+		if filepath.Base(se.manifest.Files[i].Path) == base {
+			if basenameMatch != nil {
+				return nil // ambiguous basename; require a more specific target
+			}
+			basenameMatch = &se.manifest.Files[i]
+		}
+	}
+	return basenameMatch
 }
 
 // writeDirectFiles writes direct-upload objects (raw file bytes, one object per

--- a/pkg/manifest/batch_restore_test.go
+++ b/pkg/manifest/batch_restore_test.go
@@ -269,6 +269,34 @@ func TestBatchRestore_UnknownTarget_IncrementsFailed(t *testing.T) {
 	assert.Equal(t, int64(0), stats.ChunksDownloaded)
 }
 
+// TestResolveEntry_UniquePathWinsOverAmbiguousBasename guards the restore bug the
+// ~/src dog-food surfaced: a fully-qualified relative path must resolve to its
+// exact file even when other files share the basename (and appear earlier in the
+// manifest). The old single-pass resolver bailed on basename ambiguity before
+// reaching the target's suffix match, failing ~46% of a real source-tree sample.
+func TestResolveEntry_UniquePathWinsOverAmbiguousBasename(t *testing.T) {
+	m := &Manifest{Files: []FileEntry{
+		{Path: "/root/a/dup.txt", S3Key: "k1"},
+		{Path: "/root/b/dup.txt", S3Key: "k2"},
+		{Path: "/root/c/dup.txt", S3Key: "k3"}, // target: two same-basename files precede it
+		{Path: "/root/x/only.txt", S3Key: "k4"},
+	}}
+	se := NewSelectiveExtractor(m, &mockS3Client{}, 0)
+
+	// A unique full relative path resolves to the exact file despite the collisions.
+	got := se.resolveEntry("c/dup.txt")
+	require.NotNil(t, got, "unique path must resolve even with ambiguous basename")
+	assert.Equal(t, "/root/c/dup.txt", got.Path)
+
+	// A bare, genuinely-ambiguous basename still returns nil (unchanged).
+	assert.Nil(t, se.resolveEntry("dup.txt"), "bare ambiguous basename stays unresolved")
+
+	// A unique bare basename still resolves.
+	got = se.resolveEntry("only.txt")
+	require.NotNil(t, got)
+	assert.Equal(t, "/root/x/only.txt", got.Path)
+}
+
 func TestBatchRestore_EmptyTargets(t *testing.T) {
 	m := build100FileManifest()
 	se := NewSelectiveExtractor(m, &mockS3Client{}, 0)


### PR DESCRIPTION
## What

Found by the ~/src scale dog-food. `resolveEntry` matched exact/suffix paths and detected basename ambiguity in a **single pass**, so if ≥2 files sharing the target's basename appeared *before* it in the manifest, the ambiguity guard returned `nil` before the target's suffix match was reached. A fully-qualified relative path then failed for any common basename — **29 of a random 63-file ~/src sample** (`abort.d.ts`, `__init__.py`, `run_tests.py`, …, which are everywhere in node_modules / venvs).

## Fix

Two passes: when the target carries a path separator, match exact/suffix across **all** entries first (a unique suffix always wins); only fall back to bare-basename matching (unambiguous-only) when there's no path match.

## Verified on the real archive

Re-restoring the same sample against the real 811K-file / 1307-chunk dog-food archive went **34/63 → 63/63, all byte-identical**. Regression test `TestResolveEntry_UniquePathWinsOverAmbiguousBasename` added (verified it fails without the fix).

Fixes #475