### PR TITLE
ci(release): fail loudly if the verification report can't attach (#458)

### DIFF
--- a/.github/workflows/real-aws-integration.yml
+++ b/.github/workflows/real-aws-integration.yml
@@ -151,5 +151,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" "${{ steps.report.outputs.path }}" --clobber \
-            || echo "release ${GITHUB_REF_NAME} not found yet — artifact still available in workflow run"
+          # The release is published by a separate workflow on the same tag, so
+          # it may not exist for the first minute or two — retry to absorb that
+          # race. But do NOT swallow a genuine failure (#458): if the upload never
+          # succeeds, fail the step. The report is also kept as a workflow artifact
+          # (previous step), so evidence is never lost even on failure.
+          for attempt in $(seq 1 12); do
+            if gh release upload "${GITHUB_REF_NAME}" "${{ steps.report.outputs.path }}" --clobber; then
+              echo "attached verification report to release ${GITHUB_REF_NAME} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "attempt ${attempt}/12: release ${GITHUB_REF_NAME} not ready or upload failed; retrying in 30s..."
+            sleep 30
+          done
+          echo "::error::failed to attach the verification report to release ${GITHUB_REF_NAME} after 12 attempts (6 min)"
+          exit 1


### PR DESCRIPTION
The "Attach report to release" step swallowed a failed upload with `|| echo`, so a genuine failure looked like success and the release silently lacked its verification report. Replaced with a bounded retry (12×30s = 6 min, to absorb the race where the release is published by a separate workflow on the same tag) that **fails the step** if the upload never succeeds; the report is still kept as a workflow artifact.

Note: this fix was authored during the v0.24.3 cycle but never committed — #497 closed #458 via its message while landing only the #448 deletion. This actually lands it.

Fixes #458