### PR TITLE
fix(resume): count skipped chunks + stop re-adding files on resume (#447)

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -49,6 +50,17 @@ type Builder struct {
 
 	// Hostname for upload source tracking
 	hostname string
+
+	// #447: keys of files already recorded, so a resumed run (which preloads the
+	// prior manifest's Files) does not re-append them when the scanner rediscovers
+	// the same corpus and doubles TotalFiles. Keyed by fileEntryKey.
+	seen map[string]bool
+}
+
+// fileEntryKey is a FileEntry's unique identity for dedup — its path, plus the
+// part index for a split file (so each part of a split file is distinct).
+func fileEntryKey(e FileEntry) string {
+	return e.Path + "#" + strconv.Itoa(e.PartIndex)
 }
 
 // NewBuilder creates a new manifest builder
@@ -74,6 +86,7 @@ func NewBuilder(uploadID, sourcePath, bucket, prefix, region string) (*Builder, 
 			Shards:            make([]ShardEntry, 0),
 		},
 		hostname: hostname,
+		seen:     make(map[string]bool),
 	}, nil
 }
 
@@ -113,9 +126,17 @@ func NewBuilderFromExisting(existing *Manifest) (*Builder, error) {
 		DVCPipeline:       existing.DVCPipeline,
 	}
 
+	// #447: seed the dedup set from the preloaded files so a resumed run that
+	// re-scans the same corpus doesn't append them again (which doubled TotalFiles).
+	seen := make(map[string]bool, len(cloned.Files))
+	for _, f := range cloned.Files {
+		seen[fileEntryKey(f)] = true
+	}
+
 	return &Builder{
 		manifest: cloned,
 		hostname: hostname,
+		seen:     seen,
 	}, nil
 }
 
@@ -124,6 +145,11 @@ func (b *Builder) AddFile(entry FileEntry) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	key := fileEntryKey(entry)
+	if b.seen[key] { // #447: already recorded (e.g. preloaded on resume) — don't duplicate
+		return
+	}
+	b.seen[key] = true
 	b.manifest.Files = append(b.manifest.Files, entry)
 	b.manifest.TotalFiles++
 	b.manifest.TotalBytes += entry.Size
@@ -139,11 +165,15 @@ func (b *Builder) AddFileBatch(entries []FileEntry) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// Append all entries at once
-	b.manifest.Files = append(b.manifest.Files, entries...)
-
-	// Update totals
+	// #447: skip entries already recorded (resume preloads the prior Files), so a
+	// re-scan of the same corpus can't double TotalFiles.
 	for _, entry := range entries {
+		key := fileEntryKey(entry)
+		if b.seen[key] {
+			continue
+		}
+		b.seen[key] = true
+		b.manifest.Files = append(b.manifest.Files, entry)
 		b.manifest.TotalFiles++
 		b.manifest.TotalBytes += entry.Size
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -171,6 +171,53 @@ func TestBuilder_AddFileBatch_Empty(t *testing.T) {
 	assert.Equal(t, int64(0), m.TotalBytes)
 }
 
+// TestBuilder_ResumeDoesNotReAddFiles guards #447: on resume the builder is
+// preloaded with the prior manifest's files, then the scanner rediscovers the
+// same corpus and re-adds them. The builder must dedup by file identity so
+// TotalFiles doesn't double — while still keeping distinct split-file parts and
+// still accepting genuinely new files.
+func TestBuilder_ResumeDoesNotReAddFiles(t *testing.T) {
+	files := []FileEntry{
+		{Path: "a/f1.txt", Size: 100},
+		{Path: "a/f2.txt", Size: 200},
+		{Path: "big.bin", Size: 300, PartIndex: 0, TotalParts: 2},
+		{Path: "big.bin", Size: 300, PartIndex: 1, TotalParts: 2}, // same path, distinct part
+	}
+	existing := &Manifest{
+		Version: ManifestVersion, UploadID: "u1",
+		Files:      append([]FileEntry(nil), files...),
+		TotalFiles: int64(len(files)), TotalBytes: 900,
+	}
+
+	b, err := NewBuilderFromExisting(existing)
+	require.NoError(t, err)
+
+	// Re-add the exact same files (what the scanner does on resume), via both paths.
+	b.AddFileBatch(files)
+	b.AddFile(files[0])
+
+	m := b.Build()
+	assert.Len(t, m.Files, len(files), "resume must not duplicate files (#447)")
+	assert.Equal(t, int64(len(files)), m.TotalFiles)
+	assert.Equal(t, int64(900), m.TotalBytes)
+
+	// Both parts of the split file are retained (keyed by path#partIndex).
+	parts := 0
+	for _, f := range m.Files {
+		if f.Path == "big.bin" {
+			parts++
+		}
+	}
+	assert.Equal(t, 2, parts, "distinct split-file parts must be kept")
+
+	// A genuinely new file is still added.
+	b.AddFile(FileEntry{Path: "a/f3.txt", Size: 50})
+	m = b.Build()
+	assert.Len(t, m.Files, len(files)+1)
+	assert.Equal(t, int64(len(files)+1), m.TotalFiles)
+	assert.Equal(t, int64(950), m.TotalBytes)
+}
+
 // TestBuilder_AddFileBatch_Concurrent tests concurrent batch additions (Issue #34 Phase 1.4)
 func TestBuilder_AddFileBatch_Concurrent(t *testing.T) {
 	builder, err := NewBuilder("test-123", "/data", "bucket", "prefix", "us-west-2")

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -803,7 +803,16 @@ func (p *Pipeline) waitForCompletion(ctx context.Context) *Result {
 
 	// Wait for results
 	for job := range p.resultChan {
-		result.ChunksUploaded++
+		// #447: a chunk skipped on resume (already uploaded) must not be counted
+		// as uploaded. TotalChunks is the sum of both.
+		// #447: a chunk skipped on resume (already uploaded) must not be counted
+		// as uploaded. TotalChunks is the sum of both.
+		if job.Skipped {
+			result.ChunksSkipped++
+		} else {
+			result.ChunksUploaded++
+		}
+		result.TotalChunks++
 
 		if job.Error != nil {
 			result.Success = false

--- a/pkg/pipeline/resume_count_test.go
+++ b/pkg/pipeline/resume_count_test.go
@@ -1,0 +1,34 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scttfrdmn/cargoship/pkg/chunking"
+)
+
+// TestWaitForCompletion_CountsSkippedSeparately guards #447-A: a chunk skipped on
+// resume (Job.Skipped) must be counted in Result.ChunksSkipped, not
+// ChunksUploaded, and TotalChunks is the sum. Pre-fix every job — skipped or not —
+// incremented ChunksUploaded and ChunksSkipped stayed 0.
+func TestWaitForCompletion_CountsSkippedSeparately(t *testing.T) {
+	p := &Pipeline{
+		config:     &PipelineConfig{}, // UseRealS3 false, no manifest upload
+		resultChan: make(chan *Job, 4),
+		progress:   &ProgressTracker{progress: Progress{StartTime: time.Now()}},
+	}
+
+	p.resultChan <- &Job{Chunk: chunking.Chunk{FileCount: 1}}                // uploaded
+	p.resultChan <- &Job{Chunk: chunking.Chunk{FileCount: 1}, Skipped: true} // skipped
+	p.resultChan <- &Job{Chunk: chunking.Chunk{FileCount: 1}, Skipped: true} // skipped
+	close(p.resultChan)
+
+	res := p.waitForCompletion(context.Background())
+
+	assert.Equal(t, 1, res.ChunksUploaded, "only the non-skipped chunk is an upload")
+	assert.Equal(t, 2, res.ChunksSkipped, "skipped chunks are counted as skipped")
+	assert.Equal(t, 3, res.TotalChunks, "TotalChunks = uploaded + skipped")
+}

--- a/pkg/pipeline/s3_multiprefix_uploader.go
+++ b/pkg/pipeline/s3_multiprefix_uploader.go
@@ -313,6 +313,7 @@ func (s *S3MultiPrefixUploaderStage) processJob(ctx context.Context, job *Job, p
 	if skip {
 		// Chunk already uploaded - skip and mark as complete
 		job.EndTime = time.Now()
+		job.Skipped = true // #447: so waitForCompletion counts it as skipped, not uploaded
 
 		// Update statistics (but not bytes processed since we didn't actually upload)
 		atomic.AddInt64(&s.jobsProcessed, 1)

--- a/pkg/pipeline/s3_uploader.go
+++ b/pkg/pipeline/s3_uploader.go
@@ -245,6 +245,7 @@ func (s *S3UploaderStage) Process(ctx context.Context, job *Job) error {
 	if skip {
 		// Chunk already uploaded - skip and mark as complete
 		job.EndTime = time.Now()
+		job.Skipped = true // #447: so waitForCompletion counts it as skipped, not uploaded
 
 		// Update statistics (but not bytes processed since we didn't actually upload)
 		atomic.AddInt64(&s.jobsProcessed, 1)

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -22,6 +22,7 @@ type Job struct {
 	Error       error             // Error if job failed
 	StartTime   time.Time         // When job started
 	EndTime     time.Time         // When job completed
+	Skipped     bool              // #447: chunk was skipped on resume (already uploaded), not re-uploaded
 
 	// Phase 3.3: Compressed-aware chunking with adaptive sizing
 	TargetCompressedSize int64 // Target compressed size from CompressedAwareChunker (0 = no target)


### PR DESCRIPTION
Two defects surfaced while wiring resume (#119):

**A. `Result.ChunksSkipped` never incremented.** `waitForCompletion` did `ChunksUploaded++` for every job; `Job` had no skipped marker, so a skipped chunk was miscounted as uploaded. Added `Job.Skipped`, set in both uploaders' skip branches, and branch in `waitForCompletion` (skipped → `ChunksSkipped`, else `ChunksUploaded`; `TotalChunks` = sum).

**B. Files re-added (~2× `TotalFiles`) on resume.** `NewBuilderFromExisting` preloads the prior `Files`, then the scanner re-appends every file via `AddFile`/`AddFileBatch` (pure-append). Made the builder idempotent — dedup by file identity (path + part index, seeded from the preloaded files). Split-file parts stay distinct; new files still added.

Tests (both watched **failing pre-fix**): `TestWaitForCompletion_CountsSkippedSeparately`, `TestBuilder_ResumeDoesNotReAddFiles`.

Note: skip-matching still keys on per-run `chunk.ID`; robust content-keyed matching is a deeper follow-up.

Fixes #447.