### PR TITLE
feat(cost): pkg/s3cost — reusable itemized S3 cost model (#495)

### DIFF
--- a/pkg/benchharness/harness.go
+++ b/pkg/benchharness/harness.go
@@ -16,10 +16,10 @@ import (
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/scttfrdmn/cargoship/pkg/aws/config"
-	"github.com/scttfrdmn/cargoship/pkg/aws/pricingfallback"
 	"github.com/scttfrdmn/cargoship/pkg/corpus"
 	"github.com/scttfrdmn/cargoship/pkg/manifest"
 	"github.com/scttfrdmn/cargoship/pkg/pipeline"
+	"github.com/scttfrdmn/cargoship/pkg/s3cost"
 	"github.com/scttfrdmn/cargoship/pkg/s3count"
 )
 
@@ -244,39 +244,31 @@ func verifyByteIdentical(files []corpus.File, restoreDir string) (bool, error) {
 	return true, nil
 }
 
-// requestTier maps an S3 operation name to the fallback pricing request type.
-func requestTier(op string) string {
-	switch op {
-	case "PutObject", "CreateMultipartUpload", "UploadPart", "CompleteMultipartUpload", "CopyObject":
-		return "PUT"
-	case "ListObjectsV2", "ListObjects", "ListMultipartUploads", "ListParts":
-		return "LIST"
-	case "GetObject", "HeadObject", "HeadBucket":
-		return "GET"
-	default: // DeleteObject, AbortMultipartUpload, unknown → free tier
-		return "DELETE"
+// computeCost models the STANDARD-class S3 bill from measured counts + stored
+// bytes, via the shared pkg/s3cost model (one cost model for CargoShip and, once
+// competitor request counts are wired, the comparison harness). Ingress is free
+// (#451): the upload leg carries request + monthly-storage cost; the restore leg
+// carries request + egress cost, egress billed on the stored (compressed) bytes
+// that physically leave S3 — so compression cuts egress too.
+func computeCost(storedBytes int64, upload, restore map[string]int) Cost {
+	up := s3cost.Compute(s3cost.Usage{
+		StorageClass: config.StorageClassStandard, Operations: toInt64Counts(upload), StoredBytes: storedBytes,
+	})
+	rs := s3cost.Compute(s3cost.Usage{
+		StorageClass: config.StorageClassStandard, Operations: toInt64Counts(restore), EgressBytes: storedBytes,
+	})
+	return Cost{
+		UploadRequestsUSD:  up.RequestsUSD,
+		MonthlyStorageUSD:  up.MonthlyUSD,
+		RestoreRequestsUSD: rs.RequestsUSD,
+		RestoreEgressUSD:   rs.DataTransfer.USD,
 	}
 }
 
-// computeCost models the STANDARD-class S3 bill from measured counts + stored
-// bytes. Ingress (upload data transfer) is free (#451); storage is monthly;
-// restore includes GET-tier requests + egress ($0.09/GB). Egress is billed on
-// the bytes that physically leave S3 — the stored (compressed) chunk bytes we
-// download, not the decompressed size — so compression cuts egress cost too.
-func computeCost(storedBytes int64, upload, restore map[string]int) Cost {
-	const std = config.StorageClassStandard
-	reqUSD := func(counts map[string]int) float64 {
-		var usd float64
-		for op, n := range counts {
-			usd += (float64(n) / 1000.0) * pricingfallback.RequestPrice(requestTier(op), std)
-		}
-		return usd
+func toInt64Counts(m map[string]int) map[string]int64 {
+	out := make(map[string]int64, len(m))
+	for k, v := range m {
+		out[k] = int64(v)
 	}
-	storedGB := float64(storedBytes) / (1024 * 1024 * 1024)
-	return Cost{
-		UploadRequestsUSD:  reqUSD(upload),
-		MonthlyStorageUSD:  storedGB * pricingfallback.StoragePrice(std),
-		RestoreRequestsUSD: reqUSD(restore),
-		RestoreEgressUSD:   storedGB * 0.09, // $0.09/GB egress on the bytes leaving S3
-	}
+	return out
 }

--- a/pkg/benchharness/harness_test.go
+++ b/pkg/benchharness/harness_test.go
@@ -1,33 +1,58 @@
 package benchharness
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scttfrdmn/cargoship/pkg/aws/config"
 	"github.com/scttfrdmn/cargoship/pkg/aws/pricingfallback"
+	"github.com/scttfrdmn/cargoship/pkg/corpus"
 )
 
-func TestRequestTier(t *testing.T) {
-	cases := map[string]string{
-		"PutObject":               "PUT",
-		"CreateMultipartUpload":   "PUT",
-		"UploadPart":              "PUT",
-		"CompleteMultipartUpload": "PUT",
-		"CopyObject":              "PUT",
-		"ListObjectsV2":           "LIST",
-		"ListParts":               "LIST",
-		"GetObject":               "GET",
-		"HeadObject":              "GET",
-		"DeleteObject":            "DELETE",
-		"AbortMultipartUpload":    "DELETE",
-		"WhoKnows":                "DELETE",
+func sha256hex(b []byte) string {
+	s := sha256.Sum256(b)
+	return hex.EncodeToString(s[:])
+}
+
+func TestVerifyByteIdentical(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, b []byte) corpus.File {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), b, 0o600))
+		return corpus.File{RelPath: name, Base: name, Size: len(b), Sum: sha256hex(b)}
 	}
-	for op, want := range cases {
-		assert.Equal(t, want, requestTier(op), "op %s", op)
+	files := []corpus.File{
+		write("a.txt", []byte("hello")),
+		write("b.txt", []byte("world")),
 	}
+
+	t.Run("all match", func(t *testing.T) {
+		ok, err := verifyByteIdentical(files, dir)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("content mismatch", func(t *testing.T) {
+		bad := append([]corpus.File(nil), files...)
+		bad[0].Sum = sha256hex([]byte("HELLO")) // right file, wrong expected bytes
+		ok, err := verifyByteIdentical(bad, dir)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		bad := append([]corpus.File(nil), files...)
+		bad = append(bad, corpus.File{RelPath: "c.txt", Base: "c.txt", Sum: sha256hex([]byte("x"))})
+		ok, err := verifyByteIdentical(bad, dir)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
 }
 
 func TestMBPerSec(t *testing.T) {

--- a/pkg/s3cost/cost.go
+++ b/pkg/s3cost/cost.go
@@ -1,0 +1,165 @@
+// Package s3cost turns a measured S3 workload — request counts by operation,
+// bytes stored, bytes transferred out — into an itemized dollar cost, using the
+// canonical fallback price table (pkg/aws/pricingfallback).
+//
+// It exists so the benchmark harness can score ANY mover — CargoShip or a
+// competitor (aws s3 cp / s5cmd / rclone) — with one consistent, transparent
+// cost model. The two charges that actually decide "cheapest in class" are:
+//
+//   - S3 request charges. PUT/COPY/POST/LIST are the expensive tier and vary by
+//     storage class; GET/SELECT/HEAD are cheap; DELETE is free. Uploading a
+//     million small files as a million PUTs runs up a real bill that packing
+//     into a handful of chunk PUTs avoids — this model makes that visible.
+//   - Data movement. S3 ingress (upload) is FREE, so an upload's transfer cost
+//     is $0; the billable movement is egress (download/restore) at $/GB, charged
+//     on the bytes that physically leave S3 (compressed, for a client-side
+//     packer like CargoShip — a real saving over a 1:1 mover).
+//
+// Monthly storage is reported separately (it recurs; the others are one-time).
+package s3cost
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/aws/pricingfallback"
+)
+
+// EgressUSDPerGB is the S3 → internet data-transfer-out rate. Ingress (upload)
+// is free, so only egress (download/restore) is billed here. Cross-region
+// replication transfer is out of scope for this model.
+const EgressUSDPerGB = 0.09
+
+const bytesPerGB = 1024 * 1024 * 1024
+
+// Usage is a measured (not estimated) workload for one mover on one dataset.
+type Usage struct {
+	StorageClass config.StorageClass
+	// Operations maps an S3 operation name (as the API/CloudWatch reports it —
+	// PutObject, UploadPart, CompleteMultipartUpload, GetObject, HeadObject,
+	// ListObjectsV2, DeleteObject, …) to how many were issued. Retries should not
+	// be included; count logical operations.
+	Operations map[string]int64
+	// StoredBytes is what S3 holds after the upload — the COMPRESSED size for a
+	// client-side packer, the raw size for a 1:1 mover. Drives monthly storage.
+	StoredBytes int64
+	// EgressBytes is the bytes that leave S3 on download/restore (compressed for a
+	// packer). Zero if the workload is upload-only.
+	EgressBytes int64
+}
+
+// LineItem is one itemized charge. Count is requests (for request tiers) or bytes
+// (for transfer/storage); UnitUSD is per-1,000 requests or per-GB respectively.
+type LineItem struct {
+	Label   string  `json:"label"`
+	Count   int64   `json:"count"`
+	UnitUSD float64 `json:"unit_usd"`
+	USD     float64 `json:"usd"`
+}
+
+// Breakdown is the itemized cost of a Usage.
+type Breakdown struct {
+	// Requests holds one line per billing tier that had operations, most-expensive
+	// first. DELETE (free) is included only if any occurred, at $0.
+	Requests       []LineItem `json:"requests"`
+	DataTransfer   LineItem   `json:"data_transfer"`   // egress; ingress is free
+	MonthlyStorage LineItem   `json:"monthly_storage"` // recurring
+	// Totals.
+	RequestsUSD float64 `json:"requests_usd"` // sum of Requests
+	OneTimeUSD  float64 `json:"one_time_usd"` // requests + egress (cost to move + retrieve once)
+	MonthlyUSD  float64 `json:"monthly_usd"`  // storage per month
+}
+
+// tier maps an S3 operation name to its billing tier ("PUT", "GET", or "DELETE").
+// The tier names match pricingfallback.RequestPrice.
+func tier(op string) string {
+	switch strings.ToUpper(op) {
+	case "PUTOBJECT", "CREATEMULTIPARTUPLOAD", "UPLOADPART", "UPLOADPARTCOPY",
+		"COMPLETEMULTIPARTUPLOAD", "COPYOBJECT", "POSTOBJECT",
+		"LISTOBJECTS", "LISTOBJECTSV2", "LISTMULTIPARTUPLOADS", "LISTPARTS",
+		"LISTBUCKETS", "PUTOBJECTTAGGING":
+		return "PUT"
+	case "GETOBJECT", "GETOBJECTTAGGING", "SELECTOBJECTCONTENT",
+		"HEADOBJECT", "HEADBUCKET", "GETOBJECTATTRIBUTES":
+		return "GET"
+	default:
+		// DeleteObject, DeleteObjects, AbortMultipartUpload, and anything
+		// unrecognized are treated as the free DELETE tier so an unknown op never
+		// silently inflates the bill.
+		return "DELETE"
+	}
+}
+
+// tierLabel is the human label for a billing tier.
+func tierLabel(t string) string {
+	switch t {
+	case "PUT":
+		return "PUT/COPY/POST/LIST requests"
+	case "GET":
+		return "GET/SELECT/HEAD requests"
+	default:
+		return "DELETE/abort requests (free)"
+	}
+}
+
+// Compute returns the itemized cost of a measured Usage.
+func Compute(u Usage) Breakdown {
+	cls := u.StorageClass
+	if cls == "" {
+		cls = config.StorageClassStandard
+	}
+
+	// Aggregate operation counts into billing tiers.
+	byTier := map[string]int64{}
+	for op, n := range u.Operations {
+		byTier[tier(op)] += n
+	}
+
+	var b Breakdown
+	// Emit tiers most-expensive first for readability: PUT, GET, DELETE.
+	for _, t := range []string{"PUT", "GET", "DELETE"} {
+		n, ok := byTier[t]
+		if !ok || n == 0 {
+			continue
+		}
+		unit := pricingfallback.RequestPrice(t, cls) // USD per 1,000 requests
+		cost := (float64(n) / 1000.0) * unit
+		b.Requests = append(b.Requests, LineItem{
+			Label: tierLabel(t), Count: n, UnitUSD: unit, USD: cost,
+		})
+		b.RequestsUSD += cost
+	}
+
+	egressGB := float64(u.EgressBytes) / bytesPerGB
+	b.DataTransfer = LineItem{
+		Label: "data transfer out (egress; ingress free)",
+		Count: u.EgressBytes, UnitUSD: EgressUSDPerGB, USD: egressGB * EgressUSDPerGB,
+	}
+
+	storedGB := float64(u.StoredBytes) / bytesPerGB
+	storageUnit := pricingfallback.StoragePrice(cls)
+	b.MonthlyStorage = LineItem{
+		Label: "storage (per month)",
+		Count: u.StoredBytes, UnitUSD: storageUnit, USD: storedGB * storageUnit,
+	}
+
+	b.OneTimeUSD = b.RequestsUSD + b.DataTransfer.USD
+	b.MonthlyUSD = b.MonthlyStorage.USD
+	return b
+}
+
+// TotalRequests returns the number of billable + free S3 operations in a Usage —
+// the "file operations" count that dominates a many-small-files bill.
+func TotalRequests(u Usage) int64 {
+	ops := make([]string, 0, len(u.Operations))
+	for op := range u.Operations {
+		ops = append(ops, op)
+	}
+	sort.Strings(ops) // deterministic, though the sum is order-independent
+	var n int64
+	for _, op := range ops {
+		n += u.Operations[op]
+	}
+	return n
+}

--- a/pkg/s3cost/cost_test.go
+++ b/pkg/s3cost/cost_test.go
@@ -1,0 +1,83 @@
+package s3cost
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/aws/pricingfallback"
+)
+
+func TestCompute_ItemizesOperationsAndTransfer(t *testing.T) {
+	const std = config.StorageClassStandard
+	u := Usage{
+		StorageClass: std,
+		Operations: map[string]int64{
+			"PutObject":               1,
+			"CreateMultipartUpload":   1,
+			"UploadPart":              5,
+			"CompleteMultipartUpload": 1, // → 8 PUT-tier
+			"ListObjectsV2":           2, // → PUT-tier too (10 total PUT-tier)
+			"GetObject":               3, // → GET-tier
+			"DeleteObject":            4, // → DELETE (free)
+		},
+		StoredBytes: 2 * bytesPerGB, // 2 GiB stored
+		EgressBytes: 1 * bytesPerGB, // 1 GiB egress
+	}
+	b := Compute(u)
+
+	putUnit := pricingfallback.RequestPrice("PUT", std) // 0.005 / 1k
+	getUnit := pricingfallback.RequestPrice("GET", std) // 0.0004 / 1k
+	storeUnit := pricingfallback.StoragePrice(std)      // 0.023 / GB-mo
+
+	// Three tiers present, most-expensive first: PUT(10), GET(3), DELETE(4, free).
+	if assert.Len(t, b.Requests, 3) {
+		assert.Equal(t, int64(10), b.Requests[0].Count) // PUT tier aggregates the 8 upload ops + 2 LIST
+		assert.InDelta(t, 10.0/1000*putUnit, b.Requests[0].USD, 1e-12)
+		assert.Equal(t, int64(3), b.Requests[1].Count) // GET
+		assert.InDelta(t, 3.0/1000*getUnit, b.Requests[1].USD, 1e-12)
+		assert.Equal(t, int64(4), b.Requests[2].Count) // DELETE
+		assert.Zero(t, b.Requests[2].USD, "DELETE is free")
+	}
+
+	assert.InDelta(t, 10.0/1000*putUnit+3.0/1000*getUnit, b.RequestsUSD, 1e-12)
+	assert.InDelta(t, 1.0*EgressUSDPerGB, b.DataTransfer.USD, 1e-12) // 1 GiB egress
+	assert.InDelta(t, 2.0*storeUnit, b.MonthlyStorage.USD, 1e-12)    // 2 GiB stored
+	assert.InDelta(t, b.RequestsUSD+b.DataTransfer.USD, b.OneTimeUSD, 1e-12)
+	assert.InDelta(t, b.MonthlyStorage.USD, b.MonthlyUSD, 1e-12)
+	assert.Equal(t, int64(17), TotalRequests(u)) // 1+1+5+1+2+3+4
+}
+
+// TestCompute_UploadOnlyHasNoTransferCost guards the "ingress is free" property.
+func TestCompute_UploadOnlyHasNoTransferCost(t *testing.T) {
+	b := Compute(Usage{
+		StorageClass: config.StorageClassStandard,
+		Operations:   map[string]int64{"PutObject": 1000},
+		StoredBytes:  10 * bytesPerGB,
+		// EgressBytes: 0 → upload-only
+	})
+	assert.Zero(t, b.DataTransfer.USD, "an upload incurs no data-transfer charge (ingress free)")
+	assert.InDelta(t, pricingfallback.RequestPrice("PUT", config.StorageClassStandard), b.RequestsUSD, 1e-12) // 1000/1000 * unit
+	assert.Positive(t, b.MonthlyUSD)
+	assert.InDelta(t, b.RequestsUSD, b.OneTimeUSD, 1e-12)
+}
+
+// TestCompute_ManySmallFilesRunUpRequestCost is the headline: N direct PUTs cost
+// far more than packing into a few chunk PUTs, at the same stored bytes.
+func TestCompute_ManySmallFilesRunUpRequestCost(t *testing.T) {
+	stored := int64(1 * bytesPerGB)
+	direct := Compute(Usage{StorageClass: config.StorageClassStandard,
+		Operations: map[string]int64{"PutObject": 100000}, StoredBytes: stored})
+	packed := Compute(Usage{StorageClass: config.StorageClassStandard,
+		Operations: map[string]int64{"PutObject": 16, "UploadPart": 4}, StoredBytes: stored})
+	assert.Greater(t, direct.OneTimeUSD, packed.OneTimeUSD*100,
+		"100k PUTs should dwarf a packed handful — the request-cost story")
+}
+
+// TestTier_UnknownOpIsFree ensures an unrecognized op never inflates the bill.
+func TestTier_UnknownOpIsFree(t *testing.T) {
+	assert.Equal(t, "DELETE", tier("SomeFutureOp"))
+	assert.Equal(t, "PUT", tier("uploadpart")) // case-insensitive
+	assert.Equal(t, "GET", tier("HeadObject"))
+}


### PR DESCRIPTION
Part of #495 (Phase-2 competitor benchmarks). Builds the **detailed cost-measurement capability** requested: score any mover's S3 bill from a *measured* workload, around the two charges that decide "cheapest in class":

- **S3 request charges, itemized by tier** — PUT/COPY/POST/LIST (expensive, class-varying), GET/SELECT/HEAD, DELETE (free). Makes "many small PUTs run up the bill" a concrete dollar line vs a packed handful of chunk PUTs.
- **Data movement** — ingress (upload) is free, so egress ($0.09/GB) on the bytes that physically leave S3 (compressed, for a client-side packer) is the billable transfer. Monthly storage reported separately.

`pkg/s3cost.Compute(Usage) Breakdown` via the canonical `pkg/aws/pricingfallback` table. `benchharness.computeCost` now delegates to it (one cost model, no duplicated tier logic). Unit-tested against the fallback prices incl. the many-small-files story; added a `verifyByteIdentical` unit test to keep benchharness coverage above floor after the pricing logic moved out.

Competitor request counts (to score s5cmd/rclone/aws-cp with this same model) come from the server-side reader still tracked in #495 — this is the model they feed.