### PR TITLE
fix(cmd): read encrypted manifests in balance/cost/delete/dvc (#479)

### DIFF
--- a/cmd/cargoship/cmd/balance.go
+++ b/cmd/cargoship/cmd/balance.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/spf13/cobra"
@@ -98,11 +99,12 @@ func runBalance(cmd *cobra.Command, args []string) error {
 
 	// Create S3 client
 	s3Client := s3.NewFromConfig(awsCfg)
+	kmsClient := kms.NewFromConfig(awsCfg)
 
-	// Download manifest
-	fmt.Printf("📥 Downloading manifest from s3://%s/%s/uploads/%s/manifest.json.gz\n", bucket, prefix, uploadID)
+	// Download manifest (decryption-aware: handles --encrypt-manifest uploads, #479)
+	fmt.Printf("📥 Downloading manifest from s3://%s/%s/uploads/%s/\n", bucket, prefix, uploadID)
 
-	m, err := manifest.DownloadFromS3(ctx, s3Client, bucket, prefix, uploadID)
+	m, err := manifest.DownloadFromS3WithDecryption(ctx, s3Client, kmsClient, bucket, prefix, uploadID)
 	if err != nil {
 		return fmt.Errorf("failed to download manifest: %w", err)
 	}

--- a/cmd/cargoship/cmd/cost.go
+++ b/cmd/cargoship/cmd/cost.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/spf13/cobra"
 
@@ -818,35 +818,12 @@ func runCostUpload(ctx context.Context, region, bucket, prefix, uploadID string,
 	}
 
 	s3Client := s3.NewFromConfig(awsCfg)
+	kmsClient := kms.NewFromConfig(awsCfg)
 
-	// Build manifest key
-	manifestKey := fmt.Sprintf("%s/uploads/%s/manifest.json.gz", prefix, uploadID)
-
-	// Download manifest
-	getObjectInput := &s3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(manifestKey),
-	}
-
-	result, err := s3Client.GetObject(ctx, getObjectInput)
+	// Download manifest (decryption-aware: handles --encrypt-manifest uploads, #479).
+	m, err := manifest.DownloadFromS3WithDecryption(ctx, s3Client, kmsClient, bucket, prefix, uploadID)
 	if err != nil {
 		return fmt.Errorf("failed to download manifest from S3: %w", err)
-	}
-	defer func() {
-		if cerr := result.Body.Close(); cerr != nil {
-			slog.Warn("failed to close manifest body", "error", cerr)
-		}
-	}()
-
-	// Read and decompress manifest
-	manifestBytes, err := io.ReadAll(result.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read manifest: %w", err)
-	}
-
-	m, err := manifest.FromJSONCompressed(manifestBytes)
-	if err != nil {
-		return fmt.Errorf("failed to parse manifest: %w", err)
 	}
 
 	// Calculate total compressed size

--- a/cmd/cargoship/cmd/delete.go
+++ b/cmd/cargoship/cmd/delete.go
@@ -4,13 +4,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/dustin/go-humanize"
@@ -74,32 +74,14 @@ Examples:
 			}
 
 			s3Client := s3.NewFromConfig(cfg)
+			kmsClient := kms.NewFromConfig(cfg)
 
-			// Download manifest to get all S3 keys
-			manifestKey := fmt.Sprintf("%s/uploads/%s/manifest.json.gz", prefix, uploadID)
-			fmt.Printf("📥 Loading manifest: s3://%s/%s\n", bucket, manifestKey)
-
-			getObjectInput := &s3.GetObjectInput{
-				Bucket: aws.String(bucket),
-				Key:    aws.String(manifestKey),
-			}
-
-			result, err := s3Client.GetObject(ctx, getObjectInput)
+			// Download manifest (decryption-aware: handles --encrypt-manifest uploads,
+			// #479 — a delete that can't read the manifest would orphan objects).
+			fmt.Printf("📥 Loading manifest: s3://%s/%s/uploads/%s/\n", bucket, prefix, uploadID)
+			m, err := manifest.DownloadFromS3WithDecryption(ctx, s3Client, kmsClient, bucket, prefix, uploadID)
 			if err != nil {
 				return fmt.Errorf("failed to download manifest from S3: %w", err)
-			}
-
-			// Read manifest
-			manifestBytes, err := io.ReadAll(result.Body)
-			_ = result.Body.Close()
-			if err != nil {
-				return fmt.Errorf("failed to read manifest: %w", err)
-			}
-
-			// Deserialize manifest
-			m, err := manifest.FromJSONCompressed(manifestBytes)
-			if err != nil {
-				return fmt.Errorf("failed to deserialize manifest: %w", err)
 			}
 
 			// Build list of all S3 keys to delete
@@ -110,8 +92,13 @@ Examples:
 				keysToDelete = append(keysToDelete, shard.ChunkKeys...)
 			}
 
-			// Add manifest itself
-			keysToDelete = append(keysToDelete, manifestKey)
+			// Add the manifest object(s): both the plaintext and encrypted names,
+			// since the upload may have used --encrypt-manifest (#479). Deleting a
+			// key that doesn't exist is a harmless no-op.
+			keysToDelete = append(keysToDelete,
+				fmt.Sprintf("%s/uploads/%s/manifest.json.gz", prefix, uploadID),
+				fmt.Sprintf("%s/uploads/%s/manifest.encrypted.json.gz", prefix, uploadID),
+			)
 
 			// Calculate total size
 			var totalCompressedSize int64

--- a/cmd/cargoship/cmd/dvc.go
+++ b/cmd/cargoship/cmd/dvc.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/spf13/cobra"
 
@@ -226,6 +227,7 @@ func loadManifestFromS3URL(ctx context.Context, s3URL, region string) (*manifest
 		return nil, fmt.Errorf("load AWS config: %w", err)
 	}
 	s3Client := s3.NewFromConfig(cfg)
+	kmsClient := kms.NewFromConfig(cfg)
 
 	var actualPrefix, uploadID string
 	if idx := strings.Index(prefix, "/uploads/"); idx != -1 {
@@ -235,7 +237,8 @@ func loadManifestFromS3URL(ctx context.Context, s3URL, region string) (*manifest
 		uploadID = prefix
 	}
 
-	m, err := manifest.DownloadFromS3(ctx, s3Client, bucket, actualPrefix, uploadID)
+	// Decryption-aware: handles --encrypt-manifest uploads (#479).
+	m, err := manifest.DownloadFromS3WithDecryption(ctx, s3Client, kmsClient, bucket, actualPrefix, uploadID)
 	if err != nil {
 		return nil, fmt.Errorf("download manifest: %w", err)
 	}


### PR DESCRIPTION
Follow-up to #474. `verify`/`info`/`restore`/`list`/`download`/`shell`/`browse` were routed through `DownloadFromS3WithDecryption`, but `balance`, `cost`, `delete`, and `dvc` still loaded the manifest via the plaintext-only path (`DownloadFromS3` or a hardcoded `manifest.json.gz` GetObject) and failed on `--encrypt-manifest` uploads. Route all four through `DownloadFromS3WithDecryption` with a KMS client.

`delete` also now targets **both** the plaintext and encrypted manifest object names (deleting a missing key is a no-op) — an unreadable manifest there would orphan objects.

## Verified on real S3

Against an `--encrypt-manifest` upload: `cost upload`, `balance`, and `delete --dry-run` all read the manifest (previously errored).

## Related finding filed separately

While validating this I found **#487**: `delete` builds its object list from `m.Shards`, which is empty for **direct** uploads, so it orphans a direct upload's file objects (dry-run showed "2 objects" for 8 files). Separate fix.

Fixes #479