### PR TITLE
feat(dashboard): completed-uploads inventory + on-demand analyze view (#449)

### DIFF
--- a/cmd/cargoship/cmd/dashboard.go
+++ b/cmd/cargoship/cmd/dashboard.go
@@ -5,46 +5,58 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/spf13/cobra"
 
 	"github.com/scttfrdmn/cargoship/pkg/aws/cost"
+	"github.com/scttfrdmn/cargoship/pkg/aws/costs"
+	s3pkg "github.com/scttfrdmn/cargoship/pkg/aws/s3"
+	"github.com/scttfrdmn/cargoship/pkg/manifest"
 	"github.com/scttfrdmn/cargoship/pkg/tui"
 )
 
 // NewDashboardCmd creates the TUI dashboard command.
 func NewDashboardCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "dashboard",
+		Use:   "dashboard [s3://bucket[/prefix]]",
 		Short: "Launch the CargoShip TUI dashboard",
 		Long: `Launch the CargoShip terminal dashboard — a read-only view over your real
-local data. It fabricates nothing; when a source has no data it says so.
+data. It fabricates nothing; when a source has no data it says so.
 
-Views:
+Views (local, always available):
 - 🏠 Overview: this month's recorded spend, budget used, in-progress uploads
 - 💰 Costs:    recorded spend this month by storage class, plus budget status
 - 📦 Uploads:  in-progress / resumable uploads and their progress
 
-Data comes from the local cost ledger (see 'cargoship cost') and local upload
-state (see 'cargoship resume'); the dashboard makes no live bucket scans. To
-browse and restore archived data interactively, use 'cargoship browse'.
+Passing an S3 target adds two bucket-backed views:
+- 🗂️  Inventory: completed uploads, read from the manifests under the prefix
+- 🔎 Analyze:   an on-demand bucket cost/savings scan (press 'a'; not automatic)
+
+Local data comes from the cost ledger (see 'cargoship cost') and upload state
+(see 'cargoship resume'). To browse and restore archived data, use
+'cargoship browse'.
 
 Navigation:
-  Tab / ← →   Switch view      1-3   Jump to a view
-  ↑ ↓         Move in a table   R     Refresh now      Q / Ctrl+C   Quit`,
+  Tab / ← →   Switch view      1-5   Jump to a view
+  ↑ ↓         Move in a table   a     Analyze (with an S3 target)
+  R           Refresh now       Q / Ctrl+C   Quit`,
 		Example: `  cargoship dashboard
   cargoship dashboard --view costs
-  cargoship dashboard --refresh 10s`,
+  cargoship dashboard s3://my-bucket/backups   # adds Inventory + Analyze`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: runDashboard,
 	}
 
-	cmd.Flags().String("view", "overview", "Initial view (overview, costs, uploads)")
+	cmd.Flags().String("view", "overview", "Initial view (overview, costs, uploads, inventory, analyze)")
 	cmd.Flags().Duration("refresh", 0, "Data refresh interval (e.g. 5s, 1m; default 5s)")
+	cmd.Flags().String("region", "", "AWS region for the S3 target (auto-detected if empty)")
+	cmd.Flags().String("profile", "", "AWS profile for the S3 target")
 
 	return cmd
 }
 
 // runDashboard starts the TUI dashboard.
-func runDashboard(cmd *cobra.Command, _ []string) error {
+func runDashboard(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	logger := slog.Default()
 
@@ -55,6 +67,10 @@ func runDashboard(cmd *cobra.Command, _ []string) error {
 		initial = tui.DashboardCosts
 	case "uploads", "upload":
 		initial = tui.DashboardUploads
+	case "inventory":
+		initial = tui.DashboardInventory
+	case "analyze":
+		initial = tui.DashboardAnalyze
 	default:
 		initial = tui.DashboardOverview
 	}
@@ -72,8 +88,107 @@ func runDashboard(cmd *cobra.Command, _ []string) error {
 		costProvider = mgr
 	}
 
-	if err := tui.NewDashboard(ctx, costProvider, initial, refresh, logger).Run(); err != nil {
+	// #449: an optional S3 target adds the Inventory + Analyze views.
+	var inv tui.InventoryProvider
+	var an tui.AnalyzeProvider
+	var target string
+	if len(args) == 1 {
+		i, a, t, err := s3Providers(ctx, cmd, args[0])
+		if err != nil {
+			return err
+		}
+		inv, an, target = i, a, t
+	}
+
+	if err := tui.NewDashboard(ctx, costProvider, inv, an, target, initial, refresh, logger).Run(); err != nil {
 		return fmt.Errorf("dashboard failed: %w", err)
 	}
 	return nil
+}
+
+// s3Providers builds the Inventory + Analyze providers for an S3 target, resolving
+// region + credentials the same way 'cargoship analyze' does.
+func s3Providers(ctx context.Context, cmd *cobra.Command, url string) (tui.InventoryProvider, tui.AnalyzeProvider, string, error) {
+	bucket, prefix, err := s3pkg.ParseS3URL(url)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("invalid S3 target %q: %w", url, err)
+	}
+	profile, _ := cmd.Flags().GetString("profile")
+	region, _ := cmd.Flags().GetString("region")
+
+	awsCfg, err := loadAWSConfig(ctx, profile, region)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("failed to load AWS config: %w", err)
+	}
+	client := s3.NewFromConfig(awsCfg)
+	if region == "" {
+		if r, err := s3pkg.GetBucketRegion(ctx, client, bucket); err == nil {
+			region = r
+			awsCfg.Region = r
+			client = s3.NewFromConfig(awsCfg)
+		}
+	}
+
+	target := fmt.Sprintf("s3://%s/%s", bucket, prefix)
+	return dashInventory{client: client, bucket: bucket, prefix: prefix},
+		dashAnalyzer{client: client, bucket: bucket, prefix: prefix, region: region},
+		target, nil
+}
+
+// dashInventory adapts manifest.ListAllManifests to tui.InventoryProvider.
+type dashInventory struct {
+	client         *s3.Client
+	bucket, prefix string
+}
+
+func (d dashInventory) ListManifests(ctx context.Context) ([]tui.ManifestSummary, error) {
+	ms, err := manifest.ListAllManifests(ctx, d.client, d.bucket, d.prefix)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]tui.ManifestSummary, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, tui.ManifestSummary{
+			UploadID:    m.UploadID,
+			Source:      m.SourcePath,
+			Destination: fmt.Sprintf("s3://%s/%s", m.Bucket, m.Prefix),
+			Files:       m.TotalFiles,
+			Bytes:       m.TotalBytes,
+			Created:     m.CreatedAt,
+			Completed:   !m.CompletedAt.IsZero(),
+		})
+	}
+	return out, nil
+}
+
+// dashAnalyzer adapts costs.S3Analyzer to tui.AnalyzeProvider.
+type dashAnalyzer struct {
+	client                 *s3.Client
+	bucket, prefix, region string
+}
+
+func (d dashAnalyzer) Analyze(ctx context.Context) (*tui.AnalyzeResult, error) {
+	scanner := s3pkg.NewBucketScanner(d.client, &s3pkg.BucketScanConfig{
+		Bucket: d.bucket, Prefix: d.prefix, Concurrency: 1,
+	})
+	analyzer := costs.NewS3Analyzer(costs.NewCalculator(d.region), scanner, d.region)
+	res, err := analyzer.Analyze(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := &tui.AnalyzeResult{}
+	if res.BucketStats != nil {
+		out.Objects = res.BucketStats.ObjectCount
+		out.Bytes = res.BucketStats.TotalSize
+	}
+	if res.CurrentCosts != nil {
+		out.CurrentMonthly = res.CurrentCosts.TotalMonthlyCost
+	}
+	if res.ProjectedCosts != nil {
+		out.ProjectedMonthly = res.ProjectedCosts.TotalMonthlyCost
+	}
+	if res.Savings != nil {
+		out.Savings = res.Savings.MonthlySavings
+	}
+	return out, nil
 }

--- a/docs/gen/cli/cargoship_dashboard.md
+++ b/docs/gen/cli/cargoship_dashboard.md
@@ -5,23 +5,28 @@ Launch the CargoShip TUI dashboard
 ### Synopsis
 
 Launch the CargoShip terminal dashboard — a read-only view over your real
-local data. It fabricates nothing; when a source has no data it says so.
+data. It fabricates nothing; when a source has no data it says so.
 
-Views:
+Views (local, always available):
 - 🏠 Overview: this month's recorded spend, budget used, in-progress uploads
 - 💰 Costs:    recorded spend this month by storage class, plus budget status
 - 📦 Uploads:  in-progress / resumable uploads and their progress
 
-Data comes from the local cost ledger (see 'cargoship cost') and local upload
-state (see 'cargoship resume'); the dashboard makes no live bucket scans. To
-browse and restore archived data interactively, use 'cargoship browse'.
+Passing an S3 target adds two bucket-backed views:
+- 🗂️  Inventory: completed uploads, read from the manifests under the prefix
+- 🔎 Analyze:   an on-demand bucket cost/savings scan (press 'a'; not automatic)
+
+Local data comes from the cost ledger (see 'cargoship cost') and upload state
+(see 'cargoship resume'). To browse and restore archived data, use
+'cargoship browse'.
 
 Navigation:
-  Tab / ← →   Switch view      1-3   Jump to a view
-  ↑ ↓         Move in a table   R     Refresh now      Q / Ctrl+C   Quit
+  Tab / ← →   Switch view      1-5   Jump to a view
+  ↑ ↓         Move in a table   a     Analyze (with an S3 target)
+  R           Refresh now       Q / Ctrl+C   Quit
 
 ```
-cargoship dashboard [flags]
+cargoship dashboard [s3://bucket[/prefix]] [flags]
 ```
 
 ### Examples
@@ -29,15 +34,17 @@ cargoship dashboard [flags]
 ```
   cargoship dashboard
   cargoship dashboard --view costs
-  cargoship dashboard --refresh 10s
+  cargoship dashboard s3://my-bucket/backups   # adds Inventory + Analyze
 ```
 
 ### Options
 
 ```
   -h, --help               help for dashboard
+      --profile string     AWS profile for the S3 target
       --refresh duration   Data refresh interval (e.g. 5s, 1m; default 5s)
-      --view string        Initial view (overview, costs, uploads) (default "overview")
+      --region string      AWS region for the S3 target (auto-detected if empty)
+      --view string        Initial view (overview, costs, uploads, inventory, analyze) (default "overview")
 ```
 
 ### Options inherited from parent commands
@@ -47,7 +54,6 @@ cargoship dashboard [flags]
       --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
       --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
       --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
-      --profile               Enable performance profiling. This will generate profile files in a temp directory
   -t, --trace                 Enable trace messages in output
   -v, --verbose               Enable verbose output
 ```

--- a/pkg/manifest/sync.go
+++ b/pkg/manifest/sync.go
@@ -178,7 +178,7 @@ func FindLatestManifestForSource(ctx context.Context, s3Client *s3.Client, bucke
 	}
 
 	// List all manifests in the bucket/prefix
-	manifests, err := listAllManifests(ctx, s3Client, bucket, prefix)
+	manifests, err := ListAllManifests(ctx, s3Client, bucket, prefix)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list manifests: %w", err)
 	}
@@ -213,8 +213,10 @@ func FindLatestManifestForSource(ctx context.Context, s3Client *s3.Client, bucke
 	return latest, nil
 }
 
-// listAllManifests lists all manifests in the specified S3 bucket/prefix
-func listAllManifests(ctx context.Context, s3Client *s3.Client, bucket, prefix string) ([]*Manifest, error) {
+// ListAllManifests lists and parses every completed-upload manifest under
+// s3://bucket/<prefix>/uploads/. Exported for the dashboard's completed-uploads
+// inventory (#449); also used internally by FindLatestManifestForSource.
+func ListAllManifests(ctx context.Context, s3Client *s3.Client, bucket, prefix string) ([]*Manifest, error) {
 	var manifests []*Manifest
 
 	// List all objects under prefix/uploads/

--- a/pkg/tui/dashboard.go
+++ b/pkg/tui/dashboard.go
@@ -26,6 +26,10 @@ const (
 	DashboardCosts
 	// DashboardUploads lists in-progress / resumable uploads.
 	DashboardUploads
+	// DashboardInventory lists completed uploads read from S3 manifests (#449).
+	DashboardInventory
+	// DashboardAnalyze shows an on-demand bucket cost/inventory analysis (#449).
+	DashboardAnalyze
 )
 
 // CostProvider is the subset of *cost.Manager the dashboard reads. It is an
@@ -36,13 +40,50 @@ type CostProvider interface {
 	GetBudgetStatus() map[string]interface{}
 }
 
+// InventoryProvider lists completed uploads from S3 manifests (#449). It is an
+// interface (nil when no bucket is configured) so pkg/tui stays free of AWS
+// dependencies and tests can inject a fake. The command layer adapts
+// manifest.ListAllManifests into ManifestSummary values.
+type InventoryProvider interface {
+	ListManifests(ctx context.Context) ([]ManifestSummary, error)
+}
+
+// ManifestSummary is one completed upload, projected from a manifest.
+type ManifestSummary struct {
+	UploadID    string
+	Source      string
+	Destination string
+	Files       int64
+	Bytes       int64
+	Created     time.Time
+	Completed   bool
+}
+
+// AnalyzeProvider runs an on-demand bucket analysis (#449). Nil when no bucket is
+// configured; the command layer adapts costs.S3Analyzer into an AnalyzeResult.
+type AnalyzeProvider interface {
+	Analyze(ctx context.Context) (*AnalyzeResult, error)
+}
+
+// AnalyzeResult is the projected outcome of a bucket scan.
+type AnalyzeResult struct {
+	Objects          int64
+	Bytes            int64
+	CurrentMonthly   float64
+	ProjectedMonthly float64
+	Savings          float64
+}
+
 // Dashboard is a read-only Bubble Tea dashboard over CargoShip's real local
 // data: the recorded cost ledger (pkg/aws/cost) and in-progress upload state
 // (pkg/resume). It fabricates nothing and performs no live bucket scans — when a
 // source has no data it says so rather than showing invented numbers.
 type Dashboard struct {
 	ctx     context.Context
-	cost    CostProvider // nil when the cost manager is unavailable
+	cost    CostProvider      // nil when the cost manager is unavailable
+	inv     InventoryProvider // nil when no bucket is configured (#449)
+	an      AnalyzeProvider   // nil when no bucket is configured (#449)
+	target  string            // "s3://bucket/prefix" for display; "" when none
 	logger  *slog.Logger
 	refresh time.Duration
 
@@ -53,12 +94,18 @@ type Dashboard struct {
 	summary    *cost.CostSummary
 	budget     map[string]interface{}
 	uploads    []*resume.UploadState
+	manifests  []ManifestSummary // #449: completed uploads from S3
+	invErr     error
+	analysis   *AnalyzeResult // #449: last on-demand bucket analysis
+	analyzeErr error
+	analyzing  bool
 	fetchErr   error
 	lastUpdate time.Time
 
 	// Widgets.
-	costTable   table.Model
-	uploadTable table.Model
+	costTable      table.Model
+	uploadTable    table.Model
+	inventoryTable table.Model
 
 	// Styles.
 	titleStyle     lipgloss.Style
@@ -72,7 +119,7 @@ type Dashboard struct {
 // spend figures then report as unavailable while Uploads still works). initial
 // selects the opening view; refresh is the data refresh cadence (a sane default
 // is applied when non-positive).
-func NewDashboard(ctx context.Context, costProvider CostProvider, initial DashboardType, refresh time.Duration, logger *slog.Logger) *Dashboard {
+func NewDashboard(ctx context.Context, costProvider CostProvider, inv InventoryProvider, an AnalyzeProvider, target string, initial DashboardType, refresh time.Duration, logger *slog.Logger) *Dashboard {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -99,16 +146,36 @@ func NewDashboard(ctx context.Context, costProvider CostProvider, initial Dashbo
 		table.WithFocused(true),
 		table.WithHeight(12),
 	)
+	inventoryTable := table.New(
+		table.WithColumns([]table.Column{
+			{Title: "Upload ID", Width: 26},
+			{Title: "Source", Width: 28},
+			{Title: "Files", Width: 10},
+			{Title: "Size", Width: 12},
+			{Title: "Created", Width: 20},
+		}),
+		table.WithFocused(true),
+		table.WithHeight(12),
+	)
+
+	tabs := []string{"🏠 Overview", "💰 Costs", "📦 Uploads"}
+	if inv != nil || an != nil { // S3-backed views only when a bucket is configured
+		tabs = append(tabs, "🗂️  Inventory", "🔎 Analyze")
+	}
 
 	return &Dashboard{
 		ctx:            ctx,
 		cost:           costProvider,
+		inv:            inv,
+		an:             an,
+		target:         target,
 		logger:         logger.With("component", "tui-dashboard"),
 		refresh:        refresh,
 		currentView:    initial,
-		tabs:           []string{"🏠 Overview", "💰 Costs", "📦 Uploads"},
+		tabs:           tabs,
 		costTable:      costTable,
 		uploadTable:    uploadTable,
+		inventoryTable: inventoryTable,
 		titleStyle:     lipgloss.NewStyle().Foreground(lipgloss.Color("86")).Background(lipgloss.Color("235")).Padding(0, 1),
 		tabStyle:       lipgloss.NewStyle().Padding(0, 1).Foreground(lipgloss.Color("252")).Background(lipgloss.Color("238")),
 		activeTabStyle: lipgloss.NewStyle().Padding(0, 1).Foreground(lipgloss.Color("15")).Background(lipgloss.Color("69")).Bold(true),
@@ -127,10 +194,18 @@ func (d *Dashboard) Run() error {
 
 // dataMsg carries a refreshed snapshot of the real data sources.
 type dataMsg struct {
-	summary *cost.CostSummary
-	budget  map[string]interface{}
-	uploads []*resume.UploadState
-	err     error
+	summary   *cost.CostSummary
+	budget    map[string]interface{}
+	uploads   []*resume.UploadState
+	manifests []ManifestSummary
+	invErr    error
+	err       error
+}
+
+// analyzeMsg carries the result of an on-demand bucket analysis (#449).
+type analyzeMsg struct {
+	result *AnalyzeResult
+	err    error
 }
 
 type tickMsg time.Time
@@ -146,7 +221,7 @@ func (d *Dashboard) tick() tea.Cmd {
 
 // fetch reads the real data sources off the UI goroutine.
 func (d *Dashboard) fetch() tea.Cmd {
-	ctx, cp := d.ctx, d.cost
+	ctx, cp, inv := d.ctx, d.cost, d.inv
 	return func() tea.Msg {
 		msg := dataMsg{}
 		// In-progress / resumable uploads (local, no AWS calls).
@@ -164,7 +239,27 @@ func (d *Dashboard) fetch() tea.Cmd {
 			// A report error (e.g. no records yet) is not fatal — Costs shows an
 			// honest empty state.
 		}
+		// #449: completed-uploads inventory from S3 manifests (a bounded ListObjects
+		// + manifest reads; cheap relative to a full bucket scan, so it refreshes
+		// with the tick).
+		if inv != nil {
+			if manifests, err := inv.ListManifests(ctx); err == nil {
+				msg.manifests = manifests
+			} else {
+				msg.invErr = err
+			}
+		}
 		return msg
+	}
+}
+
+// analyze runs the on-demand bucket analysis off the UI goroutine (#449). A full
+// bucket scan is expensive, so it is triggered by a key, not the refresh tick.
+func (d *Dashboard) analyze() tea.Cmd {
+	ctx, an := d.ctx, d.an
+	return func() tea.Msg {
+		result, err := an.Analyze(ctx)
+		return analyzeMsg{result: result, err: err}
 	}
 }
 
@@ -185,6 +280,21 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.currentView = DashboardCosts
 		case "3":
 			d.currentView = DashboardUploads
+		case "4":
+			if d.inv != nil || d.an != nil {
+				d.currentView = DashboardInventory
+			}
+		case "5":
+			if d.inv != nil || d.an != nil {
+				d.currentView = DashboardAnalyze
+			}
+		case "a":
+			// #449: run the on-demand bucket analysis (expensive; explicit trigger).
+			if d.an != nil && !d.analyzing {
+				d.analyzing = true
+				d.analyzeErr = nil
+				return d, d.analyze()
+			}
 		case "r":
 			return d, d.fetch()
 		}
@@ -194,10 +304,18 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		d.summary = msg.summary
 		d.budget = msg.budget
 		d.uploads = msg.uploads
+		d.manifests = msg.manifests
+		d.invErr = msg.invErr
 		d.fetchErr = msg.err
 		d.lastUpdate = time.Now()
 		d.costTable.SetRows(costRows(msg.summary))
 		d.uploadTable.SetRows(uploadRows(msg.uploads))
+		d.inventoryTable.SetRows(inventoryRows(msg.manifests))
+		return d, nil
+	case analyzeMsg:
+		d.analyzing = false
+		d.analysis = msg.result
+		d.analyzeErr = msg.err
 		return d, nil
 	}
 
@@ -208,6 +326,8 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		d.costTable, cmd = d.costTable.Update(msg)
 	case DashboardUploads:
 		d.uploadTable, cmd = d.uploadTable.Update(msg)
+	case DashboardInventory:
+		d.inventoryTable, cmd = d.inventoryTable.Update(msg)
 	}
 	return d, cmd
 }
@@ -232,11 +352,20 @@ func (d *Dashboard) View() string {
 		body = d.renderCosts()
 	case DashboardUploads:
 		body = d.renderUploads()
+	case DashboardInventory:
+		body = d.renderInventory()
+	case DashboardAnalyze:
+		body = d.renderAnalyze()
 	}
 
-	help := d.helpStyle.Render("tab/1-3 switch · r refresh · q quit")
+	n := len(d.tabs)
+	keys := fmt.Sprintf("tab/1-%d switch · r refresh · q quit", n)
+	if d.an != nil {
+		keys = fmt.Sprintf("tab/1-%d switch · a analyze · r refresh · q quit", n)
+	}
+	help := d.helpStyle.Render(keys)
 	if !d.lastUpdate.IsZero() {
-		help = d.helpStyle.Render(fmt.Sprintf("tab/1-3 switch · r refresh · q quit · updated %s ago", time.Since(d.lastUpdate).Round(time.Second)))
+		help = d.helpStyle.Render(fmt.Sprintf("%s · updated %s ago", keys, time.Since(d.lastUpdate).Round(time.Second)))
 	}
 	return fmt.Sprintf("%s\n%s\n\n%s\n%s", header, tabs, body, help)
 }
@@ -284,6 +413,66 @@ func (d *Dashboard) renderUploads() string {
 		body += "\n\n  " + d.errStyle.Render("could not read upload state: "+d.fetchErr.Error())
 	}
 	return body
+}
+
+func (d *Dashboard) renderInventory() string {
+	body := fmt.Sprintf("Inventory — completed uploads in %s\n\n%s", d.target, d.inventoryTable.View())
+	if d.invErr != nil {
+		body += "\n\n  " + d.errStyle.Render("could not list manifests: "+d.invErr.Error())
+	}
+	return body
+}
+
+func (d *Dashboard) renderAnalyze() string {
+	head := fmt.Sprintf("Analyze — on-demand bucket scan of %s", d.target)
+	switch {
+	case d.analyzing:
+		return head + "\n\n  scanning… (press a to re-run)"
+	case d.analyzeErr != nil:
+		return head + "\n\n  " + d.errStyle.Render("analysis failed: "+d.analyzeErr.Error())
+	case d.analysis == nil:
+		return head + "\n\n  press a to analyze (a full bucket scan; not run automatically)"
+	}
+	a := d.analysis
+	return head + "\n\n" +
+		fmt.Sprintf("  Objects:            %d\n", a.Objects) +
+		fmt.Sprintf("  Size:               %s\n", humanBytes(a.Bytes)) +
+		fmt.Sprintf("  Current storage:    $%.2f/mo\n", a.CurrentMonthly) +
+		fmt.Sprintf("  Projected (CargoShip): $%.2f/mo\n", a.ProjectedMonthly) +
+		fmt.Sprintf("  Potential savings:  $%.2f/mo", a.Savings)
+}
+
+// inventoryRows maps completed-upload summaries into table rows; an empty set
+// yields a single honest "no completed uploads" row rather than fabricated data.
+func inventoryRows(manifests []ManifestSummary) []table.Row {
+	if len(manifests) == 0 {
+		return []table.Row{{"(no completed uploads found)", "", "", "", ""}}
+	}
+	rows := make([]table.Row, 0, len(manifests))
+	for _, m := range manifests {
+		rows = append(rows, table.Row{
+			m.UploadID,
+			m.Source,
+			fmt.Sprintf("%d", m.Files),
+			humanBytes(m.Bytes),
+			m.Created.Format("2006-01-02 15:04"),
+		})
+	}
+	return rows
+}
+
+// humanBytes renders a byte count as a compact human-readable size.
+func humanBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
 // costRows maps a cost summary's per-storage-class spend into table rows. A nil

--- a/pkg/tui/dashboard_test.go
+++ b/pkg/tui/dashboard_test.go
@@ -13,8 +13,25 @@ import (
 )
 
 func newTestDashboard() *Dashboard {
-	return NewDashboard(context.Background(), nil, DashboardOverview, time.Second, nil)
+	return NewDashboard(context.Background(), nil, nil, nil, "", DashboardOverview, time.Second, nil)
 }
+
+// fakeInventory / fakeAnalyzer are in-memory providers for the S3-backed views.
+type fakeInventory struct {
+	manifests []ManifestSummary
+	err       error
+}
+
+func (f fakeInventory) ListManifests(context.Context) ([]ManifestSummary, error) {
+	return f.manifests, f.err
+}
+
+type fakeAnalyzer struct {
+	result *AnalyzeResult
+	err    error
+}
+
+func (f fakeAnalyzer) Analyze(context.Context) (*AnalyzeResult, error) { return f.result, f.err }
 
 // TestDashboard_UpdateSwitchesViews checks the real key handling: number keys and
 // tab move between the three views.
@@ -131,6 +148,66 @@ func TestUploadRows_EmptyIsHonest(t *testing.T) {
 	rows := uploadRows(nil)
 	if len(rows) != 1 || rows[0][0] == "" {
 		t.Fatalf("empty uploads should yield one honest row, got %v", rows)
+	}
+}
+
+// TestDashboard_S3TabsOnlyWithTarget: the Inventory/Analyze tabs (and keys 4/5)
+// appear only when a bucket-backed provider is configured (#449).
+func TestDashboard_S3TabsOnlyWithTarget(t *testing.T) {
+	// No providers → three tabs, keys 4/5 are no-ops.
+	d := newTestDashboard()
+	if len(d.tabs) != 3 {
+		t.Fatalf("no target should give 3 tabs, got %d", len(d.tabs))
+	}
+	if m, _ := d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")}); m.(*Dashboard).currentView != DashboardOverview {
+		t.Error("key 4 without a target should be a no-op")
+	}
+
+	// With providers → five tabs, key 4 selects Inventory.
+	dd := NewDashboard(context.Background(), nil, fakeInventory{}, fakeAnalyzer{}, "s3://b/p", DashboardOverview, time.Second, nil)
+	if len(dd.tabs) != 5 {
+		t.Fatalf("a target should give 5 tabs, got %d", len(dd.tabs))
+	}
+	if m, _ := dd.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")}); m.(*Dashboard).currentView != DashboardInventory {
+		t.Error("key 4 with a target should select Inventory")
+	}
+}
+
+// TestDashboard_InventoryRows maps completed-upload summaries and stays honest when empty.
+func TestInventoryRows(t *testing.T) {
+	rows := inventoryRows([]ManifestSummary{
+		{UploadID: "20260101-a", Source: "/data", Files: 1234, Bytes: 5 << 20, Created: time.Now()},
+	})
+	if len(rows) != 1 || rows[0][0] != "20260101-a" || rows[0][2] != "1234" {
+		t.Fatalf("inventory row not mapped: %v", rows)
+	}
+	empty := inventoryRows(nil)
+	if len(empty) != 1 || empty[0][0] == "" || empty[0][2] != "" {
+		t.Fatalf("empty inventory should be one honest row, got %v", empty)
+	}
+}
+
+// TestDashboard_AnalyzeOnDemand: pressing 'a' runs the analyzer and the result renders.
+func TestDashboard_AnalyzeOnDemand(t *testing.T) {
+	an := fakeAnalyzer{result: &AnalyzeResult{Objects: 100, Bytes: 2 << 20, CurrentMonthly: 3, ProjectedMonthly: 1, Savings: 2}}
+	d := NewDashboard(context.Background(), nil, fakeInventory{}, an, "s3://b/p", DashboardAnalyze, time.Second, nil)
+
+	// Before analyzing: honest "press a" prompt, no fabricated numbers.
+	if out := d.View(); !strings.Contains(out, "press a to analyze") {
+		t.Errorf("Analyze view should prompt before running, got:\n%s", out)
+	}
+	// Press 'a' → returns the analyze command; run it and feed the message back.
+	m, cmd := d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	d = m.(*Dashboard)
+	if cmd == nil {
+		t.Fatal("'a' should trigger an analyze command")
+	}
+	d.Update(cmd()) // execute the command, deliver analyzeMsg
+	if d.analysis == nil || d.analysis.Objects != 100 {
+		t.Fatalf("analyze result not stored: %+v", d.analysis)
+	}
+	if out := d.View(); !strings.Contains(out, "Potential savings") {
+		t.Errorf("Analyze view should render the result, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Adds two S3-backed dashboard views, opt-in via an S3 target (`cargoship dashboard s3://bucket/prefix`); without a target the dashboard is unchanged.

- **🗂️ Inventory** — completed uploads read from the manifests under the prefix, via `manifest.ListAllManifests` (exported for this). Refreshes with the tick.
- **🔎 Analyze** — on-demand bucket cost/savings scan (press `a`; a full scan, so not automatic), reusing `costs.S3Analyzer` + `s3.BucketScanner` (same as `cargoship analyze`).

`pkg/tui` stays free of AWS deps: small `InventoryProvider`/`AnalyzeProvider` interfaces + `ManifestSummary`/`AnalyzeResult` types, adapted by the command layer. Anti-theater preserved (honest empty/"press a"/unavailable states). Tests use fake providers (inventory honest-empty, analyze on-demand render, tabs-only-with-target). CLI docs regenerated.

Closes #449.