### PR TITLE
docs(verification): fastest/cheapest → Verified for small-file workloads (#495)

### DIFF
--- a/docs/project/verification.md
+++ b/docs/project/verification.md
@@ -48,7 +48,7 @@ real-AWS verification report — see [Security](/project/security) and
 | Real congestion control (BBR/CUBIC) moves bytes intact | Verified | `` `make:torture` `` |
 | Resumable uploads (skip already-uploaded chunks) | Verified | `` `cmd:resume` ``, `` `test:TestNewResumePipelineConfig_EnablesResume` ``, `` `make:torture` `` |
 | Internal throughput benchmarks | Verified | `` `cmd:benchmark` `` |
-| **Fastest mover in class** — faster than `aws s3 cp`, `s5cmd`, `rclone` for the same data | **Aspirational** | **Not yet measured.** No head-to-head benchmark exists. Tracked as a v0.25.0 workstream (a comparative harness); until it lands, CargoShip does **not** claim to be the fastest. |
+| **Fastest mover for many-small-file workloads** — faster than `aws s3 cp`, `s5cmd`, `rclone` | Verified | Measured 2026-09-11 (5000-file corpus, LA→`us-west-2`): CargoShip **9.7 MB/s** vs s5cmd 2.2 / rclone 0.1 / tar 3.5 — packing avoids per-object latency. On **few-large** files s5cmd is faster (56 vs 47), so this is **not** a blanket claim. See [benchmarks](/reference/benchmarks). `` `script:benchmarks/cargohold/benchmarks.go` ``, `` `script:pkg/s3metrics/s3metrics.go` `` |
 
 ## Cost efficiency (priority 3, tied to performance)
 
@@ -57,7 +57,7 @@ real-AWS verification report — see [Security](/project/security) and
 | Cost estimation before upload | Verified | `` `cmd:estimate` ``, `` `test:TestAnalyzeBurnRate_IncreasingPattern` `` |
 | Budgets & volume quotas | Verified | `` `cmd:budget` ``, `` `test:TestAlertCooldownPeriod` `` |
 | Packing many files into archives → far fewer S3 requests | Verified | `` `make:torture` `` (the pipeline packs; round-trip proves it) |
-| **Most cost-efficient mover in class** — lowest total S3 cost to move + store the same data | **Aspirational** | **Not yet measured.** Needs the comparative harness to also count requests / bytes transferred / bytes stored → dollars. Until then, not claimed. |
+| **Lowest S3 cost for many-small-file workloads** — fewest requests + bytes → dollars | Verified | Measured 2026-09-11 (5000-file corpus): **7 requests → $0.00003** vs s5cmd 5000 → $0.025 and rclone 15001 → $0.029 (≈700× fewer requests; competitor counts from CloudWatch, priced by `pkg/s3cost`). On few-large workloads request counts are negligible for all, so cost is competitive, not ahead; storage is equal on incompressible data. See [benchmarks](/reference/benchmarks). `` `script:pkg/s3cost/cost.go` ``, `` `script:benchmarks/cargohold/cloudwatch.go` `` |
 
 ## Experimental / not shipping
 

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -206,13 +206,29 @@ dataset exceeds a conservative file-count cap (`DirectUploadMaxFiles`, default
 
 ### Competitor comparison (measured, 2026-09-11, LA → `us-west-2`, STANDARD)
 
-Head-to-head against `s5cmd`, `rclone`, and `tar+zstd+aws s3 cp`, on the shared
-reproducible `pkg/corpus` profiles. Competitor uploads are **byte-verified**
+**Provenance** (as with the microbenchmark header, a comparison number is only
+meaningful with the machine, versions, and path behind it):
+
+```
+# Date:        2026-09-11
+# Path:        Los Angeles → us-west-2 (residential uplink)
+# Machine:     Mac16,11 · Apple M4 Pro (12-core) · 48 GB · macOS 26.6.2 (25G83)
+# CargoShip:   built from main @ 64b2b45 (v0.24.5-dev)
+# s5cmd:       v2.3.0        rclone:  v1.75.1
+# aws-cli:     2.36.42       tar:     bsdtar 3.5.3 (libarchive 3.7.4) + zstd v1.5.7
+# Storage:     STANDARD      Corpora: pkg/corpus many-tiny, few-large (fixed seed)
+# Reproduce:   cargohold -tools cargohold,s5cmd,rclone,tar -corpus <name> \
+#                -iterations 1 -cloudwatch-metrics -bucket <b> -prefix cmp
+```
+
+One machine, one network path, one run each — recorded for reference and
+reproducible, not a portable absolute (a faster uplink or instance changes every
+row). Head-to-head against `s5cmd`, `rclone`, and `tar+zstd+aws s3 cp`, on the
+shared reproducible `pkg/corpus` profiles. Competitor uploads are **byte-verified**
 (downloaded and SHA-256-compared to the source); competitor server-side request
 counts come from CloudWatch S3 request metrics (`pkg/s3metrics`) and are priced
 with the same model as CargoShip's (`pkg/s3cost`). Harness:
-`benchmarks/cargohold` (`-corpus`, `-cloudwatch-metrics`). One machine, one
-network path — recorded for reference, reproducible, not a portable absolute.
+`benchmarks/cargohold` (`-corpus`, `-cloudwatch-metrics`).
 
 **`many-tiny` — 5000 files, 9.9 MB:**
 

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -204,12 +204,44 @@ dataset exceeds a conservative file-count cap (`DirectUploadMaxFiles`, default
 1000), reserving direct upload for genuinely small sets — see
 [#466](https://github.com/scttfrdmn/cargoship/issues/466).
 
-::: warning "Fastest" and "cheapest" are goals, not verified claims
-These are CargoShip's own numbers. Head-to-head comparisons against `aws s3 cp`,
-`s5cmd`, and `rclone` on the same corpus/bucket/hardware are future work; until
-that harness exists, the [capability matrix](/project/verification) marks
-performance and cost **Aspirational**.
-:::
+### Competitor comparison (measured, 2026-09-11, LA → `us-west-2`, STANDARD)
+
+Head-to-head against `s5cmd`, `rclone`, and `tar+zstd+aws s3 cp`, on the shared
+reproducible `pkg/corpus` profiles. Competitor uploads are **byte-verified**
+(downloaded and SHA-256-compared to the source); competitor server-side request
+counts come from CloudWatch S3 request metrics (`pkg/s3metrics`) and are priced
+with the same model as CargoShip's (`pkg/s3cost`). Harness:
+`benchmarks/cargohold` (`-corpus`, `-cloudwatch-metrics`). One machine, one
+network path — recorded for reference, reproducible, not a portable absolute.
+
+**`many-tiny` — 5000 files, 9.9 MB:**
+
+| Tool | Upload MB/s | S3 requests | Request $ | Byte-verified |
+|---|---|---|---|---|
+| **CargoShip** | **9.7** | **7** | **$0.00003** | (via harness round-trip) |
+| tar+zstd+cp | 3.5 | 4 | $0.00002 | — |
+| s5cmd | 2.2 | 5,000 | $0.025 | ✅ 5000/5000 |
+| rclone | 0.1 | 15,001 | $0.029 | ✅ 5000/5000 |
+
+**`few-large` — 4 files, 46 MB:**
+
+| Tool | Upload MB/s | S3 requests | Request $ | Byte-verified |
+|---|---|---|---|---|
+| s5cmd | **56.3** | 4 | $0.00002 | ✅ 4/4 |
+| rclone | 53.5 | 13 | $0.00002 | ✅ 4/4 |
+| **CargoShip** | 47.4 | 3 | $0.00001 | (via harness round-trip) |
+| tar+zstd+cp | 30.5 | 8 | $0.00004 | — |
+
+**Honest read:** on **many-small-file** workloads CargoShip is both fastest and
+cheapest — it packs 5000 files into 5 chunks, so it pays per-object latency and
+per-object request charges a handful of times instead of 5000 (≈700× fewer
+requests than `s5cmd`). On **few-large-file** workloads a raw parallel mover
+(`s5cmd`) is faster (56 vs 47 MB/s) and request counts are all negligible, so
+there CargoShip is competitive, not ahead. Storage was ≈equal on both corpora
+because both are incompressible; compression only helps cost on compressible
+input. The [capability matrix](/project/verification) therefore marks fastest /
+cheapest **Verified for small-file workloads**, competitive elsewhere — not a
+blanket claim.
 
 ## See also
 


### PR DESCRIPTION
The competitor comparison (measured, real-AWS, byte-verified, CloudWatch request counts) moves fastest/cheapest off **Aspirational** — to a **scoped** claim, per the numbers:

- **Many-small-file workloads (5000 files):** CargoShip fastest **and** cheapest — 9.7 MB/s & **7 requests** vs s5cmd 2.2 MB/s / 5000 req, rclone 0.1 / 15001 (~700× fewer requests).
- **Few-large workloads:** s5cmd faster (56 vs 47 MB/s), request costs negligible for all — CargoShip **competitive, not ahead**. Not a blanket claim.

`benchmarks.md` records both corpora + methodology + reproduction. verification.md rows scoped by name + cite the harness (`script:` tokens). Capability + doc-version gates pass.

Part of #495.