### PR TITLE
feat(bench): pkg/s3metrics — CloudWatch reader for competitor request counts (#495)

### DIFF
--- a/.coverage-baseline
+++ b/.coverage-baseline
@@ -73,6 +73,7 @@ pkg/repl 41
 pkg/restore 76
 pkg/resume 41
 pkg/s3count 92
+pkg/s3metrics 90
 pkg/s3optimization 58
 pkg/staging 81
 pkg/testutils 76

--- a/pkg/s3metrics/s3metrics.go
+++ b/pkg/s3metrics/s3metrics.go
@@ -1,0 +1,177 @@
+// Package s3metrics reads a mover's SERVER-SIDE S3 request counts from CloudWatch
+// S3 request metrics, so the benchmark harness can score any black-box competitor
+// (aws s3 cp / s5cmd / rclone / mc) with the same pkg/s3cost model as CargoShip —
+// whose counts come from client-side middleware (pkg/s3count) that a competitor
+// binary doesn't expose.
+//
+// Request metrics are a bucket feature: PutBucketMetricsConfiguration with a
+// prefix filter tells S3 to publish per-request CloudWatch metrics (AllRequests,
+// PutRequests, GetRequests, …) under the AWS/S3 namespace, tagged with the filter
+// Id. Two real-world latencies apply: enabling a NEW configuration takes up to
+// ~15 minutes to start filtering, and published metrics lag the requests by a few
+// minutes. So a caller enables the config ONCE per bucket and reads counts over
+// the run window after a settling delay — this package itself never sleeps.
+//
+// CloudWatch cannot be emulated (rpcv2cbor), so live use is real-AWS-only; the
+// unit tests cover query construction and response parsing via the two client
+// interfaces below.
+package s3metrics
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// namespace is where S3 publishes request metrics.
+const namespace = "AWS/S3"
+
+// BucketMetricsAPI is the S3 surface needed to enable request metrics on a bucket.
+type BucketMetricsAPI interface {
+	PutBucketMetricsConfiguration(ctx context.Context, params *s3.PutBucketMetricsConfigurationInput, optFns ...func(*s3.Options)) (*s3.PutBucketMetricsConfigurationOutput, error)
+}
+
+// MetricDataAPI is the CloudWatch surface needed to read the published counts.
+type MetricDataAPI interface {
+	GetMetricData(ctx context.Context, params *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error)
+}
+
+// Counts is the server-side request tally for one prefix over one time window.
+type Counts struct {
+	Put    int64 `json:"put"`
+	Get    int64 `json:"get"`
+	Delete int64 `json:"delete"`
+	Head   int64 `json:"head"`
+	List   int64 `json:"list"`
+	Post   int64 `json:"post"`
+	All    int64 `json:"all"`
+
+	BytesDownloaded int64 `json:"bytes_downloaded"`
+	BytesUploaded   int64 `json:"bytes_uploaded"`
+}
+
+// requestMetrics are the AWS/S3 request metrics read here, each wired to the field
+// it populates. Order defines the GetMetricData query id (m0, m1, …).
+var requestMetrics = []struct {
+	name string
+	set  func(*Counts, int64)
+}{
+	{"PutRequests", func(c *Counts, v int64) { c.Put = v }},
+	{"GetRequests", func(c *Counts, v int64) { c.Get = v }},
+	{"DeleteRequests", func(c *Counts, v int64) { c.Delete = v }},
+	{"HeadRequests", func(c *Counts, v int64) { c.Head = v }},
+	{"ListRequests", func(c *Counts, v int64) { c.List = v }},
+	{"PostRequests", func(c *Counts, v int64) { c.Post = v }},
+	{"AllRequests", func(c *Counts, v int64) { c.All = v }},
+	{"BytesDownloaded", func(c *Counts, v int64) { c.BytesDownloaded = v }},
+	{"BytesUploaded", func(c *Counts, v int64) { c.BytesUploaded = v }},
+}
+
+// Operations maps the server-side counts onto representative S3 operation names,
+// keyed so pkg/s3cost's tier classifier bills them correctly (Put/Post/List →
+// PUT tier, Get/Head → GET tier, Delete → free). Feed the result straight into
+// s3cost.Usage.Operations to price a competitor's run.
+func (c Counts) Operations() map[string]int64 {
+	return map[string]int64{
+		"PutObject":     c.Put,
+		"PostObject":    c.Post,
+		"ListObjectsV2": c.List,
+		"GetObject":     c.Get,
+		"HeadObject":    c.Head,
+		"DeleteObject":  c.Delete,
+	}
+}
+
+// Configure enables (idempotently) a prefix-filtered request-metrics configuration
+// named filterID on bucket, so S3 publishes CloudWatch metrics for objects under
+// prefix. Safe to call before every run; it takes up to ~15 minutes to activate
+// the FIRST time on a bucket.
+func Configure(ctx context.Context, api BucketMetricsAPI, bucket, filterID, prefix string) error {
+	_, err := api.PutBucketMetricsConfiguration(ctx, &s3.PutBucketMetricsConfigurationInput{
+		Bucket: aws.String(bucket),
+		Id:     aws.String(filterID),
+		MetricsConfiguration: &s3types.MetricsConfiguration{
+			Id:     aws.String(filterID),
+			Filter: &s3types.MetricsFilterMemberPrefix{Value: prefix},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("put bucket metrics configuration %q: %w", filterID, err)
+	}
+	return nil
+}
+
+// ReadCounts sums each request metric over [start, end) for the filterID's prefix.
+// Period is 60s (S3 request-metric granularity); values are summed across periods
+// and across GetMetricData pages. A metric with no data reads as zero.
+func ReadCounts(ctx context.Context, api MetricDataAPI, bucket, filterID string, start, end time.Time) (Counts, error) {
+	dims := []cwtypes.Dimension{
+		{Name: aws.String("BucketName"), Value: aws.String(bucket)},
+		{Name: aws.String("FilterId"), Value: aws.String(filterID)},
+	}
+	queries := make([]cwtypes.MetricDataQuery, len(requestMetrics))
+	for i, m := range requestMetrics {
+		queries[i] = cwtypes.MetricDataQuery{
+			Id: aws.String(fmt.Sprintf("m%d", i)),
+			MetricStat: &cwtypes.MetricStat{
+				Metric: &cwtypes.Metric{
+					Namespace:  aws.String(namespace),
+					MetricName: aws.String(m.name),
+					Dimensions: dims,
+				},
+				Period: aws.Int32(60),
+				Stat:   aws.String("Sum"),
+			},
+		}
+	}
+
+	sums := make([]float64, len(requestMetrics))
+	var token *string
+	for {
+		out, err := api.GetMetricData(ctx, &cloudwatch.GetMetricDataInput{
+			StartTime:         aws.Time(start),
+			EndTime:           aws.Time(end),
+			MetricDataQueries: queries,
+			NextToken:         token,
+		})
+		if err != nil {
+			return Counts{}, fmt.Errorf("get metric data: %w", err)
+		}
+		for _, r := range out.MetricDataResults {
+			idx := queryIndex(aws.ToString(r.Id))
+			if idx < 0 || idx >= len(sums) {
+				continue
+			}
+			for _, v := range r.Values {
+				sums[idx] += v
+			}
+		}
+		if out.NextToken == nil {
+			break
+		}
+		token = out.NextToken
+	}
+
+	var counts Counts
+	for i, m := range requestMetrics {
+		m.set(&counts, int64(sums[i]))
+	}
+	return counts, nil
+}
+
+// queryIndex parses a "m<idx>" query id back to its requestMetrics index, or -1.
+func queryIndex(id string) int {
+	n, err := strconv.Atoi(strings.TrimPrefix(id, "m"))
+	if err != nil {
+		return -1
+	}
+	return n
+}

--- a/pkg/s3metrics/s3metrics_test.go
+++ b/pkg/s3metrics/s3metrics_test.go
@@ -1,0 +1,108 @@
+package s3metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/config"
+	"github.com/scttfrdmn/cargoship/pkg/s3cost"
+)
+
+type fakeBucketMetrics struct {
+	in *s3.PutBucketMetricsConfigurationInput
+}
+
+func (f *fakeBucketMetrics) PutBucketMetricsConfiguration(_ context.Context, in *s3.PutBucketMetricsConfigurationInput, _ ...func(*s3.Options)) (*s3.PutBucketMetricsConfigurationOutput, error) {
+	f.in = in
+	return &s3.PutBucketMetricsConfigurationOutput{}, nil
+}
+
+func TestConfigure_BuildsPrefixFilter(t *testing.T) {
+	f := &fakeBucketMetrics{}
+	require.NoError(t, Configure(context.Background(), f, "bkt", "s5cmd-run", "bench/s5cmd/"))
+
+	require.NotNil(t, f.in)
+	assert.Equal(t, "bkt", aws.ToString(f.in.Bucket))
+	assert.Equal(t, "s5cmd-run", aws.ToString(f.in.Id))
+	require.NotNil(t, f.in.MetricsConfiguration)
+	assert.Equal(t, "s5cmd-run", aws.ToString(f.in.MetricsConfiguration.Id))
+	pf, ok := f.in.MetricsConfiguration.Filter.(*s3types.MetricsFilterMemberPrefix)
+	require.True(t, ok, "filter must be a prefix filter")
+	assert.Equal(t, "bench/s5cmd/", pf.Value)
+}
+
+// fakeMetricData returns queued GetMetricData pages in order, so a test can
+// exercise NextToken pagination and cross-period summing.
+type fakeMetricData struct {
+	pages []*cloudwatch.GetMetricDataOutput
+	calls int
+}
+
+func (f *fakeMetricData) GetMetricData(_ context.Context, in *cloudwatch.GetMetricDataInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
+	f.calls++
+	// The caller must echo the previous page's NextToken.
+	page := f.pages[0]
+	f.pages = f.pages[1:]
+	return page, nil
+}
+
+func result(id string, vals ...float64) cwtypes.MetricDataResult {
+	return cwtypes.MetricDataResult{Id: aws.String(id), Values: vals}
+}
+
+func TestReadCounts_SumsAcrossPeriodsAndPages(t *testing.T) {
+	fd := &fakeMetricData{pages: []*cloudwatch.GetMetricDataOutput{
+		{ // page 1: Put across two periods, some Get; more Put on the next page
+			MetricDataResults: []cwtypes.MetricDataResult{
+				result("m0", 3, 2), // Put = 5 so far
+				result("m1", 4),    // Get = 4
+			},
+			NextToken: aws.String("more"),
+		},
+		{ // page 2: remaining Put + a Delete
+			MetricDataResults: []cwtypes.MetricDataResult{
+				result("m0", 1), // Put += 1 → 6
+				result("m2", 7), // Delete = 7
+			},
+		},
+	}}
+
+	start := time.Now().Add(-10 * time.Minute)
+	c, err := ReadCounts(context.Background(), fd, "bkt", "run", start, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 2, fd.calls, "must follow NextToken to the second page")
+	assert.Equal(t, int64(6), c.Put, "Put must sum across periods AND pages")
+	assert.Equal(t, int64(4), c.Get)
+	assert.Equal(t, int64(7), c.Delete)
+	assert.Zero(t, c.List, "an absent metric reads as zero")
+}
+
+// TestCounts_FeedS3Cost is the point of the package: server-side counts price
+// through the same model as CargoShip's client-side counts, on the right tiers.
+func TestCounts_FeedS3Cost(t *testing.T) {
+	c := Counts{Put: 10, Get: 3, Delete: 4}
+	b := s3cost.Compute(s3cost.Usage{
+		StorageClass: config.StorageClassStandard,
+		Operations:   c.Operations(),
+	})
+	require.Len(t, b.Requests, 3)
+	assert.Equal(t, int64(10), b.Requests[0].Count, "Put → PUT tier")
+	assert.Equal(t, int64(3), b.Requests[1].Count, "Get → GET tier")
+	assert.Equal(t, int64(4), b.Requests[2].Count)
+	assert.Zero(t, b.Requests[2].USD, "Delete is free")
+}
+
+func TestQueryIndex(t *testing.T) {
+	assert.Equal(t, 0, queryIndex("m0"))
+	assert.Equal(t, 12, queryIndex("m12"))
+	assert.Equal(t, -1, queryIndex("bogus"))
+}


### PR DESCRIPTION
The net-new blocker for the competitor **cost** comparison. CargoShip's request counts come from client-side middleware (`pkg/s3count`), but a competitor binary (aws s3 cp / s5cmd / rclone / mc) is a black box — this reads their **server-side** counts from CloudWatch S3 request metrics, so both price through the same `pkg/s3cost` model.

- **`Configure`** — `PutBucketMetricsConfiguration` with a prefix filter → S3 publishes per-request `AWS/S3` metrics tagged with the filter Id (idempotent; ~15 min to activate the first time on a bucket).
- **`ReadCounts`** — `GetMetricData` over the run window (Sum stat, 60 s period), summed across periods and `NextToken` pages → a `Counts` tally.
- **`Counts.Operations`** — maps onto representative op names so `s3cost`'s tier classifier bills them correctly (Put/Post/List → PUT, Get/Head → GET, Delete free).

Real-AWS-only (CloudWatch can't be emulated, #459); both client interfaces are mocked in tests covering query construction, cross-page summing, and the `s3cost` feed (**92.7%** coverage).

Next: wire cargohold's `RequestCount` through this, then a real-AWS comparison run to flip fastest/cheapest Aspirational→Verified.

Part of #495.