### PR TITLE
docs(verification): fill the v0.24.4 report row

### DIFF
--- a/docs/project/verification-reports.md
+++ b/docs/project/verification-reports.md
@@ -34,7 +34,7 @@ release assets to find the evidence.
 
 | Version | Date | Files | Bytes | Paths | Suites | Result | Report |
 |---------|------|-------|-------|-------|--------|--------|--------|
-| v0.24.4 | 2026-09-11 | — | — | direct, chunked | — | ⏳ Run in progress | Pending — filled from the attached report after the tagged real-AWS lane completes. |
+| v0.24.4 | 2026-09-12 | 20 | 61.01 MB | direct, chunked | 46 / 0 | ✅ Passed | [`v0.24.4-2026-09-12.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.24.4/v0.24.4-2026-09-12.md) |
 | v0.24.3 | 2026-09-12 | 20 | 61.01 MB | direct, chunked | 45 / 0 | ✅ Passed | [`v0.24.3-2026-09-12.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.24.3/v0.24.3-2026-09-12.md) |
 | v0.24.2 | 2026-09-10 | 20 | 61.01 MB | direct, chunked | 42 / 0 | ✅ Passed | [`v0.24.2-2026-09-10.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.24.2/v0.24.2-2026-09-10.md) |
 | v0.24.1 | 2026-09-10 | — | — | direct, chunked | — | ⚠️ Lane failed on CI infra ([#459](https://github.com/scttfrdmn/cargoship/issues/459)) | No report attached: the tagged real-AWS lane failed on the CloudWatch metrics tests (not the data path). Fixed in v0.24.2; data path verified via the emulator lane + a real-S3 dog-food. |


### PR DESCRIPTION
Step 6 of the v0.24.4 release: fill the verification-reports row from the attached real-AWS report `v0.24.4-2026-09-12.md` — 20 files / 61.01 MB / **46 suites / 0 failures**, ✅ Passed. (46 = 45 + the new `pkg/s3cost` package from #501.)