### PR TITLE
fix(pipeline): key direct-upload objects by relative path, not basename (#480)

### DIFF
--- a/pkg/pipeline/direct_uploader.go
+++ b/pkg/pipeline/direct_uploader.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -37,6 +39,7 @@ type DirectUploaderConfig struct {
 	S3Client        S3Uploader            // AWS S3 client (interface for testability)
 	Bucket          string                // Target S3 bucket
 	Prefix          string                // S3 key prefix (optional)
+	SourcePath      string                // Source root; keys preserve each file's path relative to it (#480)
 	Workers         int                   // Number of concurrent upload workers
 	MaxRetries      int                   // Maximum upload retry attempts
 	RetryDelay      time.Duration         // Delay between retries
@@ -288,16 +291,26 @@ func (s *DirectUploaderStage) uploadFile(ctx context.Context, file chunking.File
 	return fmt.Errorf("upload failed after %d attempts for %s: %w", s.config.MaxRetries, file.Path, lastErr)
 }
 
-// buildS3Key constructs the S3 key from file path
+// buildS3Key constructs the S3 key for a file, preserving its path relative to
+// the source root so that two files with the same basename in different
+// directories get distinct keys. Keying by basename alone (the old behavior)
+// made same-basename files collide: the second upload overwrote the first and
+// restore silently returned the survivor's bytes for both (#480). Falls back to
+// the basename when no source root is set or the file lies outside it.
 func (s *DirectUploaderStage) buildS3Key(filePath string) string {
-	// Get relative path from file path
 	relPath := filepath.Base(filePath)
-
-	// Add prefix if configured
-	if s.config.Prefix != "" {
-		return filepath.Join(s.config.Prefix, relPath)
+	if s.config.SourcePath != "" {
+		if rel, err := filepath.Rel(s.config.SourcePath, filePath); err == nil &&
+			rel != "" && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel) {
+			relPath = rel
+		}
 	}
+	// S3 keys are always slash-separated, regardless of host OS.
+	relPath = filepath.ToSlash(relPath)
 
+	if s.config.Prefix != "" {
+		return path.Join(s.config.Prefix, relPath)
+	}
 	return relPath
 }
 

--- a/pkg/pipeline/direct_uploader_test.go
+++ b/pkg/pipeline/direct_uploader_test.go
@@ -581,3 +581,40 @@ func BenchmarkDirectUploaderStage_MultipleFiles(b *testing.B) {
 		_ = uploader.Stop()
 	}
 }
+
+// TestDirectUploaderStage_BuildS3Key_PreservesRelativePath guards #480: two files
+// with the same basename in different directories must get DISTINCT keys, or the
+// second silently overwrites the first in S3 and restore returns the wrong bytes.
+func TestDirectUploaderStage_BuildS3Key_PreservesRelativePath(t *testing.T) {
+	ctx := context.Background()
+	poolConfig := &AdaptiveWorkerPoolConfig{InitialWorkers: 2, MaxWorkers: 2, EnableAdaptive: false}
+	config := &DirectUploaderConfig{
+		S3Client:   &mockS3Client{},
+		Bucket:     "b",
+		Prefix:     "p",
+		SourcePath: "/src/root",
+		WorkerPool: NewAdaptiveWorkerPool(ctx, poolConfig),
+	}
+	up, err := NewDirectUploaderStage(config, make(chan *Job), make(chan *Job))
+	if err != nil {
+		t.Fatalf("create uploader: %v", err)
+	}
+	defer func() { _ = up.Stop() }()
+
+	a := up.buildS3Key("/src/root/dirA/README.md")
+	b := up.buildS3Key("/src/root/dirB/README.md")
+	if a != "p/dirA/README.md" {
+		t.Errorf("dirA key = %q, want p/dirA/README.md", a)
+	}
+	if b != "p/dirB/README.md" {
+		t.Errorf("dirB key = %q, want p/dirB/README.md", b)
+	}
+	if a == b {
+		t.Fatalf("same-basename files collided on one key %q", a)
+	}
+
+	// A file outside the source root falls back to the basename.
+	if out := up.buildS3Key("/elsewhere/x.txt"); out != "p/x.txt" {
+		t.Errorf("fallback key = %q, want p/x.txt", out)
+	}
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -508,6 +508,7 @@ func (p *Pipeline) startStages(ctx context.Context, rootPath string) error {
 			S3Client:        p.config.S3Client.(S3Uploader),
 			Bucket:          p.config.S3Bucket,
 			Prefix:          p.config.S3Prefix,
+			SourcePath:      p.config.SourcePath, // #480: keys preserve directory structure
 			Workers:         p.config.DirectUploadWorkers,
 			MaxRetries:      3,
 			RetryDelay:      time.Second,


### PR DESCRIPTION
## Severity: CRITICAL — silent data corruption on the default path

Found by the tree-shake asymmetry audit + reproduced on real S3.

`DirectUploaderStage.buildS3Key` keyed each object as `Join(prefix, filepath.Base(path))`, discarding directory structure. Two files with the same basename in different directories but different content (two `README.md`, `index.js`, `__init__.py`, `package.json`, …) mapped to the **same S3 key**: the second `PutObject` overwrote the first, both manifest `FileEntry`s pointed at the survivor, and restore wrote the survivor's bytes to **both** paths — silently returning the wrong content for one. Direct mode records no per-file checksum, so restore-time verification couldn't catch it.

This is the #468 collision class, still live on the **direct-upload path**, which is auto-selected by default for small datasets (≤1000 files, <500 MB, avg <5 MB). Untested because every test/torture corpus used unique basenames (same blind spot as #475).

## Fix

Add `SourcePath` to `DirectUploaderConfig` and key each object by its path **relative to the source root** (slash-normalized), falling back to the basename when no root is set or the file lies outside it. Restore already writes by `FileEntry.Path`, so the relative key and the restored layout stay consistent.

## Verified on real S3

`dirA/README.md` ("A") + `dirB/README.md` ("B") — before: `dirA/README.md` restored as **"B"** (corruption), restore reported success. After: both restore **byte-identical**. Regression test `TestDirectUploaderStage_BuildS3Key_PreservesRelativePath` asserts distinct keys.

Fixes #480