### PR TITLE
fix(bench): cargohold — cargoship runner uses --shards, not the removed --shard-strategy

### DIFF
--- a/benchmarks/cargohold/benchmarks.go
+++ b/benchmarks/cargohold/benchmarks.go
@@ -115,13 +115,17 @@ func runCargoHoldBenchmark(config *BenchmarkConfig, spec ScenarioSpec, dataDir, 
 		}
 	}
 
+	// `cargoship create upload` takes --shards (there is no --shard-strategy /
+	// --shard-count in the current CLI); the strategy is retained only as a label
+	// for the S3 prefix and results. --quiet disables the TUI for non-interactive
+	// exec.
 	args := []string{
 		"create", "upload",
 		dataDir,
 		"--bucket", config.Bucket,
 		"--prefix", fmt.Sprintf("%s/cargohold-%s-%s", config.Prefix, strategy, config.Scenario),
-		"--shard-strategy", strategy,
-		"--shard-count", "10",
+		"--shards", "10",
+		"--quiet",
 	}
 
 	cmd := exec.Command(cargoshipPath, args...)


### PR DESCRIPTION
The comparison dry-run surfaced this: cargohold's CargoShip runner passed `--shard-strategy <s> --shard-count 10`, but `cargoship create upload` has **neither** flag (current CLI uses `--shards N`; no shard-strategy concept) → every CargoShip run exited 2, so CargoShip was silently absent from any comparison. Now `--shards 10 --quiet`; strategy kept only as a prefix/result label. Confirmed on real S3 (34.4 MB/s, mixed corpus).

Part of #495.