### PR TITLE
feat(bench): cargohold — reproducible pkg/corpus + byte-verify competitors (#500)

### DIFF
--- a/benchmarks/cargohold/benchmarks.go
+++ b/benchmarks/cargohold/benchmarks.go
@@ -3,14 +3,96 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/scttfrdmn/cargoship/pkg/corpus"
 )
+
+// verifyIfCorpus byte-verifies a completed upload against the source corpus when
+// running in corpus mode. It downloads what the tool wrote to S3 and confirms
+// every file matches by sha256. Mirror-style tools (s5cmd, rclone, mc) preserve
+// the file tree and are verified here; cargohold writes chunked archives
+// (byte-verified separately by pkg/benchharness) and tar writes a single
+// archive, so those log a skip rather than a false failure.
+func verifyIfCorpus(config *BenchmarkConfig, tool string, files []corpus.File, result *BenchmarkResult) {
+	if config.Corpus == "" || len(files) == 0 {
+		return
+	}
+	prefix, ok := mirrorPrefix(tool, config)
+	if !ok {
+		log.Printf("      Verify: skipped for %s (chunked/archive layout — cargoship is verified by pkg/benchharness)", tool)
+		return
+	}
+	n, err := verifyMirrorUpload(config.Bucket, prefix, files)
+	if err != nil {
+		log.Printf("      ❌ Verify FAILED for %s: %v", tool, err)
+		result.ErrorCount++
+		return
+	}
+	result.Verified = true
+	result.VerifiedFiles = n
+}
+
+// mirrorPrefix returns the S3 key prefix a mirror-style tool wrote its file tree
+// under, matching the dest each runner builds. Non-mirror tools return ok=false.
+func mirrorPrefix(tool string, config *BenchmarkConfig) (string, bool) {
+	switch tool {
+	case "s5cmd", "rclone", "mc":
+		return fmt.Sprintf("%s/%s-%s", config.Prefix, tool, config.Scenario), true
+	default: // cargohold (chunked), tar (single archive)
+		return "", false
+	}
+}
+
+// verifyMirrorUpload downloads everything under s3://bucket/prefix/ and confirms
+// every source file is present with byte-identical content (matched by basename,
+// as pkg/benchharness does). Returns the number of files verified.
+func verifyMirrorUpload(bucket, prefix string, files []corpus.File) (int, error) {
+	tmp, err := os.MkdirTemp("", "cargohold-verify-")
+	if err != nil {
+		return 0, err
+	}
+	defer os.RemoveAll(tmp)
+
+	src := fmt.Sprintf("s3://%s/%s/", bucket, prefix)
+	if out, err := exec.Command("aws", "s3", "sync", src, tmp).CombinedOutput(); err != nil {
+		return 0, fmt.Errorf("aws s3 sync %s: %w\n%s", src, err, out)
+	}
+	return compareDownloaded(tmp, files)
+}
+
+// compareDownloaded confirms every source file appears in dir (matched by
+// basename) with a byte-identical sha256. Returns the count verified.
+func compareDownloaded(dir string, files []corpus.File) (int, error) {
+	idx, err := corpus.IndexByBase(dir)
+	if err != nil {
+		return 0, err
+	}
+	for _, f := range files {
+		path, ok := idx[f.Base]
+		if !ok {
+			return 0, fmt.Errorf("file %q missing from upload", f.Base)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			return 0, err
+		}
+		sum := sha256.Sum256(got)
+		if hex.EncodeToString(sum[:]) != f.Sum {
+			return 0, fmt.Errorf("file %q content mismatch (sha256)", f.Base)
+		}
+	}
+	return len(files), nil
+}
 
 // runCargoHoldBenchmark runs a benchmark using CargoHold
 func runCargoHoldBenchmark(config *BenchmarkConfig, spec ScenarioSpec, dataDir, strategy string) (BenchmarkResult, error) {
@@ -86,7 +168,9 @@ func runS5cmdBenchmark(config *BenchmarkConfig, spec ScenarioSpec, dataDir strin
 		return result, fmt.Errorf("s5cmd not found in PATH")
 	}
 
-	s3Dest := fmt.Sprintf("s3://%s/%s/s5cmd-%s/*", config.Bucket, config.Prefix, config.Scenario)
+	// Target must be a plain prefix (s5cmd rejects a glob in the destination);
+	// the source "dir/*" recurses subdirectories.
+	s3Dest := fmt.Sprintf("s3://%s/%s/s5cmd-%s/", config.Bucket, config.Prefix, config.Scenario)
 
 	// Run upload using s5cmd's parallel cp
 	cmd := exec.Command(s5cmdPath,

--- a/benchmarks/cargohold/benchmarks_test.go
+++ b/benchmarks/cargohold/benchmarks_test.go
@@ -4,7 +4,61 @@ import (
 	"fmt"
 	"os/exec"
 	"testing"
+
+	"github.com/scttfrdmn/cargoship/pkg/corpus"
 )
+
+func TestMirrorPrefix(t *testing.T) {
+	cfg := &BenchmarkConfig{Prefix: "bench", Scenario: "small"}
+	for _, tool := range []string{"s5cmd", "rclone", "mc"} {
+		got, ok := mirrorPrefix(tool, cfg)
+		if !ok {
+			t.Fatalf("%s should be a mirror tool", tool)
+		}
+		if want := "bench/" + tool + "-small"; got != want {
+			t.Fatalf("%s prefix = %q, want %q", tool, got, want)
+		}
+	}
+	for _, tool := range []string{"cargohold", "tar"} {
+		if _, ok := mirrorPrefix(tool, cfg); ok {
+			t.Fatalf("%s must NOT be treated as a mirror tool (chunked/archive)", tool)
+		}
+	}
+}
+
+func TestCompareDownloaded(t *testing.T) {
+	dir := t.TempDir()
+	files, err := corpus.UniformProfile(20, 512).Plant(dir)
+	if err != nil {
+		t.Fatalf("plant: %v", err)
+	}
+
+	t.Run("all present and identical", func(t *testing.T) {
+		n, err := compareDownloaded(dir, files)
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		if n != len(files) {
+			t.Fatalf("verified %d, want %d", n, len(files))
+		}
+	})
+
+	t.Run("content mismatch is caught", func(t *testing.T) {
+		bad := append([]corpus.File(nil), files...)
+		bad[0].Sum = "deadbeef"
+		if _, err := compareDownloaded(dir, bad); err == nil {
+			t.Fatal("expected a mismatch error")
+		}
+	})
+
+	t.Run("missing file is caught", func(t *testing.T) {
+		bad := append([]corpus.File(nil), files...)
+		bad = append(bad, corpus.File{Base: "not-uploaded.dat", Sum: "x"})
+		if _, err := compareDownloaded(dir, bad); err == nil {
+			t.Fatal("expected a missing-file error")
+		}
+	})
+}
 
 // TestRunInstrumentedSamplesChild proves the fix for the wrong-PID sampler: a
 // CPU-burning CHILD process must show non-zero CPU, which only happens if we

--- a/benchmarks/cargohold/go.mod
+++ b/benchmarks/cargohold/go.mod
@@ -1,6 +1,8 @@
 module github.com/scttfrdmn/cargoship/benchmarks/cargohold
 
-go 1.23
+go 1.26.0
 
 // Use local cargoship module during development
 replace github.com/scttfrdmn/cargoship => ../..
+
+require github.com/scttfrdmn/cargoship v0.0.0-00010101000000-000000000000

--- a/benchmarks/cargohold/go.sum
+++ b/benchmarks/cargohold/go.sum
@@ -1,0 +1,4 @@
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=

--- a/benchmarks/cargohold/main.go
+++ b/benchmarks/cargohold/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/scttfrdmn/cargoship/pkg/corpus"
 )
 
 // BenchmarkConfig holds configuration for a benchmark run
@@ -22,6 +24,7 @@ type BenchmarkConfig struct {
 	ResultsDir      string   // Results output directory
 	Concurrency     int      // Parallel operations
 	Iterations      int      // Number of runs per test
+	Corpus          string   // shared pkg/corpus profile name; "" == legacy scenario generator
 }
 
 // BenchmarkResult stores results from a single benchmark run
@@ -39,6 +42,8 @@ type BenchmarkResult struct {
 	AvgCPUPercent          float64       `json:"avg_cpu_percent"`
 	RequestCount           int           `json:"request_count,omitempty"`
 	ErrorCount             int           `json:"error_count"`
+	Verified               bool          `json:"verified,omitempty"`       // upload byte-verified against the source corpus
+	VerifiedFiles          int           `json:"verified_files,omitempty"` // files confirmed byte-identical
 	Timestamp              time.Time     `json:"timestamp"`
 }
 
@@ -100,15 +105,28 @@ func main() {
 		log.Fatalf("Failed to create results directory: %v", err)
 	}
 
-	// Generate or verify test data
+	// Prepare test data — either the shared, reproducible pkg/corpus profile
+	// (enables byte-verify) or the legacy scenario generator.
 	spec := scenarios[config.Scenario]
+	dataDir := filepath.Join(config.DataDir, config.Scenario)
+	var corpusFiles []corpus.File
+	if config.Corpus != "" {
+		files, planted, dir, err := plantCorpus(config)
+		if err != nil {
+			log.Fatalf("Failed to plant corpus %q: %v", config.Corpus, err)
+		}
+		corpusFiles, dataDir = files, dir
+		spec = planted
+	} else {
+		if err := ensureTestData(dataDir, spec); err != nil {
+			log.Fatalf("Failed to prepare test data: %v", err)
+		}
+	}
 	log.Printf("📊 Test Scenario: %s", spec.Name)
 	log.Printf("   Files: %d", spec.FileCount)
-	log.Printf("   Total Size: %s\n", formatBytes(spec.TotalSize))
-
-	dataDir := filepath.Join(config.DataDir, config.Scenario)
-	if err := ensureTestData(dataDir, spec); err != nil {
-		log.Fatalf("Failed to prepare test data: %v", err)
+	log.Printf("   Total Size: %s", formatBytes(spec.TotalSize))
+	if config.Corpus != "" {
+		log.Printf("   Corpus: %s (reproducible; uploads will be byte-verified)\n", config.Corpus)
 	}
 
 	// Run benchmarks
@@ -126,6 +144,7 @@ func main() {
 					log.Printf("❌ CargoHold %s failed: %v", strategy, err)
 					continue
 				}
+				verifyIfCorpus(config, "cargohold", corpusFiles, &result)
 				results = append(results, result)
 				printResult(result)
 			}
@@ -138,6 +157,7 @@ func main() {
 				log.Printf("❌ %s failed: %v", tool, err)
 				continue
 			}
+			verifyIfCorpus(config, tool, corpusFiles, &result)
 			results = append(results, result)
 			printResult(result)
 		}
@@ -189,6 +209,33 @@ func runBest(iterations int, run func() (BenchmarkResult, error)) (BenchmarkResu
 	return best, nil
 }
 
+// plantCorpus materializes a shared, reproducible pkg/corpus profile and returns
+// its files (with sha256 sums, for byte-verify), a spec describing it, and the
+// directory it was planted in. It re-plants fresh each run so the corpus is
+// deterministic regardless of prior state.
+func plantCorpus(config *BenchmarkConfig) ([]corpus.File, ScenarioSpec, string, error) {
+	prof, ok := corpus.ProfileByName(config.Corpus)
+	if !ok {
+		return nil, ScenarioSpec{}, "", fmt.Errorf("unknown profile (want many-tiny|few-large|mixed|hostile)")
+	}
+	dir := filepath.Join(config.DataDir, "corpus-"+config.Corpus)
+	if err := os.RemoveAll(dir); err != nil {
+		return nil, ScenarioSpec{}, "", fmt.Errorf("clear corpus dir: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, ScenarioSpec{}, "", fmt.Errorf("create corpus dir: %w", err)
+	}
+	files, err := prof.Plant(dir)
+	if err != nil {
+		return nil, ScenarioSpec{}, "", fmt.Errorf("plant: %w", err)
+	}
+	var total int64
+	for _, f := range files {
+		total += int64(f.Size)
+	}
+	return files, ScenarioSpec{Name: prof.Name, FileCount: len(files), TotalSize: total}, dir, nil
+}
+
 func parseFlags() *BenchmarkConfig {
 	config := &BenchmarkConfig{}
 
@@ -199,6 +246,7 @@ func parseFlags() *BenchmarkConfig {
 	flag.StringVar(&config.ResultsDir, "results-dir", "./results", "Results output directory")
 	flag.IntVar(&config.Concurrency, "concurrency", 10, "Parallel operations")
 	flag.IntVar(&config.Iterations, "iterations", 3, "Number of runs per test")
+	flag.StringVar(&config.Corpus, "corpus", "", "shared pkg/corpus profile (many-tiny|few-large|mixed|hostile); enables byte-verify. Empty uses the legacy scenario generator")
 
 	var tools string
 	var strategies string
@@ -282,6 +330,9 @@ func printResult(result BenchmarkResult) {
 	log.Printf("      Throughput: %.1f MB/s", result.UploadThroughputMBps)
 	log.Printf("      Memory: %.1f MB", result.PeakMemoryMB)
 	log.Printf("      CPU: %.1f%%", result.AvgCPUPercent)
+	if result.Verified {
+		log.Printf("      Verified: ✅ %d files byte-identical", result.VerifiedFiles)
+	}
 	if result.ErrorCount > 0 {
 		log.Printf("      Errors: %d", result.ErrorCount)
 	}


### PR DESCRIPTION
Adds the two trust-critical pieces of increment 2 to the competitor harness (`benchmarks/cargohold`), **validated on real S3** (s5cmd + rclone; `many-tiny` 5000-file and `hostile` edge-case-name corpora both ✅):

- **Reproducible corpus** — a `-corpus <profile>` flag plants the shared, seeded `pkg/corpus` profile (`many-tiny|few-large|mixed|hostile`) instead of cargohold's own generator, so a published competitor number is independently reproducible and directly comparable to `cargoship-bench`'s.
- **Byte-verify** — with `-corpus` set, each mirror-style upload (s5cmd/rclone/mc) is downloaded via `aws s3 sync` and confirmed byte-identical to the source by sha256 (`corpus.File` carries the sums). A speed number for a lossy upload is meaningless — correctness becomes a gate, not an assumption. cargohold (chunked) and tar (single archive) log a skip, not a false failure; cargoship is byte-verified by `pkg/benchharness`.

**Byte-verify immediately caught a real bug**: the s5cmd runner's destination carried a `/*` glob (`s5cmd-<scenario>/*`), which s5cmd rejects in a target — *every* s5cmd run had been failing. Fixed to a plain prefix (the source `dir/*` already recurses, confirmed against S3).

`compareDownloaded` is factored out and unit-tested (present / mismatch / missing); `mirrorPrefix` is unit-tested.

Part of #495 / #500.