### PR TITLE
fix(dedup): patch duplicate FileEntry locations post-upload so they restore (#481)

### DIFF
--- a/pkg/manifest/deduplication_test.go
+++ b/pkg/manifest/deduplication_test.go
@@ -478,3 +478,64 @@ func TestUpdateFileLocationByPath_NonexistentFile(t *testing.T) {
 		t.Error("Expected error for non-existent file")
 	}
 }
+
+// TestBuilder_PatchDuplicateLocations guards #481: a duplicate FileEntry recorded
+// at scan time with an empty S3Key must be patched to the real location of its
+// content's first occurrence, or the duplicate is unrestorable.
+func TestBuilder_PatchDuplicateLocations(t *testing.T) {
+	dir := t.TempDir()
+	orig := filepath.Join(dir, "a", "orig.bin")
+	dup := filepath.Join(dir, "b", "dup.bin")
+	for _, p := range []string{orig, dup} {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("identical content for dedup"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	idx := NewFileDeduplicationIndex()
+	// First occurrence → unique; second → duplicate (index maps hash → orig path).
+	if _, _, err := idx.AddFile(orig, -1, -1, ""); err != nil {
+		t.Fatal(err)
+	}
+	isDup, loc, err := idx.AddFile(dup, -1, -1, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isDup {
+		t.Fatal("second identical file should be a duplicate")
+	}
+
+	b, err := NewBuilder("u1", dir, "bucket", "prefix", "us-west-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The original entry as it looks AFTER upload (real S3Key filled in).
+	b.AddFile(FileEntry{Path: orig, S3Key: "prefix/a/orig.bin", ChunkID: 3, ShardID: 1})
+	// The duplicate as scan time recorded it: placeholder empty key, ChunkID -1.
+	b.AddFile(FileEntry{Path: dup, IsDuplicate: true, DuplicateOfHash: loc.Hash, ChunkID: -1, ShardID: -1})
+
+	b.PatchDuplicateLocations(idx)
+
+	m := b.Build()
+	var got *FileEntry
+	for i := range m.Files {
+		if m.Files[i].Path == dup {
+			got = &m.Files[i]
+		}
+	}
+	if got == nil {
+		t.Fatal("duplicate entry missing")
+	}
+	if got.S3Key != "prefix/a/orig.bin" {
+		t.Errorf("duplicate S3Key = %q, want the original's key", got.S3Key)
+	}
+	if got.ChunkID != 3 || got.ShardID != 1 {
+		t.Errorf("duplicate location = chunk %d shard %d, want 3/1", got.ChunkID, got.ShardID)
+	}
+	if got.OriginalS3Key != "prefix/a/orig.bin" {
+		t.Errorf("OriginalS3Key = %q, want the original's key", got.OriginalS3Key)
+	}
+}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -351,6 +351,55 @@ func (b *Builder) UpdateFileS3KeyByPath(path string, shardID int, s3Key string) 
 	}
 }
 
+// PatchDuplicateLocations fills in the real chunk/object location for every
+// duplicate FileEntry (#481). A duplicate is recorded at SCAN time with the
+// placeholder location the dedup index held then — an empty S3Key and ChunkID
+// -1 — because the file's real location isn't known until its content's first
+// occurrence has been uploaded. Left unpatched, a duplicate has S3Key "" and is
+// unrestorable (restore keys on S3Key; an empty key even aborts the whole
+// restore via the glacier pre-flight). Call after uploads complete, before
+// Finalize.
+//
+// The index maps a content hash to the first occurrence's PATH (set at scan
+// time, so it's available in both direct and chunked modes); the original's own
+// FileEntry has the real S3Key by now (patched by UpdateFileS3Keys /
+// UpdateFileS3KeyByPath). So we resolve each duplicate through the original
+// entry, which works regardless of upload mode.
+func (b *Builder) PatchDuplicateLocations(index *FileDeduplicationIndex) {
+	if index == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	origByPath := make(map[string]*FileEntry)
+	for i := range b.manifest.Files {
+		if f := &b.manifest.Files[i]; !f.IsDuplicate {
+			origByPath[f.Path] = f
+		}
+	}
+	for i := range b.manifest.Files {
+		f := &b.manifest.Files[i]
+		if !f.IsDuplicate {
+			continue
+		}
+		loc := index.FindFile(f.DuplicateOfHash)
+		if loc == nil {
+			continue
+		}
+		orig := origByPath[loc.Path]
+		if orig == nil || orig.S3Key == "" {
+			continue // original not found / not yet located; leave as-is
+		}
+		f.S3Key = orig.S3Key
+		f.ChunkID = orig.ChunkID
+		f.ShardID = orig.ShardID
+		f.OriginalS3Key = orig.S3Key
+		f.OriginalChunkID = orig.ChunkID
+		f.OriginalShardID = orig.ShardID
+	}
+}
+
 // Finalize completes the manifest and returns it (thread-safe)
 func (b *Builder) Finalize() *Manifest {
 	b.mu.Lock()

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -850,6 +850,10 @@ func (p *Pipeline) uploadManifest(ctx context.Context) error {
 	// Issue #108: Export deduplication metadata if enabled
 	if p.dedupEnabled && p.dedupIndex != nil {
 		dedupIndex := p.dedupIndex.(*manifest.FileDeduplicationIndex)
+		// #481: duplicate FileEntries were recorded at scan time with a placeholder
+		// empty S3Key; fill in each one's real location (from its content's first
+		// occurrence, now uploaded) so duplicates are restorable.
+		builder.PatchDuplicateLocations(dedupIndex)
 		dedupMetadata := dedupIndex.ExportToManifest()
 		builder.SetDeduplication(dedupMetadata)
 


### PR DESCRIPTION
## Severity: CRITICAL — `--enable-dedup` (advertised feature) lost data

Found by the tree-shake flag-gap audit + reproduced on real S3.

With `--enable-dedup`, a duplicate file's manifest `FileEntry` was written at **scan time** from the dedup index's placeholder location — empty `S3Key`, `ChunkID -1` — because the real location isn't known until the content's first occurrence is uploaded. The index is later updated with the real location, but the manifest entry kept the empty key (it's patched by `ChunkID`, and duplicates have `-1`).

Restore keys on `entry.S3Key`, so duplicates were unrestorable. Worse: the empty key resolves to the bare prefix, and the glacier pre-flight `HeadObject` 404s on it → **the entire restore aborts** (not just the duplicate). `verify --deep` skips duplicates, so it couldn't catch it.

## Fix

`Builder.PatchDuplicateLocations`, called after uploads complete (before `Finalize`): for each duplicate, look up its content's first occurrence via the index (`hash → original path`, recorded at scan time) and copy that original `FileEntry`'s now-real `S3Key/ChunkID/ShardID`. Resolving through the original's **manifest entry** works in both direct and chunked modes (the index itself only gets real locations in chunked mode).

## Verified on real S3

3 files, one a content-duplicate, `--enable-dedup`: before → restoring all three **aborted entirely**; after → all three restore **byte-identical**. Regression test `TestBuilder_PatchDuplicateLocations` confirms the patch and **fails without it**.

Note: `verify` still skips duplicates (the original is verified); making it confirm the duplicate's `OriginalS3Key` exists is a possible hardening follow-up.

Fixes #481