### PR TITLE
perf(s3): skip the redundant whole-object SHA-256 on framed chunks (#522)

### DIFF
--- a/docs/reference/format/manifest.md
+++ b/docs/reference/format/manifest.md
@@ -229,7 +229,13 @@ for how a reader uses `frames` + `archive_offset` to fetch and decode a single
 file.
 
 `Checksum` here is the **SHA256 of the compressed archive object** — verify a
-downloaded chunk against it before extracting.
+downloaded chunk against it before extracting. It is **optional and omitted for
+framed chunks** (`frames` non-empty): a framed chunk's `FrameEntry.Checksum`es
+tile the entire compressed object, so they already cover it and the redundant
+whole-object hash is not computed (#522). A reader should therefore verify a
+framed chunk via its per-frame checksums and treat an empty `checksum` as
+"covered by frames," not "unverifiable"; unframed chunks always carry it as their
+object-level integrity.
 
 ## `ShardEntry`
 

--- a/pkg/manifest/deep_verify.go
+++ b/pkg/manifest/deep_verify.go
@@ -250,8 +250,10 @@ func (dv *DeepVerifier) objectKey(chunkKey string) string {
 func (dv *DeepVerifier) verifyChunk(ctx context.Context, chunk *ChunkEntry) ChunkVerifyResult {
 	cr := ChunkVerifyResult{ChunkID: chunk.ID, S3Key: chunk.S3Key, Expected: chunk.Checksum}
 
-	// No recorded checksum (or no algorithm) => can't verify.
-	if chunk.Checksum == "" || dv.manifest.ChecksumAlgorithm == "" {
+	// #522: a framed chunk records no whole-object checksum — its per-frame
+	// checksums are the integrity. Verifiable if it has a whole-object checksum OR
+	// a frame index (and a known checksum algorithm).
+	if (chunk.Checksum == "" && len(chunk.Frames) == 0) || dv.manifest.ChecksumAlgorithm == "" {
 		cr.Status = ChunkVerifyUnverifiable
 		return cr
 	}
@@ -288,7 +290,10 @@ func (dv *DeepVerifier) verifyChunk(ctx context.Context, chunk *ChunkEntry) Chun
 	cr.SizeGot = n
 	cr.Actual = hex.EncodeToString(hasher.Sum(nil))
 
-	if cr.Actual != chunk.Checksum {
+	// #522: compare the whole-object hash only when one was recorded (unframed
+	// chunks). Framed chunks (empty Checksum) are verified by their per-frame
+	// checksums in the frame block below.
+	if chunk.Checksum != "" && cr.Actual != chunk.Checksum {
 		cr.Status = ChunkVerifyMismatch
 		return cr
 	}

--- a/pkg/pipeline/archiver.go
+++ b/pkg/pipeline/archiver.go
@@ -634,6 +634,12 @@ func (s *ArchiverStage) Process(ctx context.Context, job *Job) error {
 	} else {
 		job.Metadata["compression"] = "none"
 	}
+	// #522: a framed chunk (compressed + framing on) will carry per-frame checksums
+	// that tile the whole compressed object, so the uploader can skip the redundant
+	// whole-object SHA-256. Decided here (before streaming) so the flag is set on
+	// the job before it reaches the uploader — the frame list itself isn't ready
+	// until the stream finishes.
+	job.Framed = useCompression && s.config.FrameSize > 0
 	job.Metadata["compressible_files"] = fmt.Sprintf("%d", compressibleCount)
 	job.Metadata["precompressed_files"] = fmt.Sprintf("%d", preCompressedCount)
 
@@ -683,9 +689,17 @@ func (s *ArchiverStage) Process(ctx context.Context, job *Job) error {
 		var fr *framer
 
 		if useCompression {
-			// cwC counts (and hashes, #439) compressed bytes into the pipe; cwU
-			// counts the uncompressed tar position. tw → cwU → encoder → cwC → pw.
-			cwC := &countingWriter{w: pw, h: sha256.New()}
+			// cwC counts (and, when framing is active, hashes #439) compressed bytes
+			// into the pipe; cwU counts the uncompressed tar position.
+			// tw → cwU → encoder → cwC → pw.
+			// #522: the per-frame hash is only read when frames are cut, so only pay
+			// for it when framing is on (FrameSize > 0). With framing off the digest
+			// was computed over every compressed byte and never used.
+			var cwCHash hash.Hash
+			if s.config.FrameSize > 0 {
+				cwCHash = sha256.New()
+			}
+			cwC := &countingWriter{w: pw, h: cwCHash}
 			encoder.Reset(cwC)
 			cwU := &countingWriter{w: encoder}
 			tw = tar.NewWriter(cwU)

--- a/pkg/pipeline/s3_multiprefix_uploader.go
+++ b/pkg/pipeline/s3_multiprefix_uploader.go
@@ -411,21 +411,29 @@ func (s *S3MultiPrefixUploaderStage) processJob(ctx context.Context, job *Job, p
 			// #436: the random-access frame index for this chunk, if framing was
 			// active (nil for single-frame / plain-tar chunks).
 			frames := job.Frames()
+			// #522: for a framed chunk the whole-object hash was skipped (frames
+			// cover it), so source both the true compressed size and the object
+			// integrity from the frames: the per-frame CompressedSizes sum to the
+			// exact object size, and the per-frame checksums are the integrity. An
+			// unframed chunk uses the whole-object hasher's byte count + digest
+			// (falling back to the uncompressed estimate only if it wasn't wired).
+			var compressedSize int64
+			var checksum string
 			if len(frames) > 0 {
 				builder.AddFormatFeature(manifest.FormatFeatureFrames)
+				for _, f := range frames {
+					compressedSize += f.CompressedSize
+				}
+			} else {
+				compressedSize = job.ArchiveCompressedSize()
+				if compressedSize == 0 {
+					compressedSize = atomic.LoadInt64(&job.ArchiveSize)
+				}
+				checksum = job.ArchiveChecksum()
 			}
 
-			// The true compressed size is the exact byte count read off the
-			// upload stream by the hashing wrapper. ArchiveSize is only an
-			// uncompressed-total estimate, so it made CompressedSize wrong (and
-			// "space saved" report as 0%). Fall back to the estimate when the
-			// hasher wasn't wired (e.g. a code path that didn't wrap the stream).
-			compressedSize := job.ArchiveCompressedSize()
-			if compressedSize == 0 {
-				compressedSize = atomic.LoadInt64(&job.ArchiveSize)
-			}
-
-			// Add chunk entry (#271: record the SHA-256 of the uploaded archive)
+			// Add chunk entry (#271/#522: whole-object SHA-256 for unframed chunks;
+			// empty for framed chunks, where FrameEntry.Checksum provides integrity).
 			builder.AddChunk(manifest.ChunkEntry{
 				ID:               job.Chunk.ID,
 				ShardID:          shardID,
@@ -436,7 +444,7 @@ func (s *S3MultiPrefixUploaderStage) processJob(ctx context.Context, job *Job, p
 				CompressedSize:   compressedSize,
 				CreatedAt:        job.StartTime,
 				UploadedAt:       job.EndTime,
-				Checksum:         job.ArchiveChecksum(),
+				Checksum:         checksum,
 				Frames:           frames,
 			})
 
@@ -490,7 +498,12 @@ func (s *S3MultiPrefixUploaderStage) uploadToS3(ctx context.Context, job *Job) e
 	// Both upload paths (transporter, manager) read job.Archive, so wrapping
 	// here covers both. The digest is finalized once the stream is consumed and
 	// is read into ChunkEntry.Checksum after a successful upload.
-	if job.Archive != nil && job.archiveHasher == nil {
+	// #522: skip this whole-object hash for a framed chunk — its per-frame
+	// checksums already tile the entire compressed object (a strict superset), so
+	// the whole-object digest is redundant. Frames also carry the true compressed
+	// size, so AddChunk sources that from them below. Unframed (e.g. plain-tar /
+	// incompressible) chunks still get the whole-object hash.
+	if job.Archive != nil && job.archiveHasher == nil && !job.Framed {
 		job.archiveHasher = newHashingReadCloser(job.Archive)
 		job.Archive = job.archiveHasher
 	}

--- a/pkg/pipeline/torture_test.go
+++ b/pkg/pipeline/torture_test.go
@@ -197,6 +197,13 @@ func TestTorture(t *testing.T) {
 					framesTotal += fr.CompressedSize
 				}
 				require.Equal(t, c.CompressedSize, framesTotal, "chunk compressed size must equal the sum of its frame sizes")
+				// #522: a framed chunk carries NO whole-object checksum — its
+				// per-frame checksums are the integrity. Pre-#522 this was a
+				// redundant non-empty SHA-256 over the same bytes.
+				require.Empty(t, c.Checksum, "framed chunk must omit the redundant whole-object checksum (#522)")
+				for _, fr := range c.Frames {
+					require.NotEmpty(t, fr.Checksum, "each frame must carry its own checksum")
+				}
 			}
 		}
 
@@ -247,8 +254,13 @@ func TestTorture(t *testing.T) {
 			switch {
 			case strings.HasSuffix(c.S3Key, ".tar.zst"):
 				zst++
+				// #522: framed .tar.zst chunks omit the whole-object checksum.
+				require.Empty(t, c.Checksum, "framed .tar.zst chunk must omit the redundant whole-object checksum (#522)")
 			case strings.HasSuffix(c.S3Key, ".tar"):
 				plain++
+				// #522: plain (unframed) chunks keep the whole-object checksum as
+				// their only object-level integrity (no frames cover them).
+				require.NotEmpty(t, c.Checksum, "plain .tar chunk must keep its whole-object checksum (#522)")
 			}
 		}
 		t.Logf("mixed corpus chunk kinds: %d compressed (.tar.zst), %d plain (.tar)", zst, plain)

--- a/pkg/pipeline/types.go
+++ b/pkg/pipeline/types.go
@@ -23,6 +23,7 @@ type Job struct {
 	StartTime   time.Time         // When job started
 	EndTime     time.Time         // When job completed
 	Skipped     bool              // #447: chunk was skipped on resume (already uploaded), not re-uploaded
+	Framed      bool              // #522: chunk will be a framed .tar.zst (compressed + FrameSize>0); set by the archiver before streaming so the uploader can skip the redundant whole-object hash (frames cover it)
 
 	// Phase 3.3: Compressed-aware chunking with adaptive sizing
 	TargetCompressedSize int64 // Target compressed size from CompressedAwareChunker (0 = no target)


### PR DESCRIPTION
Second #522 win. SHA-256 is ~18% of upload CPU and already ARM64-hardware-accelerated (no faster impl), so the lever is hashing fewer bytes.

- **Waste-fix:** the per-frame compressed hasher was allocated whenever compression was on, not gated on framing → with `--frame-size 0` it hashed every byte and discarded the digest. Now gated on `FrameSize > 0`.
- **Framed chunks skip the whole-object hash:** per-frame `FrameEntry.Checksum`es tile the entire compressed object (strict superset incl. tar metadata), so the always-on whole-object `ChunkEntry.Checksum` is redundant. Archiver marks `Job.Framed`; uploader skips the whole-object `hashingReadCloser`; `AddChunk` sources CompressedSize from the frame sizes + integrity from the per-frame checksums. Unframed/plain-tar chunks keep the whole-object hash.

`verify --deep` verifies framed chunks via their frames (empty `ChunkEntry.Checksum` → not "unverifiable"); errors only if a chunk has neither. `manifest.md` documents the checksum as optional.

**Validated:** unit + torture byte-exact (framed→empty / plain→non-empty checksum, fail-pre-fix confirmed); real-AWS framed upload → empty checksum + correct frame-sourced compressed size + **verify --deep PASS** + byte-identical restore, and the whole-object hash pass is **gone from the CPU profile**.

Part of #522 (BufferedPipe copy-chain remains).