### PR TITLE
fix(manifest): make --encrypt-manifest uploads verifiable and restorable (#474)

### DIFF
--- a/cmd/cargoship/cmd/verify.go
+++ b/cmd/cargoship/cmd/verify.go
@@ -3,11 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -105,36 +103,17 @@ Exit Codes:
 			}
 
 			s3Client := s3.NewFromConfig(cfg)
+			kmsClient := kms.NewFromConfig(cfg)
 
-			// Download manifest from S3
-			manifestKey := fmt.Sprintf("%s/uploads/%s/manifest.json.gz", prefix, uploadID)
-			fmt.Printf("📥 Downloading manifest: s3://%s/%s\n", bucket, manifestKey)
-
-			getObjectInput := &s3.GetObjectInput{
-				Bucket: aws.String(bucket),
-				Key:    aws.String(manifestKey),
-			}
-
-			result, err := s3Client.GetObject(ctx, getObjectInput)
+			// Download the manifest, decrypting it when the upload used
+			// --encrypt-manifest. DownloadFromS3WithDecryption transparently
+			// handles both plaintext (manifest.json.gz) and KMS-encrypted
+			// (manifest.encrypted.json.gz) manifests, so `verify` works on
+			// encrypted uploads instead of 404ing on the plaintext name (#474).
+			fmt.Printf("📥 Downloading manifest: s3://%s/%s/uploads/%s/\n", bucket, prefix, uploadID)
+			m, err := manifest.DownloadFromS3WithDecryption(ctx, s3Client, kmsClient, bucket, prefix, uploadID)
 			if err != nil {
 				return fmt.Errorf("failed to download manifest from S3: %w", err)
-			}
-			defer func() {
-				if closeErr := result.Body.Close(); closeErr != nil {
-					fmt.Fprintf(os.Stderr, "Warning: failed to close S3 response body: %v\n", closeErr)
-				}
-			}()
-
-			// Read manifest bytes
-			manifestBytes, err := io.ReadAll(result.Body)
-			if err != nil {
-				return fmt.Errorf("failed to read manifest from S3: %w", err)
-			}
-
-			// Decompress and deserialize manifest
-			m, err := manifest.FromJSONCompressed(manifestBytes)
-			if err != nil {
-				return fmt.Errorf("failed to deserialize manifest: %w", err)
 			}
 
 			fmt.Printf("✅ Manifest downloaded successfully\n\n")

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -454,6 +454,20 @@ func FromJSONCompressed(data []byte) (*Manifest, error) {
 	return FromJSON(jsonData)
 }
 
+// parseManifestJSON deserializes manifest bytes that may or may not be
+// gzip-compressed, dispatching on the gzip magic number (0x1f 0x8b). The
+// encrypted-manifest write path encrypts the COMPRESSED manifest when
+// compress=true, so the plaintext recovered after KMS decryption is itself
+// gzip — feeding it straight to FromJSON produced "invalid character '\x1f'"
+// and made every encrypted manifest unreadable (#474). Auto-detecting here keeps
+// the reader correct regardless of whether the inner payload was compressed.
+func parseManifestJSON(data []byte) (*Manifest, error) {
+	if len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b {
+		return FromJSONCompressed(data)
+	}
+	return FromJSON(data)
+}
+
 // UploadToS3 uploads the manifest to S3
 func (m *Manifest) UploadToS3(ctx context.Context, s3Client *s3.Client, compress bool) error {
 	var data []byte
@@ -610,7 +624,7 @@ func DownloadFromS3WithDecryption(ctx context.Context, s3Client *s3.Client, kmsC
 				if err := json.Unmarshal(decompressed, &encryptedManifest); err == nil {
 					manifestJSON, err := encryption.DecryptManifestBytes(ctx, kmsClient, &encryptedManifest)
 					if err == nil {
-						return FromJSON(manifestJSON)
+						return parseManifestJSON(manifestJSON)
 					}
 				}
 			}
@@ -625,7 +639,7 @@ func DownloadFromS3WithDecryption(ctx context.Context, s3Client *s3.Client, kmsC
 		if err := json.Unmarshal(data, &encryptedManifest); err == nil {
 			manifestJSON, err := encryption.DecryptManifestBytes(ctx, kmsClient, &encryptedManifest)
 			if err == nil {
-				return FromJSON(manifestJSON)
+				return parseManifestJSON(manifestJSON)
 			}
 		}
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1314,3 +1314,34 @@ func TestBuilder_SetEncryption_ClearEncryption(t *testing.T) {
 	manifest = builder.Build()
 	assert.Nil(t, manifest.Encryption)
 }
+
+// TestParseManifestJSON_HandlesPlainAndGzip guards #474: an encrypted manifest is
+// written by encrypting the COMPRESSED manifest, so the plaintext recovered after
+// KMS decryption is gzip. The reader must detect that and decompress rather than
+// feed gzip bytes to json.Unmarshal (which failed with "invalid character
+// '\x1f'", making every encrypted manifest unreadable).
+func TestParseManifestJSON_HandlesPlainAndGzip(t *testing.T) {
+	m := &Manifest{Version: ManifestVersion, UploadID: "u1", Bucket: "b"}
+
+	plain, err := m.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON: %v", err)
+	}
+	gz, err := m.ToJSONCompressed()
+	if err != nil {
+		t.Fatalf("ToJSONCompressed: %v", err)
+	}
+	if len(gz) < 2 || gz[0] != 0x1f || gz[1] != 0x8b {
+		t.Fatalf("compressed manifest is not gzip-framed: %x", gz[:2])
+	}
+
+	for name, data := range map[string][]byte{"plain": plain, "gzip": gz} {
+		got, err := parseManifestJSON(data)
+		if err != nil {
+			t.Fatalf("%s: parseManifestJSON: %v", name, err)
+		}
+		if got.UploadID != "u1" || got.Bucket != "b" {
+			t.Fatalf("%s: round-trip mismatch: %+v", name, got)
+		}
+	}
+}


### PR DESCRIPTION
## Severity: HIGH — encryption made archives unrecoverable

Found by the ~/src scale dog-food. An `--encrypt-manifest` upload could not be verified, inspected, or restored — encrypting the manifest broke recoverability. Two independent causes:

1. **`verify` never looked for the encrypted manifest.** `verify.go` hardcoded `manifest.json.gz` and 404'd on encrypted uploads (which write `manifest.encrypted.json.gz`). Now routed through `DownloadFromS3WithDecryption`, like info/restore/list/download/shell/browse.

2. **The decrypt path itself was broken.** `UploadToS3WithEncryption` encrypts the **compressed** manifest when `compress=true`, so the plaintext recovered after KMS decryption is gzip — but `DownloadFromS3WithDecryption` fed it straight to `FromJSON`, which failed with `invalid character '\x1f'`. So *every* command already using the decryption path (info, restore, list, download, shell, browse, restore_jobs) also failed. Added `parseManifestJSON`, which detects the gzip magic and decompresses, and used it in both decrypt branches.

## Verified end-to-end on real S3

A `--encrypt-manifest` upload (20 files) now:
- `verify` → **PASS** (was 404)
- `info` → prints summary (was `\x1f`)
- `restore --file …` → **byte-identical** (was `\x1f`)

Unit test `TestParseManifestJSON_HandlesPlainAndGzip` covers both plain and gzip inputs.

## Follow-up (not here)

`balance`, `cost`, `delete`, and `dvc` still load via the plaintext path and won't find an encrypted manifest — lower-priority, non-recovery commands.

Fixes #474