### PR TITLE
fix(delete): enumerate direct-upload objects so delete/cost don't orphan them (#487)

### DIFF
--- a/cmd/cargoship/cmd/cost.go
+++ b/cmd/cargoship/cmd/cost.go
@@ -826,10 +826,20 @@ func runCostUpload(ctx context.Context, region, bucket, prefix, uploadID string,
 		return fmt.Errorf("failed to download manifest from S3: %w", err)
 	}
 
-	// Calculate total compressed size
+	// Calculate total stored size. Direct uploads (len(Chunks)==0) have no
+	// shards; each file is stored as its own object, uncompressed, so the stored
+	// size is the sum of file sizes (#487 — otherwise cost showed $0).
 	var totalCompressedSize int64
-	for _, shard := range m.Shards {
-		totalCompressedSize += shard.CompressedSize
+	if len(m.Chunks) == 0 {
+		for i := range m.Files {
+			if !m.Files[i].IsDuplicate {
+				totalCompressedSize += m.Files[i].Size
+			}
+		}
+	} else {
+		for _, shard := range m.Shards {
+			totalCompressedSize += shard.CompressedSize
+		}
 	}
 
 	// Calculate storage duration

--- a/cmd/cargoship/cmd/delete.go
+++ b/cmd/cargoship/cmd/delete.go
@@ -84,13 +84,10 @@ Examples:
 				return fmt.Errorf("failed to download manifest from S3: %w", err)
 			}
 
-			// Build list of all S3 keys to delete
-			var keysToDelete []string
-
-			// Add all chunk keys from all shards
-			for _, shard := range m.Shards {
-				keysToDelete = append(keysToDelete, shard.ChunkKeys...)
-			}
+			// Build list of all S3 keys to delete: the upload's data objects
+			// (chunk objects, or one object per file for a direct upload — #487),
+			// then the manifest object(s).
+			keysToDelete := uploadObjectKeys(m)
 
 			// Add the manifest object(s): both the plaintext and encrypted names,
 			// since the upload may have used --encrypt-manifest (#479). Deleting a
@@ -228,4 +225,31 @@ Examples:
 	}
 
 	return cmd
+}
+
+// uploadObjectKeys returns the S3 keys of the data objects an upload stored: the
+// chunk objects for a chunked upload, or one object per file for a DIRECT upload
+// (len(Chunks)==0), where there are no shards/chunks. It de-duplicates and drops
+// empty keys (dedup duplicates reference the original's key). It does NOT include
+// the manifest object(s). Enumerating direct-upload file keys is what keeps
+// `delete` from orphaning a direct upload's objects (#487).
+func uploadObjectKeys(m *manifest.Manifest) []string {
+	seen := make(map[string]bool)
+	var keys []string
+	add := func(k string) {
+		if k != "" && !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	if len(m.Chunks) == 0 {
+		for i := range m.Files {
+			add(m.Files[i].S3Key)
+		}
+		return keys
+	}
+	for i := range m.Chunks {
+		add(m.Chunks[i].S3Key)
+	}
+	return keys
 }

--- a/cmd/cargoship/cmd/delete_test.go
+++ b/cmd/cargoship/cmd/delete_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/scttfrdmn/cargoship/pkg/manifest"
+)
+
+// TestUploadObjectKeys_DirectUpload guards #487: a direct upload has no
+// chunks/shards, so delete must enumerate one object per file — otherwise it
+// deletes only the manifest and orphans every file object.
+func TestUploadObjectKeys_DirectUpload(t *testing.T) {
+	m := &manifest.Manifest{
+		Files: []manifest.FileEntry{
+			{Path: "a/f1.bin", S3Key: "pfx/a/f1.bin"},
+			{Path: "b/f2.bin", S3Key: "pfx/b/f2.bin"},
+			// A dedup duplicate references the original's key — must de-dupe.
+			{Path: "c/f3.bin", S3Key: "pfx/a/f1.bin", IsDuplicate: true},
+		},
+		// no Chunks → direct upload
+	}
+	got := uploadObjectKeys(m)
+	want := map[string]bool{"pfx/a/f1.bin": true, "pfx/b/f2.bin": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %d keys %v, want %d unique", len(got), got, len(want))
+	}
+	for _, k := range got {
+		if !want[k] {
+			t.Errorf("unexpected key %q", k)
+		}
+	}
+}
+
+// TestUploadObjectKeys_Chunked enumerates chunk object keys for a chunked upload.
+func TestUploadObjectKeys_Chunked(t *testing.T) {
+	m := &manifest.Manifest{
+		Chunks: []manifest.ChunkEntry{
+			{ID: 0, ShardID: 0, S3Key: "pfx/uploads/id/shard-0/chunk-0.tar.zst"},
+			{ID: 1, ShardID: 1, S3Key: "pfx/uploads/id/shard-1/chunk-1.tar.zst"},
+		},
+		Files: []manifest.FileEntry{{Path: "x", S3Key: "pfx/uploads/id/shard-0/chunk-0.tar.zst"}},
+	}
+	got := uploadObjectKeys(m)
+	if len(got) != 2 {
+		t.Fatalf("got %d keys %v, want 2 chunk keys", len(got), got)
+	}
+}


### PR DESCRIPTION
`delete` built its object list from `m.Shards[].ChunkKeys`, empty for a **direct** upload (each file is its own object, no chunks/shards). So `cargoship delete` on a direct upload deleted only the manifest and **orphaned every file object** while reporting success — dry-run showed "2 objects" for 8 files. `cost` undercounted identically (stored size from shards → $0 for direct).

`uploadObjectKeys(m)` now returns chunk object keys for a chunked upload, or one de-duplicated object per file for a direct upload; `delete` uses it and `cost` sums file sizes for direct uploads.

**Verified on real S3:** `delete --dry-run` on an 8-file direct upload now lists the file objects + manifest names (was 2). Unit tests cover both manifest shapes.

Fixes #487