### PR TITLE
feat(bench): add rclone runner to cargohold competitor harness (#495)

### DIFF
--- a/benchmarks/cargohold/benchmarks.go
+++ b/benchmarks/cargohold/benchmarks.go
@@ -77,6 +77,8 @@ func runToolBenchmark(tool string, config *BenchmarkConfig, spec ScenarioSpec, d
 		return runS5cmdBenchmark(config, spec, dataDir, result)
 	case "mc":
 		return runMinIOMcBenchmark(config, spec, dataDir, result)
+	case "rclone":
+		return runRcloneBenchmark(config, spec, dataDir, result)
 	case "tar":
 		return runTarBenchmark(config, spec, dataDir, result)
 	default:
@@ -114,6 +116,44 @@ func runS5cmdBenchmark(config *BenchmarkConfig, spec ScenarioSpec, dataDir strin
 
 	if err != nil {
 		return result, fmt.Errorf("s5cmd failed: %w\nOutput: %s", err, string(output))
+	}
+
+	result.UploadDuration = uploadDuration
+	result.UploadThroughputMBps = float64(spec.TotalSize) / (1024 * 1024) / uploadDuration.Seconds()
+
+	return result, nil
+}
+
+// runRcloneBenchmark runs an upload benchmark using rclone's S3 backend. It uses
+// an inline `:s3:` connection string (creds from the environment via env_auth,
+// region from AWS_REGION) so no pre-configured rclone remote is required.
+func runRcloneBenchmark(config *BenchmarkConfig, spec ScenarioSpec, dataDir string, result BenchmarkResult) (BenchmarkResult, error) {
+	rclonePath, err := exec.LookPath("rclone")
+	if err != nil {
+		return result, fmt.Errorf("rclone not found in PATH")
+	}
+
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+	dest := fmt.Sprintf(":s3,provider=AWS,env_auth=true,region=%s:%s/%s/rclone-%s",
+		region, config.Bucket, config.Prefix, config.Scenario)
+
+	metrics := startMetricsCollection()
+
+	startTime := time.Now()
+	cmd := exec.Command(rclonePath, "copy", dataDir, dest,
+		"--transfers", fmt.Sprintf("%d", config.Concurrency),
+		"--s3-no-check-bucket",
+	)
+	output, err := cmd.CombinedOutput()
+	uploadDuration := time.Since(startTime)
+
+	stopMetricsCollection(metrics, &result)
+
+	if err != nil {
+		return result, fmt.Errorf("rclone failed: %w\nOutput: %s", err, string(output))
 	}
 
 	result.UploadDuration = uploadDuration


### PR DESCRIPTION
First increment of #495 (Phase-2 competitor comparison). `benchmarks/cargohold` claimed rclone support but had no runner — the dispatch switch only handled s5cmd/mc/tar. Adds `runRcloneBenchmark` using rclone's inline `:s3,provider=AWS,env_auth=true,region=…:` backend (creds from the environment, no pre-configured remote needed).

**Validated on real S3:** the rclone command form uploads correctly, and a full cargohold `small` run (10k files / 1 GB, `--tools rclone`) benchmarks it end-to-end (35.6s, 28.8 MB/s) and produces results + report.

Remaining #495 work (tracked): the `pkg/s3metrics` CloudWatch request-count reader (fills the never-set `RequestCount`), shared `pkg/corpus` corpora, byte-verify, and fixing the wrong-PID CPU/mem sampler + ignored `-iterations`.

Part of #495.