### PR TITLE
fix(archiver): sub-frame large files so they stay seekable (#502)

### DIFF
--- a/pkg/pipeline/archiver.go
+++ b/pkg/pipeline/archiver.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"archive/tar"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -78,7 +79,8 @@ func (f *framer) recordOffset(job *Job, file chunking.File) {
 
 // maybeCut ends the current frame and starts a new one when the accumulated
 // uncompressed bytes reach frameSize. Call at a file boundary (after the file's
-// data is written), so no file ever spans two frames.
+// data is written): it flushes the tar writer first so the finished file's
+// padding lands in this frame, keeping small files whole within a frame.
 func (f *framer) maybeCut() error {
 	if !f.active() || f.cwU.n-f.frameStartU < f.frameSize {
 		return nil
@@ -86,11 +88,33 @@ func (f *framer) maybeCut() error {
 	if err := f.tw.Flush(); err != nil { // push the finished file's padding into the encoder
 		return fmt.Errorf("flush tar before frame cut: %w", err)
 	}
-	if err := f.encoder.Close(); err != nil { // write this frame's epilogue into cwC→pw
+	return f.cutFrame()
+}
+
+// maybeCutMidFile ends the current frame mid-tar-entry when it reaches frameSize,
+// so a single large file spans many independently-decodable frames instead of one
+// unseekable multi-GB frame (#502). Unlike maybeCut it does NOT flush the tar
+// writer — the entry is still being written, and a zstd frame boundary need not
+// align with a tar block. The file bytes written so far are already in the
+// encoder, so closing it ends a complete, valid frame; the reader locates a byte
+// range via the frame index's uncompressed offsets.
+func (f *framer) maybeCutMidFile() error {
+	if !f.active() || f.cwU.n-f.frameStartU < f.frameSize {
+		return nil
+	}
+	return f.cutFrame()
+}
+
+// cutFrame closes the current zstd frame (writing its epilogue into cwC→pw),
+// records it, and resets the encoder to begin the next independent frame on the
+// same pipe. Callers gate on frameSize and decide whether to flush the tar writer
+// first (only maybeCut does, at a file boundary).
+func (f *framer) cutFrame() error {
+	if err := f.encoder.Close(); err != nil {
 		return fmt.Errorf("close zstd frame: %w", err)
 	}
 	f.appendFrame()
-	f.encoder.Reset(f.cwC) // begin the next independent frame on the same pipe
+	f.encoder.Reset(f.cwC)
 	return nil
 }
 
@@ -1141,24 +1165,39 @@ func (s *ArchiverStage) addFileToArchiveWithMetadata(tw *tar.Writer, fr *framer,
 	fr.recordOffset(job, file)
 
 	// Copy file content with length limit. When per-file checksums are enabled
-	// (#271) we hash the content as it's copied. This routes through a
-	// TeeReader, which bypasses the platform zero-copy (splice/sendfile) path —
-	// an accepted trade for the integrity guarantee, and this small-chunk
-	// (<3 files) branch is not the throughput-critical path (that's the
-	// in-memory parallel path). With checksums off, the fast path is unchanged.
+	// (#271) we hash the content as it's copied, via a TeeReader — an accepted
+	// trade of the zero-copy path for the integrity guarantee. When the framer is
+	// active (#502) we copy in blocks so a large file is cut into many ~frameSize
+	// frames rather than one unseekable frame; that copier also reads from an
+	// io.Reader, so it composes with the checksum TeeReader. Only the plain,
+	// checksum-off, unframed case keeps the platform zero-copy (splice/sendfile)
+	// fast path.
+	var hasher hash.Hash
+	src := io.LimitReader(f, length)
 	if job != nil && s.config.FileChecksums {
-		hasher := sha256.New()
-		if err := s.copyFileToArchivePlain(tw, io.TeeReader(io.LimitReader(f, length), hasher)); err != nil {
+		hasher = sha256.New()
+		src = io.TeeReader(src, hasher)
+	}
+	switch {
+	case fr.active():
+		if err := s.copyFileFramed(tw, fr, src); err != nil {
 			return fmt.Errorf("failed to write file content: %w", err)
 		}
-		job.SetFileChecksum(fileChecksumKey(file), hex.EncodeToString(hasher.Sum(nil)))
-	} else {
+	case hasher != nil:
+		if err := s.copyFileToArchivePlain(tw, src); err != nil {
+			return fmt.Errorf("failed to write file content: %w", err)
+		}
+	default:
 		if err := s.copyFileToArchive(tw, f, length); err != nil {
 			return fmt.Errorf("failed to write file content: %w", err)
 		}
 	}
+	if hasher != nil {
+		job.SetFileChecksum(fileChecksumKey(file), hex.EncodeToString(hasher.Sum(nil)))
+	}
 
-	// #436: at this file boundary, cut a new zstd frame if the current one is full.
+	// #436: at this file boundary, cut a new zstd frame if the current one is full
+	// (catches the tail of a large file and batches of small files).
 	return fr.maybeCut()
 }
 
@@ -1168,6 +1207,39 @@ func (s *ArchiverStage) addFileToArchiveWithMetadata(tw *tar.Writer, fr *framer,
 func (s *ArchiverStage) copyFileToArchivePlain(tw *tar.Writer, r io.Reader) error {
 	_, err := io.Copy(tw, r)
 	return err
+}
+
+// copyFileFramed copies r into the current tar entry, cutting a new zstd frame
+// each time the current frame fills to frameSize — so a large file spans many
+// independently-decodable frames rather than one unseekable frame (#502). Used
+// only when the framer is active; the inactive and zero-copy paths are untouched.
+// Reading in bounded blocks keeps frame sizes close to frameSize regardless of
+// how much r returns per Read.
+func (s *ArchiverStage) copyFileFramed(tw *tar.Writer, fr *framer, r io.Reader) error {
+	// Write granularity for the frame-full check: 1 MiB, but never larger than
+	// frameSize (so a small frameSize still yields frames near that size).
+	block := int64(1 << 20)
+	if fr.frameSize > 0 && fr.frameSize < block {
+		block = fr.frameSize
+	}
+	buf := make([]byte, block)
+	for {
+		n, rerr := r.Read(buf)
+		if n > 0 {
+			if _, werr := tw.Write(buf[:n]); werr != nil {
+				return werr
+			}
+			if cerr := fr.maybeCutMidFile(); cerr != nil {
+				return cerr
+			}
+		}
+		if rerr == io.EOF {
+			return nil
+		}
+		if rerr != nil {
+			return rerr
+		}
+	}
 }
 
 // fileChecksumKey returns the map key under which a file's (or split part's)
@@ -1215,9 +1287,17 @@ func (s *ArchiverStage) addFileToArchiveFromMemoryWithMetadata(tw *tar.Writer, f
 	// #436: the file's data starts at the current uncompressed tar offset.
 	fr.recordOffset(job, file)
 
-	// Write data from memory
-	if _, err := tw.Write(data); err != nil {
-		return fmt.Errorf("failed to write file content: %w", err)
+	// Write data from memory. When the framer is active (#502), sub-frame a large
+	// in-memory file the same way as the streaming path so it stays seekable;
+	// otherwise a single write preserves the prior behavior.
+	if fr.active() {
+		if err := s.copyFileFramed(tw, fr, bytes.NewReader(data)); err != nil {
+			return fmt.Errorf("failed to write file content: %w", err)
+		}
+	} else {
+		if _, err := tw.Write(data); err != nil {
+			return fmt.Errorf("failed to write file content: %w", err)
+		}
 	}
 
 	// #271: the file content is already in memory here, so hashing is a single

--- a/pkg/pipeline/framer_test.go
+++ b/pkg/pipeline/framer_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
@@ -94,6 +95,83 @@ func TestFramerCutsFramesAndRecordsOffsets(t *testing.T) {
 		start := off - covering.UncompressedOffset
 		assert.Equal(t, f.content, raw[start:start+int64(len(f.content))], "sliced frame bytes must match %s", f.path)
 	}
+}
+
+// TestFramerSubFramesLargeFile is the #502 guard: a single file larger than
+// frameSize must be cut into many independently-decodable frames (not one
+// unseekable frame), the stream must round-trip byte-identically, and a byte
+// range spanning a frame boundary must be reconstructable from only its covering
+// frames — the random-access promise for large files.
+func TestFramerSubFramesLargeFile(t *testing.T) {
+	const frameSize = int64(64 * 1024) // 64 KiB frames
+	var buf bytes.Buffer
+	fr := newTestFramer(t, &buf, frameSize)
+	job := &Job{}
+	s := &ArchiverStage{}
+
+	// One compressible file far larger than frameSize.
+	content := bytes.Repeat([]byte("cargoship-502-"), 80000) // ~1.12 MB
+	require.NoError(t, fr.tw.WriteHeader(&tar.Header{Name: "big.dat", Mode: 0o644, Size: int64(len(content))}))
+	fr.recordOffset(job, chunking.File{Path: "big.dat"})
+	require.NoError(t, s.copyFileFramed(fr.tw, fr, bytes.NewReader(content)))
+	require.NoError(t, fr.maybeCut())
+	require.NoError(t, fr.tw.Close())
+	require.NoError(t, fr.encoder.Close())
+	fr.finalize()
+
+	// The large file spans many frames (pre-#502 it was a single frame).
+	require.Greater(t, len(fr.frames), 5, "a large file must be cut into many sub-frames (#502)")
+
+	obj := buf.Bytes()
+	var next int64
+	for i, fe := range fr.frames {
+		assert.Equal(t, next, fe.CompressedOffset, "frame %d must start where the previous ended", i)
+		// No frame's uncompressed span materially exceeds frameSize (one block slack).
+		assert.LessOrEqual(t, fe.UncompressedSize, frameSize+frameSize, "frame %d span ~frameSize", i)
+		want := sha256.Sum256(obj[fe.CompressedOffset : fe.CompressedOffset+fe.CompressedSize])
+		assert.Equal(t, hex.EncodeToString(want[:]), fe.Checksum, "frame %d checksum", i)
+		next += fe.CompressedSize
+	}
+	assert.Equal(t, int64(buf.Len()), next, "frames must cover the whole object")
+
+	// Whole-stream round-trip is byte-identical.
+	dec, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	defer dec.Close()
+	raw, err := dec.DecodeAll(obj, nil)
+	require.NoError(t, err)
+	tr := tar.NewReader(bytes.NewReader(raw))
+	hdr, err := tr.Next()
+	require.NoError(t, err)
+	require.Equal(t, "big.dat", hdr.Name)
+	got, err := io.ReadAll(tr)
+	require.NoError(t, err)
+	require.Equal(t, content, got, "round-trip must be byte-identical")
+
+	// Random access: reconstruct a range that spans multiple frames from ONLY its
+	// covering frames, the way a frame-index reader (lith) would.
+	off := job.FileArchiveOffsets()["big.dat"]
+	start, n := frameSize, frameSize+5000 // deliberately spans >1 frame boundary
+	require.LessOrEqual(t, start+n, int64(len(content)))
+	absStart := off + start
+
+	var covering []*manifest.FrameEntry
+	for i := range fr.frames {
+		fe := &fr.frames[i]
+		if fe.UncompressedOffset+fe.UncompressedSize > absStart && fe.UncompressedOffset < absStart+n {
+			covering = append(covering, fe)
+		}
+	}
+	require.Greater(t, len(covering), 1, "a range of frameSize+ must span multiple frames")
+	var region []byte
+	for _, fe := range covering {
+		d, derr := dec.DecodeAll(obj[fe.CompressedOffset:fe.CompressedOffset+fe.CompressedSize], nil)
+		require.NoError(t, derr)
+		region = append(region, d...)
+	}
+	rel := absStart - covering[0].UncompressedOffset
+	assert.Equal(t, content[start:start+n], region[rel:rel+n],
+		"a byte range must be recoverable from only its covering frames")
 }
 
 // TestFramerInactiveIsNoOp confirms an inactive framer (frameSize 0) never CUTS

--- a/pkg/pipeline/torture_test.go
+++ b/pkg/pipeline/torture_test.go
@@ -171,6 +171,17 @@ func TestTorture(t *testing.T) {
 		}
 		require.Positive(t, framedChunks, "at least one chunk must carry a frame index")
 		require.Positive(t, multiFrame, "a 64KiB frame size over >=150KiB files must cut multiple frames")
+
+		// #502: sub-frame cutting means a single file LARGER than frameSize spans
+		// many frames. Pre-#502 the framer cut only at file boundaries, so this
+		// 24 MiB corpus over 1 MiB frames gave ~3 frames (one per file); now each
+		// large file is cut into several, so the total far exceeds the file count.
+		totalFrames := 0
+		for _, c := range m.Chunks {
+			totalFrames += len(c.Frames)
+		}
+		require.Greater(t, totalFrames, len(corpus)*3,
+			"a large file must be sub-framed into many frames, not one frame per file (#502)")
 		for _, f := range m.Files {
 			require.Positive(t, f.ArchiveOffset, "file %s must have a recorded archive offset", f.Path)
 		}


### PR DESCRIPTION
Fixes #502. The framer cut zstd frames **only at file boundaries**, so a single large file became one giant frame — a 3.5 GB CRAM was one ~3.5 GB frame. A zstd frame isn't seekable, so a random-access reader (lith, scttfrdmn/lith#94) had to fetch+decode the whole multi-GB frame to read any byte — defeating the Format 2.1 random-access promise (#436) for exactly the files where it matters most.

## Fix (ask #1: sub-frame cutting)
`copyFileFramed` writes a file's data in bounded blocks and calls `maybeCutMidFile` whenever the current frame fills to `--frame-size`. Mid-entry the cut is a **raw** `encoder.Close()/appendFrame/Reset` with **no `tw.Flush()`** — a zstd frame boundary needn't align with a tar block, and the bytes written so far are already in the encoder, so it ends a complete, valid frame. The file then spans many ~`frameSize` frames; the reader maps a byte range via the frame index's uncompressed offsets — **already in the manifest, no schema change**.

- Wired into both the streaming and in-memory write paths.
- The plain, checksum-off, unframed case keeps the zero-copy (splice/sendfile) fast path untouched.
- cargoship's own restore is unaffected (concatenated zstd frames decode identically) — only the frame index gains entries.

## Validation
- **Real S3**: a 250 MB compressible file now yields **16 frames** (was ~1) and restores **byte-identical**.
- **Unit test** `TestFramerSubFramesLargeFile`: a large file spans many frames + a range spanning a frame boundary is recoverable from only its covering frames — **verified failing pre-fix**.
- **Torture** `frames_random_access` gains a #502 assertion (total frames ≫ file count).

Ask #2 (route large already-compressed files to frameless plain chunks) is a follow-up optimization; this fix makes *any* large file seekable.