### PR TITLE
fix(manifest): record archive_offset for every chunked file + spec/guards (lith contract) (#492/#494)

### DIFF
--- a/docs/reference/format/manifest.md
+++ b/docs/reference/format/manifest.md
@@ -125,7 +125,10 @@ type FileEntry struct {
 	PartIndex  int   `json:"part_index,omitempty"`  // Part index for split files (0 = not split)
 	TotalParts int   `json:"total_parts,omitempty"` // Total parts if split (0 or 1 = not split)
 
-	// Random-access frame index (#436): data offset within the uncompressed tar
+	// Data offset within the chunk's uncompressed tar stream (#436, #492).
+	// Recorded for EVERY file in a chunked upload — framed .tar.zst AND plain
+	// .tar — so a reader can locate a file without walking tar headers. Omitted
+	// only for direct-upload files (each is its own object, no enclosing tar).
 	ArchiveOffset int64 `json:"archive_offset,omitempty"`
 
 	// Optional metadata
@@ -177,6 +180,14 @@ the duplicate to its real bytes without a second copy existing in S3.
 ## `ChunkEntry`
 
 One entry per chunk (one `.tar.zst` or `.tar` object).
+
+::: warning Chunk identity is `(shard_id, id)` or `s3_key`, not `id` alone
+`ChunkEntry.id` restarts at 0 within each shard, so a multi-shard archive has
+several chunks with `id: 0`. A chunk's stable, unique identity is its **`s3_key`**
+(or the `(shard_id, id)` pair). A `FileEntry` therefore joins to its chunk on
+`(shard_id, chunk_id)` or on `s3_key` — never on `chunk_id` alone. Readers should
+key chunks by `s3_key`, which is unambiguous. (#494)
+:::
 
 ```go
 type ChunkEntry struct {

--- a/pkg/pipeline/archiver.go
+++ b/pkg/pipeline/archiver.go
@@ -64,10 +64,13 @@ type framer struct {
 func (f *framer) active() bool { return f != nil && f.encoder != nil && f.frameSize > 0 }
 
 // recordOffset captures a file's data start (the uncompressed tar position right
-// after its header) so the reader can locate it without a tar walk. Call
-// immediately after tw.WriteHeader returns.
+// after its header) so the reader can locate it without a tar walk. Recorded for
+// EVERY chunk — framed OR plain .tar (#492) — because a plain chunk is served by a
+// direct range GET at this offset (no decompression, no frame index). Requires
+// only the uncompressed counter (cwU), not an active framer. Call immediately
+// after tw.WriteHeader returns.
 func (f *framer) recordOffset(job *Job, file chunking.File) {
-	if !f.active() || job == nil {
+	if f == nil || f.cwU == nil || job == nil {
 		return
 	}
 	job.SetFileArchiveOffset(fileChecksumKey(file), f.cwU.n)
@@ -664,8 +667,14 @@ func (s *ArchiverStage) Process(ctx context.Context, job *Job) error {
 			tw = tar.NewWriter(cwU)
 			fr = &framer{tw: tw, encoder: encoder, cwU: cwU, cwC: cwC, frameSize: s.config.FrameSize}
 		} else {
-			// Skip compression - write tar directly
-			tw = tar.NewWriter(pw)
+			// Skip compression — write the tar directly, but still count the
+			// uncompressed tar position so every file's archive_offset is recorded
+			// for random access (#492). No encoder / frameSize, so fr is not
+			// active(): no frames are cut and the byte layout is exactly the plain
+			// .tar as before; the framer only carries the offset counter.
+			cwU := &countingWriter{w: pw}
+			tw = tar.NewWriter(cwU)
+			fr = &framer{tw: tw, cwU: cwU}
 			// Track time saved by skipping compression
 			// Estimate: ~1s per 100MB for zstd compression
 			estimatedTimeSaved := (job.Chunk.TotalSize / (100 * 1024 * 1024)) * int64(time.Second)

--- a/pkg/pipeline/framer_test.go
+++ b/pkg/pipeline/framer_test.go
@@ -96,11 +96,13 @@ func TestFramerCutsFramesAndRecordsOffsets(t *testing.T) {
 	}
 }
 
-// TestFramerInactiveIsNoOp confirms a framer with frameSize 0 (or a nil framer)
-// records nothing and never cuts — the single-frame, pre-2.1 layout.
+// TestFramerInactiveIsNoOp confirms an inactive framer (frameSize 0) never CUTS
+// frames — the single-frame, pre-2.1 layout — but STILL records each file's
+// archive offset as long as it has an uncompressed counter (#492: plain/unframed
+// chunks need offsets too). A nil framer records nothing and is safe to call.
 func TestFramerInactiveIsNoOp(t *testing.T) {
 	var buf bytes.Buffer
-	fr := newTestFramer(t, &buf, 0) // framing disabled
+	fr := newTestFramer(t, &buf, 0) // framing disabled (has cwU, no frame cutting)
 	job := &Job{}
 
 	require.NoError(t, fr.tw.WriteHeader(&tar.Header{Name: "x", Mode: 0644, Size: 3}))
@@ -113,13 +115,18 @@ func TestFramerInactiveIsNoOp(t *testing.T) {
 	fr.finalize()
 
 	assert.False(t, fr.active())
-	assert.Empty(t, fr.frames, "inactive framer must not record frames")
-	assert.Nil(t, job.FileArchiveOffsets(), "inactive framer must not record offsets")
+	assert.Empty(t, fr.frames, "inactive framer must not cut frames")
+	// #492: the offset is recorded (512 = right after the tar header) even though
+	// no frames were cut, so a plain-chunk reader can range-GET the file.
+	assert.Equal(t, map[string]int64{"x": 512}, job.FileArchiveOffsets(),
+		"an inactive framer with a counter still records archive offsets (#492)")
 
-	// A nil framer is safe to call (plain .tar path passes nil).
+	// A nil framer records nothing and is safe to call (defensive).
+	njob := &Job{}
 	var nilFr *framer
 	assert.False(t, nilFr.active())
-	nilFr.recordOffset(job, chunking.File{Path: "y"})
+	nilFr.recordOffset(njob, chunking.File{Path: "y"})
 	require.NoError(t, nilFr.maybeCut())
 	nilFr.finalize()
+	assert.Nil(t, njob.FileArchiveOffsets(), "a nil framer records no offsets")
 }

--- a/pkg/pipeline/torture_test.go
+++ b/pkg/pipeline/torture_test.go
@@ -308,6 +308,27 @@ func tortureRoundTrip(t *testing.T, corpus []genFile, srcDir string, mutate func
 	require.NoError(t, err)
 	require.Equal(t, int64(len(corpus)), m.TotalFiles, "manifest file count should match corpus")
 
+	// #493: each chunk object appears exactly once — no duplicate ChunkEntry per
+	// s3_key. Staging snapshots or chunk-ID collisions (#468) would add partial
+	// extras that a strict manifest reader (lith) rejects.
+	seenKey := map[string]bool{}
+	for _, c := range m.Chunks {
+		require.False(t, seenKey[c.S3Key], "duplicate ChunkEntry for s3_key %q (#493)", c.S3Key)
+		seenKey[c.S3Key] = true
+	}
+	// #492: in a chunked upload, every file records its archive_offset — including
+	// files in a plain .tar chunk — so a random-access reader can range-GET a file
+	// without walking tar headers. (Direct uploads have no chunks; split parts use
+	// the whole-chunk path.)
+	if len(m.Chunks) > 0 {
+		for _, f := range m.Files {
+			if f.IsDuplicate || f.TotalParts > 1 {
+				continue
+			}
+			require.Positive(t, f.ArchiveOffset, "file %s missing archive_offset (#492)", f.Path)
+		}
+	}
+
 	// Restore everything and assert byte-identity by basename.
 	outDir := t.TempDir()
 	se := manifest.NewSelectiveExtractor(m, s3Client, 0)


### PR DESCRIPTION
The three new issues from the external **lith** consumer (scttfrdmn/lith#94) testing the manifest as a random-access contract.

## #492 (fix) — `archive_offset` for every chunked file
Plain `.tar` (and compressed-but-unframed) chunks recorded **no** `archive_offset`: `framer.recordOffset` was gated on `active()` and only the framed writer chain had an uncompressed counter (`cwU`). A reader couldn't locate a file in a plain chunk without walking tar headers. Now the plain path also wraps a `cwU`, and offsets are recorded for **every** file regardless of framing (frame *cutting* stays gated on `active()`).
**Verified on real S3:** a plain `chunk-0.tar` now carries offsets `512 / 2001408 / …` for all files; torture round-trips stay byte-identical.

## #494 (docs) — chunk identity
Documented in the format spec that a chunk's identity is `(shard_id, id)` / `s3_key`, not `id` alone (`id` restarts per shard); files join on `(shard_id, chunk_id)` or `s3_key`.

## #493 (guard) — already fixed by #468
The "duplicate `ChunkEntry` per `s3_key`" it reported was the #468 chunk-ID collision, fixed earlier this session. Verified with three real-S3 repros (multi-batch, multipart, compressible+framed) — all show distinct `s3_key`s. This PR adds torture guards (distinct `s3_key` per chunk + `archive_offset` present for every chunked file) so neither can regress. #493 closed separately with the evidence.

Fixes #492
Fixes #494