### PR TITLE
fix(detector): frameless already-compressed files (#511) + document packing order (#512)

### DIFF
--- a/docs/reference/format/archive-layout.md
+++ b/docs/reference/format/archive-layout.md
@@ -23,12 +23,27 @@ chunk-{m}.tar.zst
 - **Compression:** the tar stream wrapped in Zstandard — **or none**, in which
   case the object is a plain `.tar`. See below. The zstd stream is one or more
   independently-decodable frames: a single frame by default, or several cut at
-  file boundaries when `--frame-size` is set, which records a random-access frame
-  index in the manifest (format 2.1, see [Compression](/reference/format/compression)).
-  Concatenated frames are a valid zstd stream, so a whole-object decode is
-  unaffected either way.
+  `--frame-size` boundaries when set — between files, and *within* a large file so
+  it never becomes one unseekable multi-GB frame — which records a random-access
+  frame index in the manifest (format 2.1, see
+  [Compression](/reference/format/compression)). Concatenated frames are a valid
+  zstd stream, so a whole-object decode is unaffected either way.
 - Chunks are produced by streaming: files flow `tar → zstd → S3` through
   in-memory pipes, so nothing is staged to local disk.
+
+### Packing order
+
+Chunk assignment **preserves source order**: files are packed in the order they
+are scanned (sorted / tree-walk order), and each chunk holds a **contiguous run**
+of that sequence. A dataset of files `sorted[0..N)` packed into chunks of size *k*
+yields `chunk-0 = sorted[0:k]`, `chunk-1 = sorted[k:2k]`, and so on — no
+interleaving, regardless of `--shard-strategy` (the strategy chooses which *shard*
+a chunk lands in, not which files a chunk contains).
+
+A reader walking the archive in tree order can therefore rely on the walk staying
+within one chunk at a time: it reads a chunk fully before moving to the next,
+rather than jumping between chunks per file. This makes a tree-order traversal of
+a packed archive sequential per chunk.
 
 ### tar attributes
 

--- a/pkg/pipeline/compression_detector.go
+++ b/pkg/pipeline/compression_detector.go
@@ -7,7 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/klauspost/compress/zstd"
 )
+
+// probeMinSize is the file size at or above which an unknown-extension file that
+// passed the extension/magic checks is sampled with a real compression probe
+// (#511). Small files don't create the giant frames the probe guards against.
+const probeMinSize = 8 << 20 // 8 MiB
 
 // CompressionDetector determines if a file is already compressed
 type CompressionDetector struct {
@@ -60,6 +67,7 @@ func (d *CompressionDetector) ShouldCompress(path string) (bool, string) {
 	// Cache miss - compute decision
 	var shouldCompress bool
 	var reason string
+	probed := false // a content probe ran; its result is content-, not extension-, specific
 
 	// Check file extension against known compressed formats
 	if ext != "" && d.skipExtensions[ext] {
@@ -70,6 +78,13 @@ func (d *CompressionDetector) ShouldCompress(path string) (bool, string) {
 		if compressed, desc := d.checkMagicBytes(path); compressed {
 			shouldCompress = false
 			reason = "already_compressed_magic:" + desc
+		} else if isLargeFile(path) && !d.probeCompressible(path) {
+			// #511: a large unknown-extension file whose magic didn't match but that
+			// barely compresses (e.g. an oddly-named already-compressed file) is
+			// stored frameless, so a random reader never decodes a pointless frame.
+			shouldCompress = false
+			reason = "incompressible_probe"
+			probed = true
 		} else {
 			shouldCompress = true
 			reason = "compressible"
@@ -79,8 +94,9 @@ func (d *CompressionDetector) ShouldCompress(path string) (bool, string) {
 		reason = "compressible"
 	}
 
-	// Store in cache for future lookups (only cache by extension for consistency)
-	if ext != "" {
+	// Store in cache for future lookups (only cache by extension for consistency).
+	// A probe-based decision is content-specific, so it is NOT cached by extension.
+	if ext != "" && !probed {
 		d.decisionCache.Store(ext, &compressionDecision{
 			shouldCompress: shouldCompress,
 			reason:         reason,
@@ -88,6 +104,41 @@ func (d *CompressionDetector) ShouldCompress(path string) (bool, string) {
 	}
 
 	return shouldCompress, reason
+}
+
+// isLargeFile reports whether path is at least probeMinSize bytes.
+func isLargeFile(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.Size() >= probeMinSize
+}
+
+// probeCompressible samples the first ~1 MiB of path and reports whether zstd
+// shrinks it by at least 5%. A file that barely compresses is treated as already
+// compressed (#511). On any read/encode error it defaults to true (compressible),
+// preserving the prior behavior.
+func (d *CompressionDetector) probeCompressible(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return true
+	}
+	defer func() { _ = f.Close() }()
+
+	sample := make([]byte, 1<<20)
+	n, _ := io.ReadFull(f, sample)
+	if n < 4096 { // too small to judge
+		return true
+	}
+	sample = sample[:n]
+
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	if err != nil {
+		return true
+	}
+	defer func() { _ = enc.Close() }()
+	compressed := enc.EncodeAll(sample, nil)
+
+	// Compressible only if it shrank by ≥5%.
+	return len(compressed) < n*95/100
 }
 
 // checkMagicBytes reads file header and checks for compression signatures
@@ -236,6 +287,12 @@ func buildSkipExtensionsMap() map[string]bool {
 		".war", // ZIP-based
 		".ipa", // ZIP-based
 
+		// Genomics (already compressed): CRAM is its own container, BAM/BCF are
+		// BGZF-wrapped. #511 — these were being framed pointlessly.
+		".cram",
+		".bam",
+		".bcf",
+
 		// Other compressed formats
 		".dmg",  // macOS disk images
 		".iso",  // May contain compressed files
@@ -265,6 +322,7 @@ func buildSkipMagicBytes() []magicBytePattern {
 		{0, []byte{0x52, 0x61, 0x72, 0x21, 0x1A, 0x07}, "RAR"},
 		{0, []byte{0x28, 0xB5, 0x2F, 0xFD}, "ZSTD"},
 		{0, []byte{0x04, 0x22, 0x4D, 0x18}, "LZ4"},
+		{0, []byte{0x43, 0x52, 0x41, 0x4D}, "CRAM"}, // #511: CRAM is not gzip-wrapped, so an extension miss slips past the gzip magic
 
 		// Images
 		{0, []byte{0xFF, 0xD8, 0xFF}, "JPEG"},

--- a/pkg/pipeline/compression_detector_test.go
+++ b/pkg/pipeline/compression_detector_test.go
@@ -1,0 +1,75 @@
+package pipeline
+
+import (
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShouldCompress_GenomicsExtensionsAreFrameless guards #511: already-compressed
+// genomics formats must be recognized by extension so they are stored frameless
+// (plain .tar), not wrapped in a pointless zstd frame.
+func TestShouldCompress_GenomicsExtensionsAreFrameless(t *testing.T) {
+	d := NewCompressionDetector()
+	for _, name := range []string{"sample.cram", "reads.bam", "calls.bcf"} {
+		should, reason := d.ShouldCompress(name)
+		assert.False(t, should, "%s must not be compressed", name)
+		assert.Contains(t, reason, "already_compressed_extension", "%s", name)
+	}
+	// A plainly compressible file is still compressed.
+	should, _ := d.ShouldCompress("notes.txt")
+	assert.True(t, should)
+}
+
+// TestShouldCompress_CRAMMagic covers a .cram renamed to an unknown extension:
+// the CRAM magic bytes still route it frameless.
+func TestShouldCompress_CRAMMagic(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "mystery.xyz")
+	body := append([]byte("CRAM"), make([]byte, 1024)...) // CRAM magic + padding
+	require.NoError(t, os.WriteFile(p, body, 0o600))
+
+	should, reason := NewCompressionDetector().ShouldCompress(p)
+	assert.False(t, should)
+	assert.Contains(t, reason, "already_compressed_magic:CRAM")
+}
+
+// TestShouldCompress_LargeIncompressibleProbe guards #511 ask 2: a large file with
+// an unknown extension and no magic match, but incompressible content, is probed
+// and stored frameless; a compressible one of the same shape is still compressed;
+// a SMALL incompressible one is below the probe threshold and left compressible.
+func TestShouldCompress_LargeIncompressibleProbe(t *testing.T) {
+	dir := t.TempDir()
+
+	// 9 MiB of cryptographically random bytes → incompressible, and ≥ probeMinSize.
+	incompressible := filepath.Join(dir, "big.xyz")
+	buf := make([]byte, 9<<20)
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(incompressible, buf, 0o600))
+
+	should, reason := NewCompressionDetector().ShouldCompress(incompressible)
+	assert.False(t, should, "a large incompressible unknown-ext file must be frameless")
+	assert.Equal(t, "incompressible_probe", reason)
+
+	// 9 MiB of zeros → highly compressible.
+	compressible := filepath.Join(dir, "zeros.xyz")
+	require.NoError(t, os.WriteFile(compressible, make([]byte, 9<<20), 0o600))
+	should, _ = NewCompressionDetector().ShouldCompress(compressible)
+	assert.True(t, should, "a large compressible unknown-ext file must still be compressed")
+
+	// Small incompressible file: below the probe threshold, left as compressible
+	// (a small file never creates the giant frame the probe guards against).
+	small := filepath.Join(dir, "small.xyz")
+	sbuf := make([]byte, 64<<10)
+	_, err = rand.Read(sbuf)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(small, sbuf, 0o600))
+	should, reason = NewCompressionDetector().ShouldCompress(small)
+	assert.True(t, should, "a small file is not probed")
+	assert.Equal(t, "compressible", reason)
+}


### PR DESCRIPTION
Folds in the two lith-consumer issues.

**#511** — a `.cram` was framed into `.tar.zst` instead of stored frameless, re-creating the giant-frame problem (#502) for the worst-case file type. Fixes: (1) add `.cram`/`.bam`/`.bcf` to the already-compressed extension list + CRAM magic bytes (CRAM isn't gzip-wrapped, so it slipped past the gzip magic); (2) probe the first ~1 MiB of a large (≥8 MiB) unknown-extension file — if zstd shrinks it <5%, store frameless (content-specific, so not cached by extension). Tested.

**#512** — docs only: document that chunk packing preserves source tree/sort order as contiguous runs (verified against `CreateChunks` + empirically by lith). Also fixed the frame-cut wording for #502 sub-framing.

Fixes #511. Fixes #512.