### PR TITLE
perf(pipeline): widen BufferedPipe chunk 32KiB→256KiB on the upload path (#522)

### DIFF
--- a/pkg/pipeline/archiver.go
+++ b/pkg/pipeline/archiver.go
@@ -339,7 +339,7 @@ func NewArchiverStage(config *ArchiverConfig, input <-chan *Job, output chan<- *
 
 	// Issue #34 Phase 1.1: Create BufferedPipe pool (32 pipes, 64MB each = 2GB total)
 	// This prevents 64GB memory leak when processing 1000 chunks
-	pipePool := NewBufferedPipePool(32, 64*1024*1024, 32*1024)
+	pipePool := NewBufferedPipePool(32, pipeBufferSize, pipeChunkSize)
 
 	// Issue #34 Phase 2.1: Create mmap LRU cache with 1000 FD limit
 	// Prevents file descriptor exhaustion on large datasets (100k+ files)
@@ -404,7 +404,7 @@ func NewArchiverStageWithSharding(config *ArchiverConfig, input <-chan *Job, out
 	}
 
 	// Issue #34 Phase 1.1: Create BufferedPipe pool (32 pipes, 64MB each = 2GB total)
-	pipePool := NewBufferedPipePool(32, 64*1024*1024, 32*1024)
+	pipePool := NewBufferedPipePool(32, pipeBufferSize, pipeChunkSize)
 
 	// Issue #34 Phase 2.1: Create mmap LRU cache with 1000 FD limit
 	mmapCache := newMmapLRUCache(1000)

--- a/pkg/pipeline/buffered_pipe.go
+++ b/pkg/pipeline/buffered_pipe.go
@@ -6,6 +6,25 @@ import (
 	"sync"
 )
 
+// Default BufferedPipe geometry for the upload streaming path.
+//
+// pipeBufferSize is how far the archiver may work ahead of the uploader before
+// backpressure blocks it. pipeChunkSize is the granularity of a single
+// channel handoff: the writer copies incoming data into pooled chunks of this
+// size and the reader copies them back out.
+//
+// #522: the chunk size trades copy/handoff overhead against backpressure
+// granularity. It does not change the number of bytes copied (that is inherent
+// to a streaming pipe), but a larger chunk means proportionally fewer channel
+// sends, pool Get/Put pairs, and producer/consumer wakeups per GB moved. At
+// 32KiB a multi-GB chunk incurs tens of thousands of handoffs; 256KiB cuts that
+// 8× while still giving fine-grained (256-slot) backpressure over the 64MiB
+// buffer.
+const (
+	pipeBufferSize = 64 * 1024 * 1024 // 64 MiB work-ahead window
+	pipeChunkSize  = 256 * 1024       // 256 KiB per channel handoff
+)
+
 // BufferedPipePool manages a pool of BufferedPipe instances to avoid
 // allocating 64MB per chunk (Issue #34 Phase 1.1)
 //


### PR DESCRIPTION
## What

The upload streaming pipe (`BufferedPipe`, Issue #34 Phase 1.1) hands compressed
data from the archiver to the uploader in fixed-size chunks over a channel,
copying in on `Write` and out on `Read`. The chunk size was **32 KiB**, so a
multi-GB chunk incurred tens of thousands of channel sends, `sync.Pool` Get/Put
pairs, and producer/consumer wakeups.

This widens the handoff to **256 KiB** via a named constant (`pipeChunkSize`),
still giving 256-slot backpressure over the unchanged 64 MiB work-ahead window.

## Why

The last open profiling lever on #522 (BufferedPipe copy-chain, ~15% memmove in
a real-S3 upload profile). The number of **bytes** copied is inherent to a
streaming `io.Reader`/`io.Writer` pipe and is *not* changed here — the two copies
(write-in, read-out) are required by the interface contract. What this reduces is
the **per-handoff overhead**: channel ops, pool churn, and goroutine wakeups.

## Measurement

Isolated pipe A/B moving 256 MiB with a 512 KiB writer block and a 5 MiB reader
buffer (throwaway parameterized benchmark, not shipped):

| chunk | throughput | allocs/op |
|-------|-----------|-----------|
| 32 KiB  | ~41 GB/s | ~17000 |
| 256 KiB | ~52 GB/s |  ~2250 |

**~25% more pipe throughput, ~7.6× fewer allocations.** The pipe is not the
bottleneck on a network-bound upload, but this is a real CPU/GC reclaim that
matters when many shards run in parallel and contend for cores (or on fast
same-region transfers).

## Safety

Chunk size is only buffering granularity — byte-exactness is untouched. The
`integration torture` byte-exact round-trip suite passes (upload→restore
byte-identical), plus the full `pkg/pipeline` unit suite.

Refs #522.