### PR TITLE
test(pipeline): de-flake TestPipeline_TimeBreakdown

### DIFF
--- a/pkg/pipeline/integration_test.go
+++ b/pkg/pipeline/integration_test.go
@@ -246,18 +246,19 @@ func TestPipeline_TimeBreakdown(t *testing.T) {
 	t.Logf("  Upload:  %v (%.1f%%)", uploadTime, uploadPct)
 	t.Logf("  Total:   %v", totalTime)
 
-	// Validation targets from Issue #52:
-	// Archive+compress should be ~50% of time
-	// Upload should be ~30-45% of time
-
-	// Note: These are loose validations since we're simulating S3
-	// In real implementation with actual S3, these would be more accurate
-	assert.Greater(t, archivePct, 0.0, "Archive should take some time")
-	assert.Greater(t, uploadPct, 0.0, "Upload should take some time")
-
-	// Archive+Upload combined should be majority of time
-	combinedPct := archivePct + uploadPct
-	assert.Greater(t, combinedPct, 50.0, "Archive+Upload should be >50% of time")
+	// The stable invariant is that every stage did positive work — the pipeline
+	// actually exercised scan, archive, and upload. A stage's SHARE of wall-clock
+	// is NOT a reliable assertion here: the stages run concurrently in the
+	// streaming pipeline (so their times overlap and don't sum to wall-clock), and
+	// with tiny test data the whole run is single-digit milliseconds, where
+	// scheduling noise dominates. A fixed threshold like "Archive+Upload > 50%"
+	// swings above and below run to run on a shared CI runner (observed: 46.9%),
+	// so it is a flaky assertion, not a real regression signal. The percentages
+	// above are logged as a diagnostic only.
+	assert.Positive(t, scanTime, "Scan should take some time")
+	assert.Positive(t, archiveTime, "Archive should take some time")
+	assert.Positive(t, uploadTime, "Upload should take some time")
+	assert.Positive(t, totalTime, "the pipeline should record wall-clock time")
 }
 
 // Helper function to create test files


### PR DESCRIPTION
`TestPipeline_TimeBreakdown` asserted Archive+Upload > 50% of wall-clock, but the streaming pipeline runs stages **concurrently** (times overlap, don't sum to wall-clock) and the test data is tiny (single-digit ms), so a stage's share is scheduling noise. The threshold swings across 50% run to run on shared CI runners (observed **46.9%** on an unrelated docs PR — #516). Replaced with the stable invariant that every stage did positive work; the breakdown stays as a logged diagnostic. Per the fix-root-cause-don't-rerun rule.