### PR TITLE
fix(balance): decode rebalance chunks by key extension, not top-level type (#482)

### DIFF
--- a/pkg/manifest/batch_restore.go
+++ b/pkg/manifest/batch_restore.go
@@ -748,6 +748,14 @@ func (se *SelectiveExtractor) downloadChunk(ctx context.Context, s3Key string) (
 	return data, nil
 }
 
+// ChunkCompression is the exported entry point to chunkCompression, for callers
+// outside this package (e.g. the rebalance path) that must decode a chunk by its
+// per-chunk key extension rather than the manifest's single top-level type (#452,
+// #482). One implementation, so the two can never drift.
+func ChunkCompression(s3Key, manifestType string) string {
+	return chunkCompression(s3Key, manifestType)
+}
+
 // chunkCompression returns the decompression a chunk needs. The chunk's S3 key
 // extension is authoritative when present — the per-chunk signal the format spec
 // documents (#452) — because the manifest's top-level compression_type is a

--- a/pkg/manifest/mixed_compression_test.go
+++ b/pkg/manifest/mixed_compression_test.go
@@ -24,6 +24,12 @@ func TestChunkCompression(t *testing.T) {
 	assert.Equal(t, "zstd", chunkCompression("x/chunk-0", "zstd"))
 	assert.Equal(t, "zstd", chunkCompression("x/chunk-0", "")) // historical default
 	assert.Equal(t, "none", chunkCompression("x/chunk-0", "none"))
+
+	// The exported wrapper (used by the rebalance path, #482) must agree — so
+	// `balance --execute` decodes a mixed upload's plain .tar chunk as plain tar
+	// instead of wrapping a zstd reader around it.
+	assert.Equal(t, "none", ChunkCompression("x/chunk-0.tar", "zstd"))
+	assert.Equal(t, "zstd", ChunkCompression("x/chunk-0.tar.zst", "none"))
 }
 
 // TestVerifyFilesDuplicateChunkIDsAcrossShards is the #455 regression guard:

--- a/pkg/pipeline/rebalance.go
+++ b/pkg/pipeline/rebalance.go
@@ -500,9 +500,12 @@ func downloadAndExtractFiles(ctx context.Context, s3Client *s3.Client, bucket st
 		_ = result.Body.Close()
 	}()
 
-	// Decompress based on compression type
+	// Decompress by the chunk's KEY EXTENSION, not the manifest's single
+	// top-level compression_type (#452/#482): a mixed upload holds both .tar.zst
+	// and plain .tar chunks under one "zstd" type, so decoding by that type wraps
+	// a zstd reader around a plain tar and extracts nothing.
 	var decompressor io.Reader
-	switch compressionType {
+	switch manifest.ChunkCompression(chunkKey, compressionType) {
 	case "zstd":
 		decoder, err := zstd.NewReader(result.Body)
 		if err != nil {
@@ -510,9 +513,9 @@ func downloadAndExtractFiles(ctx context.Context, s3Client *s3.Client, bucket st
 		}
 		defer decoder.Close()
 		decompressor = decoder
-	case "gzip", "gz":
+	case "gzip":
 		return nil, fmt.Errorf("gzip compression not yet supported for rebalancing")
-	case "none", "":
+	case "none":
 		decompressor = result.Body
 	default:
 		return nil, fmt.Errorf("unsupported compression type: %s", compressionType)


### PR DESCRIPTION
`rebalance.go`'s `downloadAndExtractFiles` wrapped a zstd reader around every chunk based on the manifest's single top-level `compression_type`, ignoring the chunk's `.tar` vs `.tar.zst` key — the exact #452 mistake, still live in the rebalance path after restore/verify were fixed. `balance --execute` on a mixed-compressibility upload (which has plain `.tar` chunks) errored trying to zstd-decode a plain tar.

**Safe** (aborts before Step 6 deletes source chunks — no data loss), but rebalance was unusable on mixed uploads.

Route the decoder choice through `manifest.ChunkCompression(chunkKey, type)` — a new exported wrapper over the same `chunkCompression` the restore/verify paths use, so the two can't drift. Test guards the exported contract for `.tar` vs `.tar.zst`.

Note: full rebalance-on-mixed-upload extraction coverage needs an emulator test (`downloadAndExtractFiles` takes a concrete `*s3.Client`, not mockable) — follow-up.

Fixes #482