### PR TITLE
feat(s3): migrate off the deprecated manager.Uploader to transfermanager (#384)

### DIFF
--- a/cmd/cargoship/cmd/filesystem_integration_test.go
+++ b/cmd/cargoship/cmd/filesystem_integration_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/require"
@@ -347,13 +347,13 @@ func (s *IntegrationTestSuite) UploadToS3(localPath, s3Key string) string {
 	require.NoError(s.t, err, "Failed to open file for upload: %s", localPath)
 	defer file.Close()
 
-	// Use the multipart upload manager rather than a bare PutObject: S3 caps a
-	// single PutObject at 5 GiB, and this suite uploads larger archives. The
-	// manager streams the file in bounded-size parts, which is also what
-	// CargoShip's own uploader does — so it keeps process memory flat regardless
-	// of file size (see #239).
-	uploader := manager.NewUploader(s.S3Client)
-	_, err = uploader.Upload(ctx, &s3.PutObjectInput{
+	// Use the SDK transfer manager rather than a bare PutObject: S3 caps a single
+	// PutObject at 5 GiB, and this suite uploads larger archives. transfermanager
+	// streams the file in bounded-size parts, which is also what CargoShip's own
+	// uploader does (#384) — so it keeps process memory flat regardless of file
+	// size (see #239).
+	uploader := transfermanager.New(s.S3Client)
+	_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
 		Bucket: aws.String(s.S3Bucket),
 		Key:    aws.String(s3Key),
 		Body:   file,

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,6 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.45.1
 	github.com/aws/aws-sdk-go-v2/config v1.33.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.20.1
-	// Pinned: see the #384 note in .github/dependabot.yml. v1.22.35+ deprecates
-	// the Uploader API in favour of feature/s3/transfermanager, which is 11
-	// blocking SA1019 on the upload path. Bump only via the #384 migration.
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.82
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.69.1
 	github.com/aws/aws-sdk-go-v2/service/kms v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.46.1
@@ -50,6 +46,10 @@ require (
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+// #384: migrated the upload path off the deprecated feature/s3/manager Uploader.
+// NOTE: transfermanager is still pre-1.0 (v0.x) — watch for breaking changes on bump.
+require github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.3.9
 
 require (
 	dario.cat/mergo v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.20.1 h1:Z8GRNEx0u9sDkZOq4PUnN8mjGwbU
 github.com/aws/aws-sdk-go-v2/credentials v1.20.1/go.mod h1:uBIK00kFo95dnemqfFMTWx0X8YRqsh6ecIoCjjOkZqM=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.19.1 h1:YIEBqcqRnpi4Pfv0YHImtgi6czGCwKHANC7SwmUAVD0=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.19.1/go.mod h1:imEf0oufgAo8KAkCHhrOdqGEC0YWx1PPBQH82shSxGw=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.82 h1:EO13QJTCD1Ig2IrQnoHTRrn981H9mB7afXsZ89WptI4=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.82/go.mod h1:AGh1NCg0SH+uyJamiJA5tTQcql4MMRDXGRdMmCxCXzY=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.3.9 h1:LKgUMt2H+6ew/+BuybwBS8Or7Xnjh0OO/UKC2dhNQOc=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.3.9/go.mod h1:saCYE0P4PiIN98vX4E30sfzzaqB/1m6VS5GufInE1aQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1 h1:pc138gM1CW+XPc60rEwUlwwuwWFQK16CI1T7v1F9Oec=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1/go.mod h1:1+koxpPIbfBdfzP6vojm5/zTpTQ/micYwlxIiNB3TxI=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1 h1:K0JsbZQj+1h208Ro1zHeA4l7bMp0NvRffHQ91q8Ol1s=

--- a/pkg/aws/s3/optimized_transporter.go
+++ b/pkg/aws/s3/optimized_transporter.go
@@ -9,7 +9,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
@@ -20,7 +21,7 @@ import (
 // OptimizedTransporter provides backward-compatible CargoShip transport using new optimization modules
 type OptimizedTransporter struct {
 	optimizer *s3optimization.S3Optimizer
-	uploader  *manager.Uploader
+	uploader  *transfermanager.Client
 	config    awsconfig.S3Config
 	logger    *slog.Logger
 }
@@ -60,12 +61,13 @@ func NewOptimizedTransporter(ctx context.Context, s3Client *s3.Client, config aw
 		return nil, fmt.Errorf("failed to create S3 optimizer: %w", err)
 	}
 
-	// Create AWS SDK uploader for reliable Content-Length handling
-	uploader := manager.NewUploader(s3Client, func(u *manager.Uploader) {
-		u.PartSize = config.MultipartChunkSize
-		u.Concurrency = int(config.Concurrency)
-		u.LeavePartsOnError = false
-		u.MaxUploadParts = 10000
+	// #384: transfermanager replaces the deprecated manager.Uploader. It aborts a
+	// failed multipart upload by default (no LeavePartsOnError) and manages its own
+	// buffers; part size, concurrency, and max-parts map directly.
+	uploader := transfermanager.New(s3Client, func(o *transfermanager.Options) {
+		o.PartSizeBytes = config.MultipartChunkSize
+		o.Concurrency = int(config.Concurrency)
+		o.MaxUploadParts = 10000
 	})
 
 	transporter := &OptimizedTransporter{
@@ -88,12 +90,12 @@ func NewOptimizedTransporter(ctx context.Context, s3Client *s3.Client, config aw
 // putObjectInput builds the S3 PutObjectInput for an archive. Extracted from
 // Upload so the header mapping — notably the #353 Content-Encoding rule — is
 // unit-testable without a live S3 client.
-func (t *OptimizedTransporter) putObjectInput(archive *Archive) *s3.PutObjectInput {
-	input := &s3.PutObjectInput{
+func (t *OptimizedTransporter) putObjectInput(archive *Archive) *transfermanager.UploadObjectInput {
+	input := &transfermanager.UploadObjectInput{
 		Bucket:       aws.String(t.config.Bucket),
 		Key:          aws.String(archive.Key),
 		Body:         archive.Reader,
-		StorageClass: types.StorageClass(archive.StorageClass),
+		StorageClass: tmtypes.StorageClass(string(archive.StorageClass)),
 		Metadata:     archive.Metadata,
 	}
 
@@ -105,14 +107,14 @@ func (t *OptimizedTransporter) putObjectInput(archive *Archive) *s3.PutObjectInp
 
 	// Add KMS encryption if configured
 	if t.config.KMSKeyID != "" {
-		input.ServerSideEncryption = types.ServerSideEncryptionAwsKms
-		input.SSEKMSKeyId = aws.String(t.config.KMSKeyID)
+		input.ServerSideEncryption = tmtypes.ServerSideEncryptionAwsKms
+		input.SSEKMSKeyID = aws.String(t.config.KMSKeyID)
 	}
 
 	return input
 }
 
-// Upload performs an optimized CargoShip archive upload using manager.Uploader
+// Upload performs an optimized CargoShip archive upload using the SDK transfer manager
 func (t *OptimizedTransporter) Upload(ctx context.Context, archive *Archive) (*UploadResult, error) {
 	if archive == nil {
 		return nil, fmt.Errorf("archive cannot be nil")
@@ -130,8 +132,8 @@ func (t *OptimizedTransporter) Upload(ctx context.Context, archive *Archive) (*U
 	// Convert CargoShip archive to S3 input (extracted for unit testing).
 	input := t.putObjectInput(archive)
 
-	// Use manager.Uploader which handles Content-Length automatically
-	result, err := t.uploader.Upload(ctx, input)
+	// transfermanager handles Content-Length and multipart automatically.
+	result, err := t.uploader.UploadObject(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("optimized upload failed: %w", err)
 	}
@@ -147,10 +149,10 @@ func (t *OptimizedTransporter) Upload(ctx context.Context, archive *Archive) (*U
 
 	// Convert result back to CargoShip format
 	uploadResult := &UploadResult{
-		Location:     result.Location,
+		Location:     aws.ToString(result.Location), // #384: *string now
 		Key:          archive.Key,
 		ETag:         aws.ToString(result.ETag),
-		UploadID:     result.UploadID,
+		UploadID:     aws.ToString(result.UploadID),
 		Duration:     duration,
 		Throughput:   throughput,
 		StorageClass: types.StorageClass(archive.StorageClass),

--- a/pkg/aws/s3/transporter.go
+++ b/pkg/aws/s3/transporter.go
@@ -10,7 +10,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
@@ -22,7 +23,7 @@ import (
 // Transporter implements S3-based transport for CargoShip
 type Transporter struct {
 	client   *s3.Client
-	uploader *manager.Uploader
+	uploader *transfermanager.Client
 	config   awsconfig.S3Config
 	tracer   *tracing.S3Tracer // Optional: S3 operation tracer (Issue #155)
 }
@@ -66,14 +67,13 @@ type UploadResult struct {
 
 // NewTransporter creates a new S3 transporter
 func NewTransporter(client *s3.Client, config awsconfig.S3Config) *Transporter {
-	uploader := manager.NewUploader(client, func(u *manager.Uploader) {
-		u.PartSize = config.MultipartChunkSize
-		u.Concurrency = config.Concurrency
-		u.LeavePartsOnError = false // Clean up failed uploads
-		// Issue #34 Phase 2.2: Increased from 25MB to 64MB buffers
-		// Better matches typical chunk sizes, reduces buffer allocation overhead
-		// Pool size automatically managed by AWS SDK (typically 16 buffers = 1GB total)
-		u.BufferProvider = manager.NewBufferedReadSeekerWriteToPool(64 * 1024 * 1024)
+	// #384: migrated off the deprecated feature/s3/manager Uploader to
+	// feature/s3/transfermanager. transfermanager aborts a failed multipart upload
+	// by default (no LeavePartsOnError knob) and manages its own part buffers (no
+	// BufferProvider); part size and concurrency map directly.
+	uploader := transfermanager.New(client, func(o *transfermanager.Options) {
+		o.PartSizeBytes = config.MultipartChunkSize
+		o.Concurrency = config.Concurrency
 	})
 
 	return &Transporter{
@@ -91,12 +91,14 @@ func (t *Transporter) SetTracer(tracer *tracing.S3Tracer) {
 // putObjectInput builds the S3 PutObjectInput for an archive. Extracted from
 // Upload so the header/metadata mapping — notably the #353 Content-Encoding
 // rule — is unit-testable without a live S3 client.
-func (t *Transporter) putObjectInput(archive Archive, storageClass types.StorageClass) *s3.PutObjectInput {
-	input := &s3.PutObjectInput{
-		Bucket:       aws.String(t.config.Bucket),
-		Key:          aws.String(archive.Key),
-		Body:         archive.Reader,
-		StorageClass: storageClass,
+func (t *Transporter) putObjectInput(archive Archive, storageClass types.StorageClass) *transfermanager.UploadObjectInput {
+	input := &transfermanager.UploadObjectInput{
+		Bucket: aws.String(t.config.Bucket),
+		Key:    aws.String(archive.Key),
+		Body:   archive.Reader,
+		// #384: transfermanager has its own StorageClass enum with identical string
+		// values (STANDARD, GLACIER, …), so a string cast preserves the class.
+		StorageClass: tmtypes.StorageClass(string(storageClass)),
 		Metadata:     t.buildMetadata(archive),
 	}
 
@@ -109,8 +111,8 @@ func (t *Transporter) putObjectInput(archive Archive, storageClass types.Storage
 
 	// Add KMS encryption if configured
 	if t.config.KMSKeyID != "" {
-		input.ServerSideEncryption = types.ServerSideEncryptionAwsKms
-		input.SSEKMSKeyId = aws.String(t.config.KMSKeyID)
+		input.ServerSideEncryption = tmtypes.ServerSideEncryptionAwsKms
+		input.SSEKMSKeyID = aws.String(t.config.KMSKeyID)
 	}
 
 	return input
@@ -138,7 +140,7 @@ func (t *Transporter) Upload(ctx context.Context, archive Archive) (*UploadResul
 	input := t.putObjectInput(archive, storageClass)
 
 	// Perform upload
-	result, err := t.uploader.Upload(ctx, input)
+	result, err := t.uploader.UploadObject(ctx, input)
 	if err != nil {
 		// Record error in span
 		if span != nil && t.tracer != nil {
@@ -158,10 +160,11 @@ func (t *Transporter) Upload(ctx context.Context, archive Archive) (*UploadResul
 	}
 
 	return &UploadResult{
-		Location:     result.Location,
+		// #384: transfermanager returns *string for these (manager returned string).
+		Location:     aws.ToString(result.Location),
 		Key:          archive.Key,
 		ETag:         aws.ToString(result.ETag),
-		UploadID:     result.UploadID,
+		UploadID:     aws.ToString(result.UploadID),
 		Duration:     duration,
 		Throughput:   throughput,
 		StorageClass: storageClass,

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -981,13 +981,13 @@ func (p *Pipeline) savePartialManifest(ctx context.Context) error {
 	// Construct S3 key: prefix/uploads/{uploadID}/manifest.partial.json.gz
 	s3Key := fmt.Sprintf("%s/uploads/%s/manifest.partial.json.gz", p.config.S3Prefix, p.config.UploadID)
 
-	// Upload to S3 using the same S3 client
+	// Upload to S3 using the same S3 client (#384: transfermanager).
 	s3Client := p.config.S3Client.(*s3.Client)
-	uploader := manager.NewUploader(s3Client, func(u *manager.Uploader) {
-		u.PartSize = 5 * 1024 * 1024 // 5MB parts
+	uploader := transfermanager.New(s3Client, func(o *transfermanager.Options) {
+		o.PartSizeBytes = 5 * 1024 * 1024 // 5MB parts
 	})
 
-	input := &s3.PutObjectInput{
+	input := &transfermanager.UploadObjectInput{
 		Bucket:      aws.String(p.config.S3Bucket),
 		Key:         aws.String(s3Key),
 		Body:        bytes.NewReader(manifestBytes),
@@ -1001,7 +1001,7 @@ func (p *Pipeline) savePartialManifest(ctx context.Context) error {
 		},
 	}
 
-	_, err = uploader.Upload(ctx, input)
+	_, err = uploader.UploadObject(ctx, input)
 	if err != nil {
 		return fmt.Errorf("failed to upload partial manifest to S3: %w", err)
 	}

--- a/pkg/pipeline/s3_multiprefix_uploader.go
+++ b/pkg/pipeline/s3_multiprefix_uploader.go
@@ -14,7 +14,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	smithy "github.com/aws/smithy-go"
 	s3transport "github.com/scttfrdmn/cargoship/pkg/aws/s3"
@@ -53,7 +54,7 @@ type S3MultiPrefixUploaderStage struct {
 	perPrefixStats map[string]*PrefixStats
 
 	// S3 uploader (shared across all workers)
-	uploader *manager.Uploader
+	uploader *transfermanager.Client
 
 	// v0.6.2: Advanced transporter (optional, shared across all shards)
 	transporter s3transport.BasicTransporter
@@ -116,12 +117,11 @@ func NewS3MultiPrefixUploaderStage(
 		logger = slog.Default()
 	}
 
-	// Create AWS S3 uploader with optimized settings (backward compatibility)
-	uploader := manager.NewUploader(config.S3Client, func(u *manager.Uploader) {
-		u.PartSize = config.PartSize
-		u.Concurrency = 4 // Internal concurrency per upload
-		u.LeavePartsOnError = false
-		u.BufferProvider = manager.NewBufferedReadSeekerWriteToPool(25 * 1024 * 1024)
+	// Create AWS S3 uploader with optimized settings (#384: transfermanager, which
+	// aborts a failed multipart upload by default and manages its own buffers).
+	uploader := transfermanager.New(config.S3Client, func(o *transfermanager.Options) {
+		o.PartSizeBytes = config.PartSize
+		o.Concurrency = 4 // Internal concurrency per upload
 	})
 
 	// Initialize per-prefix stats
@@ -510,7 +510,7 @@ func (s *S3MultiPrefixUploaderStage) uploadToS3(ctx context.Context, job *Job) e
 		"cargoship-archive":     "tar",
 	}
 
-	// Choose upload path: transporter (advanced) or manager.Uploader (basic)
+	// Choose upload path: transporter (advanced) or the SDK transfer manager (basic)
 	if s.transporter != nil {
 		return s.uploadViaTransporter(ctx, s3Key, job, metadata)
 	}
@@ -561,33 +561,34 @@ func (s *S3MultiPrefixUploaderStage) maybeSignalThrottle(err error, job *Job) {
 	}
 }
 
-// uploadViaManager uploads using basic AWS SDK manager.Uploader (backward compatibility)
+// uploadViaManager uploads using basic AWS SDK the SDK transfer manager (backward compatibility)
 func (s *S3MultiPrefixUploaderStage) uploadViaManager(ctx context.Context, s3Key string, job *Job, metadata map[string]string) error {
-	// Prepare upload input
-	input := &s3.PutObjectInput{
+	// Prepare upload input (#384: transfermanager types; string casts preserve
+	// identical StorageClass/SSE values).
+	input := &transfermanager.UploadObjectInput{
 		Bucket:       aws.String(s.config.Bucket),
 		Key:          aws.String(s3Key),
 		Body:         job.Archive,
-		StorageClass: s.config.StorageClass,
+		StorageClass: tmtypes.StorageClass(string(s.config.StorageClass)),
 		Metadata:     metadata,
 	}
 
 	// Add server-side encryption if configured
 	if s.config.ServerSideEncryption != "" {
-		input.ServerSideEncryption = s.config.ServerSideEncryption
+		input.ServerSideEncryption = tmtypes.ServerSideEncryption(string(s.config.ServerSideEncryption))
 		if s.config.SSEKMSKeyId != "" {
-			input.SSEKMSKeyId = aws.String(s.config.SSEKMSKeyId)
+			input.SSEKMSKeyID = aws.String(s.config.SSEKMSKeyId)
 		}
 	}
 
-	// Ensure job.Archive implements io.Reader for manager.Uploader
+	// Ensure job.Archive implements io.Reader
 	var reader io.Reader = job.Archive
 
 	// Replace Body with reader to ensure interface satisfaction
 	input.Body = reader
 
-	// Upload using AWS SDK manager (handles multipart automatically)
-	_, err := s.uploader.Upload(ctx, input)
+	// Upload (handles multipart automatically)
+	_, err := s.uploader.UploadObject(ctx, input)
 	if err != nil {
 		s.maybeSignalThrottle(err, job)
 		return fmt.Errorf("S3 upload failed for %s: %w", job.S3Key, err)

--- a/pkg/pipeline/s3_uploader.go
+++ b/pkg/pipeline/s3_uploader.go
@@ -11,7 +11,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	awsconfig "github.com/scttfrdmn/cargoship/pkg/aws/config"
@@ -38,7 +39,7 @@ type S3UploaderConfig struct {
 	TierSelector *StorageTierSelector // If nil, uses StorageClass for all uploads
 
 	// Advanced transporter (v0.6.2)
-	// If set, uses advanced S3 transporter instead of basic manager.Uploader
+	// If set, uses advanced S3 transporter instead of basic SDK transfer manager
 	Transporter s3transport.BasicTransporter // Optional advanced transporter
 
 	// #424: real congestion control. When EnableOptimization is set, the
@@ -66,7 +67,7 @@ type S3UploaderStage struct {
 	bytesProcessed int64
 
 	// S3 uploader
-	uploader *manager.Uploader
+	uploader *transfermanager.Client
 
 	// Manifest tracking (Issue #157)
 	pipeline *Pipeline // Reference to parent pipeline for resume capability
@@ -104,12 +105,11 @@ func NewS3UploaderStage(config *S3UploaderConfig, input <-chan *Job, output chan
 		logger = slog.Default()
 	}
 
-	// Create AWS S3 uploader with optimized settings
-	uploader := manager.NewUploader(config.S3Client, func(u *manager.Uploader) {
-		u.PartSize = config.PartSize
-		u.Concurrency = 4 // Internal concurrency per upload
-		u.LeavePartsOnError = false
-		u.BufferProvider = manager.NewBufferedReadSeekerWriteToPool(25 * 1024 * 1024)
+	// Create AWS S3 uploader with optimized settings (#384: transfermanager, which
+	// aborts a failed multipart upload by default and manages its own buffers).
+	uploader := transfermanager.New(config.S3Client, func(o *transfermanager.Options) {
+		o.PartSizeBytes = config.PartSize
+		o.Concurrency = 4 // Internal concurrency per upload
 	})
 
 	return &S3UploaderStage{
@@ -383,13 +383,13 @@ func (s *S3UploaderStage) uploadToS3(ctx context.Context, job *Job) error {
 		"cargoship-archive":     "tar",
 	}
 
-	// Choose upload path: transporter (advanced) or manager.Uploader (basic)
+	// Choose upload path: transporter (advanced) or the SDK transfer manager (basic)
 	if s.config.Transporter != nil {
 		// Use advanced transporter (staging, adaptive, optimized)
 		return s.uploadViaTransporter(ctx, s3Key, job, metadata)
 	}
 
-	// Fallback to basic manager.Uploader (backward compatibility)
+	// Fallback to basic SDK transfer manager (backward compatibility)
 	return s.uploadViaManager(ctx, s3Key, job, metadata)
 }
 
@@ -450,7 +450,7 @@ func (s *S3UploaderStage) uploadViaTransporter(ctx context.Context, s3Key string
 	return nil
 }
 
-// uploadViaManager uploads using basic AWS SDK manager.Uploader (backward compatibility)
+// uploadViaManager uploads using basic AWS SDK the SDK transfer manager (backward compatibility)
 func (s *S3UploaderStage) uploadViaManager(ctx context.Context, s3Key string, job *Job, metadata map[string]string) error {
 	// Determine storage class: use pre-assigned tier (Issue #164), TierSelector, or default
 	storageClass := s.config.StorageClass
@@ -485,31 +485,32 @@ func (s *S3UploaderStage) uploadViaManager(ctx context.Context, s3Key string, jo
 		}
 	}
 
-	// Prepare upload input
-	input := &s3.PutObjectInput{
+	// Prepare upload input (#384: transfermanager's own input/enum types; string
+	// casts preserve identical StorageClass/SSE values).
+	input := &transfermanager.UploadObjectInput{
 		Bucket:       aws.String(s.config.Bucket),
 		Key:          aws.String(s3Key),
 		Body:         job.Archive,
-		StorageClass: storageClass,
+		StorageClass: tmtypes.StorageClass(string(storageClass)),
 		Metadata:     metadata,
 	}
 
 	// Add server-side encryption if configured
 	if s.config.ServerSideEncryption != "" {
-		input.ServerSideEncryption = s.config.ServerSideEncryption
+		input.ServerSideEncryption = tmtypes.ServerSideEncryption(string(s.config.ServerSideEncryption))
 		if s.config.SSEKMSKeyId != "" {
-			input.SSEKMSKeyId = aws.String(s.config.SSEKMSKeyId)
+			input.SSEKMSKeyID = aws.String(s.config.SSEKMSKeyId)
 		}
 	}
 
-	// Ensure job.Archive implements io.Reader for manager.Uploader
+	// Ensure job.Archive implements io.Reader
 	var reader io.Reader = job.Archive
 
 	// Replace Body with reader to ensure interface satisfaction
 	input.Body = reader
 
-	// Upload using AWS SDK manager (handles multipart automatically)
-	_, err := s.uploader.Upload(ctx, input)
+	// Upload (handles multipart automatically)
+	_, err := s.uploader.UploadObject(ctx, input)
 	if err != nil {
 		return fmt.Errorf("S3 upload failed for %s: %w", job.S3Key, err)
 	}

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -269,7 +269,7 @@ type PipelineConfig struct {
 	KMSClient       interface{} // *kms.Client for manifest encryption (type: *github.com/aws/aws-sdk-go-v2/service/kms.Client)
 
 	// Advanced transporter configuration (v0.6.2)
-	// If set, uses advanced S3 transporters (staging, adaptive, optimized) instead of basic manager.Uploader
+	// If set, uses advanced S3 transporters (staging, adaptive, optimized) instead of basic SDK transfer manager
 	// Set via NewPipelineTransporter() factory
 	Transporter interface{} // s3transport.BasicTransporter for advanced uploads (type: github.com/scttfrdmn/cargoship/pkg/aws/s3.BasicTransporter)
 


### PR DESCRIPTION
The `feature/s3/manager` Uploader is deprecated (SA1019), blocking the aws-sdk group bump (#370). Migrates the whole upload path to `feature/s3/transfermanager` across all 5 sites (2 transporters + 3 pipeline files + a test helper).

**Mapping:** `manager.NewUploader`→`transfermanager.New`; `PartSize`→`PartSizeBytes`; Concurrency/MaxUploadParts direct; `*s3.PutObjectInput`→`*transfermanager.UploadObjectInput` (StorageClass/SSE → transfermanager/types via string cast — identical enum values; `SSEKMSKeyId`→`SSEKMSKeyID`); `Upload`→`UploadObject`; result Location/UploadID now `*string`. `LeavePartsOnError`/`BufferProvider` have no equivalent (transfermanager aborts a failed MPU by default + manages its own buffers).

`manager` fully removed from go.mod → **resolves all 11 SA1019** and unblocks #370. transfermanager pinned v0.3.9, noted **pre-1.0**.

**Validated** (the byte path on a pre-1.0 SDK): emulator integration (pkg/aws/s3 + pkg/pipeline incl. storage-class mapping) + torture byte-exact round-trip, **and a real-AWS multipart upload + byte-identical restore** (300 MB, us-west-2). `staticcheck` = 0 SA1019 on the migrated packages.

Closes #384. Unblocks #370.