### PR TITLE
perf(s3): drop the redundant per-upload CRC32 (#522)

### DIFF
--- a/pkg/aws/s3/optimized_transporter.go
+++ b/pkg/aws/s3/optimized_transporter.go
@@ -68,6 +68,8 @@ func NewOptimizedTransporter(ctx context.Context, s3Client *s3.Client, config aw
 		o.PartSizeBytes = config.MultipartChunkSize
 		o.Concurrency = int(config.Concurrency)
 		o.MaxUploadParts = 10000
+		// #522: skip the SDK's default per-upload CRC32 (redundant with our SHA-256).
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 	})
 
 	transporter := &OptimizedTransporter{

--- a/pkg/aws/s3/transporter.go
+++ b/pkg/aws/s3/transporter.go
@@ -74,6 +74,11 @@ func NewTransporter(client *s3.Client, config awsconfig.S3Config) *Transporter {
 	uploader := transfermanager.New(client, func(o *transfermanager.Options) {
 		o.PartSizeBytes = config.MultipartChunkSize
 		o.Concurrency = config.Concurrency
+		// #522: transfermanager defaults to calculating a CRC32 on every upload,
+		// which is ~5% of upload CPU and redundant with CargoShip's own per-archive
+		// SHA-256 (#271) + verify-on-restore. Only compute a checksum when the API
+		// requires it. TLS still protects bytes on the wire.
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 	})
 
 	return &Transporter{

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -985,6 +985,8 @@ func (p *Pipeline) savePartialManifest(ctx context.Context) error {
 	s3Client := p.config.S3Client.(*s3.Client)
 	uploader := transfermanager.New(s3Client, func(o *transfermanager.Options) {
 		o.PartSizeBytes = 5 * 1024 * 1024 // 5MB parts
+		// #522: skip the SDK's default per-upload CRC32 (redundant with our SHA-256).
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 	})
 
 	input := &transfermanager.UploadObjectInput{

--- a/pkg/pipeline/s3_multiprefix_uploader.go
+++ b/pkg/pipeline/s3_multiprefix_uploader.go
@@ -122,6 +122,8 @@ func NewS3MultiPrefixUploaderStage(
 	uploader := transfermanager.New(config.S3Client, func(o *transfermanager.Options) {
 		o.PartSizeBytes = config.PartSize
 		o.Concurrency = 4 // Internal concurrency per upload
+		// #522: skip the SDK's default per-upload CRC32 (redundant with our SHA-256).
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 	})
 
 	// Initialize per-prefix stats

--- a/pkg/pipeline/s3_uploader.go
+++ b/pkg/pipeline/s3_uploader.go
@@ -110,6 +110,8 @@ func NewS3UploaderStage(config *S3UploaderConfig, input <-chan *Job, output chan
 	uploader := transfermanager.New(config.S3Client, func(o *transfermanager.Options) {
 		o.PartSizeBytes = config.PartSize
 		o.Concurrency = 4 // Internal concurrency per upload
+		// #522: skip the SDK's default per-upload CRC32 (redundant with our SHA-256).
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 	})
 
 	return &S3UploaderStage{


### PR DESCRIPTION
Profiling a real-S3 2 GB upload showed transfermanager's default per-upload CRC32 (`RequestChecksumCalculationWhenSupported`) at ~5% of upload CPU — redundant with CargoShip's own per-archive SHA-256 (#271) + verify-on-restore. Set `RequestChecksumCalculationWhenRequired` on all five uploaders; TLS still protects the wire and SHA-256 remains the integrity guarantee.

**Validated:** emulator integration + torture byte-exact, and a real-AWS re-profile confirms `computeChecksumReader`/CRC32 is **gone** from the CPU profile with the upload still **byte-identical on restore**.

First low-risk win from the #522 profiling; SHA-256 (~18%) and the BufferedPipe copy chain (~15%) are the larger follow-ups tracked there.