### PR TITLE
feat(access): read-only bucket access-control posture report (#529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`cargoship access-check s3://bucket/prefix`** — a read-only report on the
+  access-control posture of a target bucket: Block Public Access (bucket +
+  account), wildcard-principal grants in the bucket policy and ACL, object
+  ownership, and the scoping of the default SSE-KMS key policy. Each check
+  degrades gracefully — a check the caller lacks permission for reports
+  `unknown` with the IAM action it needs, and the rest still run. Report-only:
+  exits 0 on findings, exits 1 only if the bucket is unreachable. `--format json`
+  for machine output. Scoped to user/group access controls, not a general
+  security audit. (#529)
+
 ## [0.27.0] - 2026-09-12
 
 **Upload efficiency.** Systematic profiling of a real-S3 upload (#522) found the

--- a/cmd/cargoship/cmd/access_check.go
+++ b/cmd/cargoship/cmd/access_check.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/access"
+	s3pkg "github.com/scttfrdmn/cargoship/pkg/aws/s3"
+)
+
+// NewAccessCheckCmd creates the 'access-check' command: a read-only report on
+// the access-control posture of a target bucket (Issue #529).
+func NewAccessCheckCmd() *cobra.Command {
+	var (
+		bucket   string
+		prefix   string
+		region   string
+		profile  string
+		kmsKeyID string
+		format   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "access-check [s3://bucket/prefix]",
+		Short: "Report the access-control posture of a target bucket",
+		Long: `Report whether the bucket CargoShip writes to (or reads from) is exposed:
+public access, wildcard-principal grants in the bucket policy or ACL, object
+ownership, and the scoping of the default SSE-KMS key policy.
+
+This is a read-only posture report — it makes no changes and always exits 0 when
+it can reach the bucket (findings are informational). It is deliberately scoped
+to user/group access controls, not a general security audit.
+
+Each check degrades gracefully: if the calling principal lacks permission for a
+check, that check reports "unknown" with the IAM action it needs, and the rest
+of the report still runs. Checks are bucket-level (a prefix is recorded for
+context but S3 policy/ACL/BPA/ownership apply to the whole bucket).
+
+Examples:
+  # Report on a bucket/prefix
+  cargoship access-check s3://my-bucket/archives
+
+  # Using flags, with a specific profile and region
+  cargoship access-check --bucket my-bucket --region us-west-2 --profile prod
+
+  # Machine-readable output
+  cargoship access-check s3://my-bucket/archives --format json
+
+  # Inspect a specific KMS key's policy instead of the bucket default
+  cargoship access-check s3://my-bucket/archives --kms-key-id alias/cargoship
+
+Exit Codes:
+  0 - Report produced (regardless of findings)
+  1 - Could not reach the bucket (missing/invalid credentials, no such bucket)
+  2 - Usage error
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if len(args) > 0 {
+				parsedBucket, parsedPrefix, err := s3pkg.ParseS3URL(args[0])
+				if err != nil {
+					return fmt.Errorf("invalid S3 URL: %w", err)
+				}
+				if bucket == "" {
+					bucket = parsedBucket
+				}
+				if prefix == "" {
+					prefix = parsedPrefix
+				}
+			}
+			if bucket == "" {
+				return fmt.Errorf("bucket is required (provide an s3:// URL or --bucket)")
+			}
+			if format != "table" && format != "json" {
+				return fmt.Errorf("unsupported --format %q (want table or json)", format)
+			}
+
+			cfg, err := loadAWSConfig(ctx, profile, region)
+			if err != nil {
+				return fmt.Errorf("failed to load AWS config: %w", err)
+			}
+			s3Client := s3.NewFromConfig(cfg)
+
+			if region == "" {
+				detected, err := s3pkg.GetBucketRegion(ctx, s3Client, bucket)
+				if err != nil {
+					return fmt.Errorf("could not reach bucket %q (check the name, region, and credentials): %w", bucket, err)
+				}
+				region = detected
+				cfg.Region = region
+				s3Client = s3.NewFromConfig(cfg)
+			}
+
+			checker := &access.Checker{
+				S3:       s3Client,
+				STS:      sts.NewFromConfig(cfg),
+				KMS:      kms.NewFromConfig(cfg),
+				KMSKeyID: kmsKeyID,
+			}
+			report, err := checker.Check(ctx, bucket, prefix)
+			if err != nil {
+				return fmt.Errorf("access check failed: %w", err)
+			}
+			report.Region = region
+
+			if format == "json" {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(report)
+			}
+			printAccessReport(report)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&bucket, "bucket", "b", "", "S3 bucket name")
+	cmd.Flags().StringVarP(&prefix, "prefix", "p", "", "S3 prefix (for context; checks are bucket-level)")
+	cmd.Flags().StringVarP(&region, "region", "r", "", "AWS region (auto-detected if omitted)")
+	cmd.Flags().StringVar(&profile, "profile", "", "AWS profile")
+	cmd.Flags().StringVar(&kmsKeyID, "kms-key-id", "", "KMS key ID/ARN/alias to inspect (default: the bucket's SSE-KMS key)")
+	cmd.Flags().StringVar(&format, "format", "table", "output format: table or json")
+
+	return cmd
+}
+
+// printAccessReport renders a posture report as a human-readable table.
+func printAccessReport(r *access.Report) {
+	fmt.Printf("🔐 Access-control posture — s3://%s", r.Bucket)
+	if r.Prefix != "" {
+		fmt.Printf("/%s", r.Prefix)
+	}
+	fmt.Println()
+	if r.Region != "" {
+		fmt.Printf("   region: %s\n", r.Region)
+	}
+	if r.CallerARN != "" {
+		fmt.Printf("   caller: %s (account %s)\n", r.CallerARN, r.Account)
+	}
+	fmt.Println()
+
+	for _, f := range r.Findings {
+		fmt.Printf("%s  %-22s %s\n", severityIcon(f.Severity), f.Check, f.Summary)
+		if f.Detail != "" {
+			fmt.Printf("       %s\n", f.Detail)
+		}
+		if f.Remediation != "" {
+			fmt.Printf("       ↳ %s\n", f.Remediation)
+		}
+	}
+
+	fmt.Printf("\nOverall: %s %s\n", severityIcon(r.Worst()), strings.ToUpper(string(r.Worst())))
+}
+
+func severityIcon(s access.Severity) string {
+	switch s {
+	case access.SeverityCritical:
+		return "🛑"
+	case access.SeverityWarn:
+		return "⚠️ "
+	case access.SeverityUnknown:
+		return "❓"
+	case access.SeverityInfo:
+		return "ℹ️ "
+	default: // ok
+		return "✅"
+	}
+}

--- a/cmd/cargoship/cmd/access_check_test.go
+++ b/cmd/cargoship/cmd/access_check_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/cargoship/pkg/aws/access"
+)
+
+func TestAccessCheckCmd_Validation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing bucket", []string{}, "bucket is required"},
+		{"bad s3 url", []string{"http://nope"}, "invalid S3 URL"},
+		{"bad format", []string{"s3://b/p", "--format", "yaml"}, "unsupported --format"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewAccessCheckCmd()
+			c.SetArgs(tt.args)
+			c.SilenceUsage = true
+			c.SilenceErrors = true
+			err := c.Execute()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("want error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestPrintAccessReport(t *testing.T) {
+	r := &access.Report{
+		Bucket:    "my-bucket",
+		Prefix:    "archives",
+		Region:    "us-west-2",
+		Account:   "111122223333",
+		CallerARN: "arn:aws:iam::111122223333:role/writer",
+		Findings: []access.Finding{
+			{Check: "block-public-access", Severity: access.SeverityOK, Summary: "Block Public Access fully enabled"},
+			{Check: "bucket-policy", Severity: access.SeverityCritical, Summary: "Wildcard principal", Detail: "statement[0]", Remediation: "scope it"},
+			{Check: "kms-key-policy", Severity: access.SeverityUnknown, Summary: "denied", Remediation: "grant kms:GetKeyPolicy"},
+		},
+	}
+	out := captureStdout(t, func() { printAccessReport(r) })
+	for _, want := range []string{"my-bucket/archives", "us-west-2", "role/writer", "block-public-access", "scope it", "CRITICAL"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestSeverityIcon(t *testing.T) {
+	for _, s := range []access.Severity{
+		access.SeverityOK, access.SeverityInfo, access.SeverityWarn, access.SeverityCritical, access.SeverityUnknown,
+	} {
+		if severityIcon(s) == "" {
+			t.Errorf("severity %q has no icon", s)
+		}
+	}
+}
+
+// captureStdout runs fn and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	rd, wr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = wr
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	_ = wr.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, rd)
+	return buf.String()
+}

--- a/cmd/cargoship/cmd/root.go
+++ b/cmd/cargoship/cmd/root.go
@@ -92,23 +92,24 @@ func NewRootCmdWithVersion(lo io.Writer, versionInfo string) *cobra.Command {
 		NewContextCmd(),
 		NewShellCmd(),
 		NewDashboardCmd(),
-		NewUploadCmd(),   // Issue #95: Upload command with CargoHold sharding
-		NewSyncCmd(),     // Issue #148: Incremental sync command
-		NewMigrateCmd(),  // Issue #100: Migrate command for archive conversion
-		NewListCmd(),     // Issue #97: List uploaded files from manifest
-		NewDownloadCmd(), // Issue #96: Download with selective extraction
-		NewInfoCmd(),     // Issue #98: Info command for upload metadata
-		NewVerifyCmd(),   // Issue #99: Verify command for integrity checks
-		NewBalanceCmd(),  // Issue #109: Analyze shard balance and rebalancing
-		NewDeleteCmd(),   // Delete specific upload
-		NewScuttleCmd(),  // Nuclear option: delete everything
-		NewResumeCmd(),   // Issue #119: Resume interrupted uploads with local state
-		NewCostCmd(),     // Issue #145: Cost management and budget tracking
-		NewBudgetCmd(),   // Issue #147: Budget management and volume quotas
-		NewAlertsCmd(),   // Issue #147 Phase 4: Budget alerts and notifications
-		NewRestoreCmd(),  // Issue #189: Hash/DVC-aware selective file restore
-		NewBrowseCmd(),   // Issue #190: Interactive TUI file browser
-		NewDVCCmd(),      // v0.13.0: DVC pipeline auto-discovery and stage inspection
+		NewUploadCmd(),      // Issue #95: Upload command with CargoHold sharding
+		NewSyncCmd(),        // Issue #148: Incremental sync command
+		NewMigrateCmd(),     // Issue #100: Migrate command for archive conversion
+		NewListCmd(),        // Issue #97: List uploaded files from manifest
+		NewDownloadCmd(),    // Issue #96: Download with selective extraction
+		NewInfoCmd(),        // Issue #98: Info command for upload metadata
+		NewVerifyCmd(),      // Issue #99: Verify command for integrity checks
+		NewAccessCheckCmd(), // Issue #529: read-only access-control posture report
+		NewBalanceCmd(),     // Issue #109: Analyze shard balance and rebalancing
+		NewDeleteCmd(),      // Delete specific upload
+		NewScuttleCmd(),     // Nuclear option: delete everything
+		NewResumeCmd(),      // Issue #119: Resume interrupted uploads with local state
+		NewCostCmd(),        // Issue #145: Cost management and budget tracking
+		NewBudgetCmd(),      // Issue #147: Budget management and volume quotas
+		NewAlertsCmd(),      // Issue #147 Phase 4: Budget alerts and notifications
+		NewRestoreCmd(),     // Issue #189: Hash/DVC-aware selective file restore
+		NewBrowseCmd(),      // Issue #190: Interactive TUI file browser
+		NewDVCCmd(),         // v0.13.0: DVC pipeline auto-discovery and stage inspection
 	)
 	// Legacy commands removed: NewWizardCmd, NewAnalyzeCmd, NewSchemaCmd, newTravelAgentCmd
 	cmd.AddCommand(NewMDDocsCmd())

--- a/docs/gen/cli/cargoship_access-check.md
+++ b/docs/gen/cli/cargoship_access-check.md
@@ -1,0 +1,65 @@
+## cargoship access-check
+
+Report the access-control posture of a target bucket
+
+### Synopsis
+
+Report whether the bucket CargoShip writes to (or reads from) is exposed:
+public access, wildcard-principal grants in the bucket policy or ACL, object
+ownership, and the scoping of the default SSE-KMS key policy.
+
+This is a read-only posture report — it makes no changes and always exits 0 when
+it can reach the bucket (findings are informational). It is deliberately scoped
+to user/group access controls, not a general security audit.
+
+Each check degrades gracefully: if the calling principal lacks permission for a
+check, that check reports "unknown" with the IAM action it needs, and the rest
+of the report still runs. Checks are bucket-level (a prefix is recorded for
+context but S3 policy/ACL/BPA/ownership apply to the whole bucket).
+
+Examples:
+  # Report on a bucket/prefix
+  cargoship access-check s3://my-bucket/archives
+
+  # Using flags, with a specific profile and region
+  cargoship access-check --bucket my-bucket --region us-west-2 --profile prod
+
+  # Machine-readable output
+  cargoship access-check s3://my-bucket/archives --format json
+
+  # Inspect a specific KMS key's policy instead of the bucket default
+  cargoship access-check s3://my-bucket/archives --kms-key-id alias/cargoship
+
+Exit Codes:
+  0 - Report produced (regardless of findings)
+  1 - Could not reach the bucket (missing/invalid credentials, no such bucket)
+  2 - Usage error
+
+
+```
+cargoship access-check [s3://bucket/prefix] [flags]
+```
+
+### Options
+
+```
+  -b, --bucket string       S3 bucket name
+      --format string       output format: table or json (default "table")
+  -h, --help                help for access-check
+      --kms-key-id string   KMS key ID/ARN/alias to inspect (default: the bucket's SSE-KMS key)
+  -p, --prefix string       S3 prefix (for context; checks are bucket-level)
+      --profile string      AWS profile
+  -r, --region string       AWS region (auto-detected if omitted)
+```
+
+### Options inherited from parent commands
+
+```
+      --context string        Override execution context (local, repl)
+      --memory-limit string   Set a memory limit for the run. This will slow things down, but will less likely to OOM in certain situations. Avoid this unless you are having memory issues.
+      --pprof                 Enable runtime profiling HTTP endpoint at localhost:6060
+      --pprof-addr string     Address for runtime profiling HTTP endpoint (default "localhost:6060")
+  -t, --trace                 Enable trace messages in output
+  -v, --verbose               Enable verbose output
+```
+

--- a/docs/reference/commands/inspect.md
+++ b/docs/reference/commands/inspect.md
@@ -17,6 +17,8 @@ Flag tables below are generated from the CLI and kept in sync by a drift check.
 
 <!-- @include: ../../gen/cli/cargoship_verify.md -->
 
+<!-- @include: ../../gen/cli/cargoship_access-check.md -->
+
 <!-- @include: ../../gen/cli/cargoship_balance.md -->
 
 <!-- @include: ../../gen/cli/cargoship_download.md -->

--- a/pkg/aws/access/access.go
+++ b/pkg/aws/access/access.go
@@ -1,0 +1,488 @@
+// Package access implements read-only access-control posture checks for the S3
+// buckets CargoShip writes to and reads from (Issue #529).
+//
+// The goal is narrow and deliberate: surface whether an archive would be
+// world- or account-wide-readable, and whether the encryption key protecting it
+// is scoped to the intended principals — NOT a general security audit (that is
+// tracked separately in #323). Every check is read-only and degrades
+// gracefully: a check that lacks permission reports an "unknown" posture with
+// the IAM action it needs, and never aborts the rest of the report.
+package access
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithy "github.com/aws/smithy-go"
+)
+
+// Severity ranks a finding from benign to actionable.
+type Severity string
+
+const (
+	// SeverityOK means the posture is as locked-down as expected.
+	SeverityOK Severity = "ok"
+	// SeverityInfo is a neutral observation, not a problem.
+	SeverityInfo Severity = "info"
+	// SeverityWarn is a posture worth a second look but not clearly wrong.
+	SeverityWarn Severity = "warn"
+	// SeverityCritical means the archive is (or can be) broadly readable.
+	SeverityCritical Severity = "critical"
+	// SeverityUnknown means the check could not run (usually missing permission).
+	SeverityUnknown Severity = "unknown"
+)
+
+// rank orders severities so a report can roll up to its worst finding.
+func (s Severity) rank() int {
+	switch s {
+	case SeverityCritical:
+		return 4
+	case SeverityWarn:
+		return 3
+	case SeverityUnknown:
+		return 2
+	case SeverityInfo:
+		return 1
+	default: // SeverityOK
+		return 0
+	}
+}
+
+// Finding is the result of a single posture check.
+type Finding struct {
+	Check       string   `json:"check"`                 // stable machine key, e.g. "block-public-access"
+	Severity    Severity `json:"severity"`              // ok | info | warn | critical | unknown
+	Summary     string   `json:"summary"`               // one-line human verdict
+	Detail      string   `json:"detail,omitempty"`      // supporting evidence
+	Remediation string   `json:"remediation,omitempty"` // what to do about it (incl. the IAM action for unknowns)
+}
+
+// Report is the full posture report for one bucket target.
+type Report struct {
+	Bucket    string    `json:"bucket"`
+	Prefix    string    `json:"prefix,omitempty"`
+	Region    string    `json:"region,omitempty"`
+	Account   string    `json:"account,omitempty"`
+	CallerARN string    `json:"caller_arn,omitempty"`
+	Findings  []Finding `json:"findings"`
+}
+
+// Worst returns the highest severity across all findings (SeverityOK if empty).
+func (r *Report) Worst() Severity {
+	worst := SeverityOK
+	for _, f := range r.Findings {
+		if f.Severity.rank() > worst.rank() {
+			worst = f.Severity
+		}
+	}
+	return worst
+}
+
+// S3PolicyAPI is the subset of the S3 API the posture checks call. It is an
+// interface so tests can supply a mock instead of a live client.
+type S3PolicyAPI interface {
+	GetPublicAccessBlock(context.Context, *s3.GetPublicAccessBlockInput, ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error)
+	GetBucketPolicyStatus(context.Context, *s3.GetBucketPolicyStatusInput, ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
+	GetBucketPolicy(context.Context, *s3.GetBucketPolicyInput, ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error)
+	GetBucketAcl(context.Context, *s3.GetBucketAclInput, ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	GetBucketOwnershipControls(context.Context, *s3.GetBucketOwnershipControlsInput, ...func(*s3.Options)) (*s3.GetBucketOwnershipControlsOutput, error)
+	GetBucketEncryption(context.Context, *s3.GetBucketEncryptionInput, ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error)
+}
+
+// STSAPI resolves the calling identity for report context. Optional.
+type STSAPI interface {
+	GetCallerIdentity(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+// KMSAPI inspects a KMS key's policy. Optional. GetKeyPolicy accepts a key ID,
+// ARN, or alias directly, so no DescribeKey resolution step is needed.
+type KMSAPI interface {
+	GetKeyPolicy(context.Context, *kms.GetKeyPolicyInput, ...func(*kms.Options)) (*kms.GetKeyPolicyOutput, error)
+}
+
+// Checker runs the posture checks against one bucket. S3 is required; STS and
+// KMS are optional (nil disables the caller-identity and KMS-key checks).
+type Checker struct {
+	S3  S3PolicyAPI
+	STS STSAPI
+	KMS KMSAPI
+	// KMSKeyID, when set, forces the KMS key-policy check against this key
+	// instead of auto-detecting the bucket's default SSE-KMS key.
+	KMSKeyID string
+}
+
+// Check runs every posture check and returns the assembled report. It never
+// returns an error for a check that merely lacks permission — that surfaces as
+// an "unknown" finding. A non-nil error is reserved for a caller that wants to
+// treat total failure as fatal; today Check always returns nil.
+func (c *Checker) Check(ctx context.Context, bucket, prefix string) (*Report, error) {
+	r := &Report{Bucket: bucket, Prefix: prefix}
+
+	if c.STS != nil {
+		if out, err := c.STS.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}); err == nil {
+			r.Account = aws.ToString(out.Account)
+			r.CallerARN = aws.ToString(out.Arn)
+		}
+	}
+
+	r.Findings = append(r.Findings,
+		c.checkPublicAccessBlock(ctx, bucket),
+		c.checkPolicyStatus(ctx, bucket),
+		c.checkBucketPolicy(ctx, bucket),
+		c.checkBucketACL(ctx, bucket),
+		c.checkOwnership(ctx, bucket),
+	)
+	r.Findings = append(r.Findings, c.checkKMS(ctx, bucket))
+
+	return r, nil
+}
+
+// apiErrCode extracts the AWS API error code (e.g. "AccessDenied") from err,
+// or "" if err is not a recognized API error.
+func apiErrCode(err error) string {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode()
+	}
+	return ""
+}
+
+// isAccessDenied reports whether err is an access-denied API error (S3 uses
+// "AccessDenied", KMS "AccessDeniedException").
+func isAccessDenied(err error) bool {
+	switch apiErrCode(err) {
+	case "AccessDenied", "AccessDeniedException", "Forbidden":
+		return true
+	}
+	return false
+}
+
+// denied builds the standard "couldn't check — missing permission" finding.
+func denied(check, action string) Finding {
+	return Finding{
+		Check:       check,
+		Severity:    SeverityUnknown,
+		Summary:     "Could not determine posture (access denied)",
+		Remediation: fmt.Sprintf("Grant %s to the calling principal to include this check.", action),
+	}
+}
+
+func (c *Checker) checkPublicAccessBlock(ctx context.Context, bucket string) Finding {
+	const check = "block-public-access"
+	out, err := c.S3.GetPublicAccessBlock(ctx, &s3.GetPublicAccessBlockInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isAccessDenied(err) {
+			return denied(check, "s3:GetBucketPublicAccessBlock")
+		}
+		if apiErrCode(err) == "NoSuchPublicAccessBlockConfiguration" {
+			return Finding{
+				Check:       check,
+				Severity:    SeverityWarn,
+				Summary:     "No bucket-level Block Public Access configuration",
+				Detail:      "The bucket has no BPA config of its own; only account-level BPA (if any) protects it.",
+				Remediation: "Enable Block Public Access on the bucket (all four settings) unless public access is intended.",
+			}
+		}
+		return Finding{Check: check, Severity: SeverityUnknown, Summary: "Block Public Access check failed", Detail: err.Error()}
+	}
+	cfg := out.PublicAccessBlockConfiguration
+	if cfg != nil && aws.ToBool(cfg.BlockPublicAcls) && aws.ToBool(cfg.IgnorePublicAcls) &&
+		aws.ToBool(cfg.BlockPublicPolicy) && aws.ToBool(cfg.RestrictPublicBuckets) {
+		return Finding{Check: check, Severity: SeverityOK, Summary: "Block Public Access fully enabled"}
+	}
+	return Finding{
+		Check:       check,
+		Severity:    SeverityWarn,
+		Summary:     "Block Public Access is not fully enabled",
+		Detail:      fmt.Sprintf("BlockPublicAcls=%t IgnorePublicAcls=%t BlockPublicPolicy=%t RestrictPublicBuckets=%t", aws.ToBool(cfg.BlockPublicAcls), aws.ToBool(cfg.IgnorePublicAcls), aws.ToBool(cfg.BlockPublicPolicy), aws.ToBool(cfg.RestrictPublicBuckets)),
+		Remediation: "Enable all four Block Public Access settings unless public access is intended.",
+	}
+}
+
+func (c *Checker) checkPolicyStatus(ctx context.Context, bucket string) Finding {
+	const check = "bucket-public-status"
+	out, err := c.S3.GetBucketPolicyStatus(ctx, &s3.GetBucketPolicyStatusInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isAccessDenied(err) {
+			return denied(check, "s3:GetBucketPolicyStatus")
+		}
+		// No policy → not public via policy.
+		if apiErrCode(err) == "NoSuchBucketPolicy" {
+			return Finding{Check: check, Severity: SeverityOK, Summary: "Bucket is not public (no policy)"}
+		}
+		return Finding{Check: check, Severity: SeverityUnknown, Summary: "Public-status check failed", Detail: err.Error()}
+	}
+	if out.PolicyStatus != nil && aws.ToBool(out.PolicyStatus.IsPublic) {
+		return Finding{
+			Check:       check,
+			Severity:    SeverityCritical,
+			Summary:     "Bucket is PUBLIC per its policy status",
+			Remediation: "Remove the public grant from the bucket policy or enable Block Public Access.",
+		}
+	}
+	return Finding{Check: check, Severity: SeverityOK, Summary: "Bucket is not public"}
+}
+
+func (c *Checker) checkBucketPolicy(ctx context.Context, bucket string) Finding {
+	const check = "bucket-policy"
+	out, err := c.S3.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isAccessDenied(err) {
+			return denied(check, "s3:GetBucketPolicy")
+		}
+		if apiErrCode(err) == "NoSuchBucketPolicy" {
+			return Finding{Check: check, Severity: SeverityOK, Summary: "No bucket policy (no policy-based grants)"}
+		}
+		return Finding{Check: check, Severity: SeverityUnknown, Summary: "Bucket policy check failed", Detail: err.Error()}
+	}
+	wildcards := wildcardPrincipalStatements(aws.ToString(out.Policy))
+	if len(wildcards) > 0 {
+		return Finding{
+			Check:       check,
+			Severity:    SeverityCritical,
+			Summary:     "Bucket policy grants access to a wildcard principal",
+			Detail:      fmt.Sprintf("%d Allow statement(s) with Principal \"*\": %s", len(wildcards), strings.Join(wildcards, ", ")),
+			Remediation: "Scope the bucket policy Principal to specific accounts/roles, or add a Condition that restricts it.",
+		}
+	}
+	return Finding{Check: check, Severity: SeverityOK, Summary: "Bucket policy has no wildcard-principal Allow statements"}
+}
+
+func (c *Checker) checkBucketACL(ctx context.Context, bucket string) Finding {
+	const check = "bucket-acl"
+	out, err := c.S3.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isAccessDenied(err) {
+			return denied(check, "s3:GetBucketAcl")
+		}
+		return Finding{Check: check, Severity: SeverityUnknown, Summary: "Bucket ACL check failed", Detail: err.Error()}
+	}
+	const (
+		allUsers  = "http://acs.amazonaws.com/groups/global/AllUsers"
+		authUsers = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+	)
+	var public, authenticated []string
+	for _, g := range out.Grants {
+		if g.Grantee == nil || g.Grantee.Type != types.TypeGroup {
+			continue
+		}
+		switch aws.ToString(g.Grantee.URI) {
+		case allUsers:
+			public = append(public, string(g.Permission))
+		case authUsers:
+			authenticated = append(authenticated, string(g.Permission))
+		}
+	}
+	if len(public) > 0 {
+		return Finding{
+			Check:       check,
+			Severity:    SeverityCritical,
+			Summary:     "Bucket ACL grants access to everyone (AllUsers)",
+			Detail:      "Permissions: " + strings.Join(public, ", "),
+			Remediation: "Remove the AllUsers grant; prefer Block Public Access with ACLs disabled (BucketOwnerEnforced).",
+		}
+	}
+	if len(authenticated) > 0 {
+		return Finding{
+			Check:       check,
+			Severity:    SeverityWarn,
+			Summary:     "Bucket ACL grants access to any authenticated AWS account",
+			Detail:      "Permissions: " + strings.Join(authenticated, ", "),
+			Remediation: "Remove the AuthenticatedUsers grant; it allows any AWS account, not just yours.",
+		}
+	}
+	return Finding{Check: check, Severity: SeverityOK, Summary: "Bucket ACL has no public or cross-account group grants"}
+}
+
+func (c *Checker) checkOwnership(ctx context.Context, bucket string) Finding {
+	const check = "object-ownership"
+	out, err := c.S3.GetBucketOwnershipControls(ctx, &s3.GetBucketOwnershipControlsInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isAccessDenied(err) {
+			return denied(check, "s3:GetBucketOwnershipControls")
+		}
+		if apiErrCode(err) == "OwnershipControlsNotFoundError" {
+			return Finding{
+				Check:    check,
+				Severity: SeverityInfo,
+				Summary:  "No object-ownership controls set (ACLs enabled by default)",
+			}
+		}
+		return Finding{Check: check, Severity: SeverityUnknown, Summary: "Ownership controls check failed", Detail: err.Error()}
+	}
+	if out.OwnershipControls != nil {
+		for _, rule := range out.OwnershipControls.Rules {
+			if rule.ObjectOwnership == types.ObjectOwnershipBucketOwnerEnforced {
+				return Finding{Check: check, Severity: SeverityOK, Summary: "Object ownership is BucketOwnerEnforced (ACLs disabled)"}
+			}
+		}
+	}
+	return Finding{
+		Check:       check,
+		Severity:    SeverityInfo,
+		Summary:     "Object ACLs are enabled (ownership not BucketOwnerEnforced)",
+		Remediation: "Consider setting ObjectOwnership=BucketOwnerEnforced to disable ACLs entirely.",
+	}
+}
+
+// checkKMS inspects the key policy of the bucket's default SSE-KMS key (or the
+// KMSKeyID override). It returns a single finding; when there is nothing to
+// inspect (no KMS client, no default KMS encryption) the finding is Info.
+func (c *Checker) checkKMS(ctx context.Context, bucket string) Finding {
+	const check = "kms-key-policy"
+	if c.KMS == nil {
+		return Finding{Check: check, Severity: SeverityInfo, Summary: "KMS key-policy check skipped (KMS inspection not enabled)"}
+	}
+
+	keyID := c.KMSKeyID
+	if keyID == "" {
+		var err error
+		keyID, err = c.defaultBucketKMSKey(ctx, bucket)
+		if err != nil {
+			if isAccessDenied(err) {
+				return denied(check, "s3:GetEncryptionConfiguration")
+			}
+			return Finding{Check: check, Severity: SeverityUnknown, Summary: "Could not read bucket encryption configuration", Detail: err.Error()}
+		}
+		if keyID == "" {
+			return Finding{Check: check, Severity: SeverityInfo, Summary: "No default SSE-KMS key on the bucket to inspect"}
+		}
+	}
+
+	pol, err := c.KMS.GetKeyPolicy(ctx, &kms.GetKeyPolicyInput{KeyId: aws.String(keyID), PolicyName: aws.String("default")})
+	if err != nil {
+		if isAccessDenied(err) {
+			return denied(check, "kms:GetKeyPolicy")
+		}
+		return Finding{Check: check, Severity: SeverityUnknown, Summary: "KMS key-policy check failed", Detail: err.Error()}
+	}
+	wildcards := wildcardPrincipalStatements(aws.ToString(pol.Policy))
+	if len(wildcards) > 0 {
+		return Finding{
+			Check:       check,
+			Severity:    SeverityWarn,
+			Summary:     "KMS key policy has wildcard-principal Allow statements",
+			Detail:      fmt.Sprintf("key %s: %d statement(s) with Principal \"*\" — verify a Condition scopes them: %s", keyID, len(wildcards), strings.Join(wildcards, ", ")),
+			Remediation: "Ensure any Principal \"*\" statement in the key policy is constrained by a Condition (e.g. kms:ViaService, aws:PrincipalOrgID).",
+		}
+	}
+	return Finding{Check: check, Severity: SeverityOK, Summary: fmt.Sprintf("KMS key %s policy has no unconditioned wildcard-principal grants", keyID)}
+}
+
+// defaultBucketKMSKey returns the KMS key ID from the bucket's default SSE-KMS
+// encryption rule, or "" if the bucket has no SSE-KMS default.
+func (c *Checker) defaultBucketKMSKey(ctx context.Context, bucket string) (string, error) {
+	out, err := c.S3.GetBucketEncryption(ctx, &s3.GetBucketEncryptionInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if apiErrCode(err) == "ServerSideEncryptionConfigurationNotFoundError" {
+			return "", nil
+		}
+		return "", err
+	}
+	if out.ServerSideEncryptionConfiguration == nil {
+		return "", nil
+	}
+	for _, rule := range out.ServerSideEncryptionConfiguration.Rules {
+		d := rule.ApplyServerSideEncryptionByDefault
+		if d != nil && d.SSEAlgorithm == types.ServerSideEncryptionAwsKms {
+			return aws.ToString(d.KMSMasterKeyID), nil
+		}
+	}
+	return "", nil
+}
+
+// policyDocument is the minimal shape of an IAM/S3/KMS policy we parse. The
+// Principal and Action fields are polymorphic in JSON (string or list/object),
+// so they are decoded as json.RawMessage and interpreted by helpers.
+type policyDocument struct {
+	Statement []struct {
+		Sid       string          `json:"Sid"`
+		Effect    string          `json:"Effect"`
+		Principal json.RawMessage `json:"Principal"`
+		Condition json.RawMessage `json:"Condition"`
+	} `json:"Statement"`
+}
+
+// wildcardPrincipalStatements returns the Sid (or index) of every Allow
+// statement whose Principal is the wildcard "*" (or {"AWS":"*"}) AND which
+// carries no Condition. Statements gated by a Condition are treated as
+// intentionally scoped and excluded — a Principal "*" with a Condition is a
+// common, legitimate pattern (e.g. kms:ViaService, aws:SourceArn).
+func wildcardPrincipalStatements(policyJSON string) []string {
+	policyJSON = strings.TrimSpace(policyJSON)
+	if policyJSON == "" {
+		return nil
+	}
+	// Bucket-policy JSON may arrive URL-encoded from some APIs; decode best-effort.
+	if !strings.HasPrefix(policyJSON, "{") {
+		if dec, err := url.QueryUnescape(policyJSON); err == nil {
+			policyJSON = dec
+		}
+	}
+	var doc policyDocument
+	if err := json.Unmarshal([]byte(policyJSON), &doc); err != nil {
+		return nil
+	}
+	var hits []string
+	for i, st := range doc.Statement {
+		if !strings.EqualFold(st.Effect, "Allow") {
+			continue
+		}
+		if len(st.Condition) > 0 && string(st.Condition) != "null" && string(st.Condition) != "{}" {
+			continue // conditioned wildcard — treated as intentionally scoped
+		}
+		if principalIsWildcard(st.Principal) {
+			label := st.Sid
+			if label == "" {
+				label = fmt.Sprintf("statement[%d]", i)
+			}
+			hits = append(hits, label)
+		}
+	}
+	return hits
+}
+
+// principalIsWildcard reports whether a policy Principal is the unrestricted
+// wildcard, in any of its JSON encodings: "*" or {"AWS":"*"} (or a list
+// containing "*").
+func principalIsWildcard(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	// Form 1: "Principal": "*"
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s == "*"
+	}
+	// Form 2: "Principal": {"AWS": "*"} or {"AWS": ["*", ...]}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err == nil {
+		for _, v := range m {
+			var vs string
+			if err := json.Unmarshal(v, &vs); err == nil {
+				if vs == "*" {
+					return true
+				}
+				continue
+			}
+			var vl []string
+			if err := json.Unmarshal(v, &vl); err == nil {
+				for _, item := range vl {
+					if item == "*" {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}

--- a/pkg/aws/access/access_test.go
+++ b/pkg/aws/access/access_test.go
@@ -1,0 +1,335 @@
+package access
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithy "github.com/aws/smithy-go"
+)
+
+// apiErr builds a smithy API error with the given code, matching how the SDK
+// surfaces service errors (AccessDenied, NoSuchBucketPolicy, ...).
+func apiErr(code string) error { return &smithy.GenericAPIError{Code: code, Message: code} }
+
+// mockS3 is a configurable S3PolicyAPI. A nil func field yields a "clean,
+// locked-down" default so a test overrides only the behavior it exercises.
+type mockS3 struct {
+	pab func() (*s3.GetPublicAccessBlockOutput, error)
+	ps  func() (*s3.GetBucketPolicyStatusOutput, error)
+	pol func() (*s3.GetBucketPolicyOutput, error)
+	acl func() (*s3.GetBucketAclOutput, error)
+	own func() (*s3.GetBucketOwnershipControlsOutput, error)
+	enc func() (*s3.GetBucketEncryptionOutput, error)
+}
+
+func allTrue() *types.PublicAccessBlockConfiguration {
+	return &types.PublicAccessBlockConfiguration{
+		BlockPublicAcls:       aws.Bool(true),
+		IgnorePublicAcls:      aws.Bool(true),
+		BlockPublicPolicy:     aws.Bool(true),
+		RestrictPublicBuckets: aws.Bool(true),
+	}
+}
+
+func (m *mockS3) GetPublicAccessBlock(context.Context, *s3.GetPublicAccessBlockInput, ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+	if m.pab != nil {
+		return m.pab()
+	}
+	return &s3.GetPublicAccessBlockOutput{PublicAccessBlockConfiguration: allTrue()}, nil
+}
+
+func (m *mockS3) GetBucketPolicyStatus(context.Context, *s3.GetBucketPolicyStatusInput, ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+	if m.ps != nil {
+		return m.ps()
+	}
+	return &s3.GetBucketPolicyStatusOutput{PolicyStatus: &types.PolicyStatus{IsPublic: aws.Bool(false)}}, nil
+}
+
+func (m *mockS3) GetBucketPolicy(context.Context, *s3.GetBucketPolicyInput, ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
+	if m.pol != nil {
+		return m.pol()
+	}
+	return nil, apiErr("NoSuchBucketPolicy")
+}
+
+func (m *mockS3) GetBucketAcl(context.Context, *s3.GetBucketAclInput, ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+	if m.acl != nil {
+		return m.acl()
+	}
+	return &s3.GetBucketAclOutput{}, nil
+}
+
+func (m *mockS3) GetBucketOwnershipControls(context.Context, *s3.GetBucketOwnershipControlsInput, ...func(*s3.Options)) (*s3.GetBucketOwnershipControlsOutput, error) {
+	if m.own != nil {
+		return m.own()
+	}
+	return &s3.GetBucketOwnershipControlsOutput{OwnershipControls: &types.OwnershipControls{
+		Rules: []types.OwnershipControlsRule{{ObjectOwnership: types.ObjectOwnershipBucketOwnerEnforced}},
+	}}, nil
+}
+
+func (m *mockS3) GetBucketEncryption(context.Context, *s3.GetBucketEncryptionInput, ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error) {
+	if m.enc != nil {
+		return m.enc()
+	}
+	return nil, apiErr("ServerSideEncryptionConfigurationNotFoundError")
+}
+
+type mockKMS struct {
+	pol func() (*kms.GetKeyPolicyOutput, error)
+}
+
+func (m *mockKMS) GetKeyPolicy(context.Context, *kms.GetKeyPolicyInput, ...func(*kms.Options)) (*kms.GetKeyPolicyOutput, error) {
+	return m.pol()
+}
+
+type mockSTS struct{}
+
+func (m *mockSTS) GetCallerIdentity(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{Account: aws.String("111122223333"), Arn: aws.String("arn:aws:iam::111122223333:role/writer")}, nil
+}
+
+// findingFor returns the finding for a given check key.
+func findingFor(r *Report, check string) (Finding, bool) {
+	for _, f := range r.Findings {
+		if f.Check == check {
+			return f, true
+		}
+	}
+	return Finding{}, false
+}
+
+func TestChecker_LockedDown(t *testing.T) {
+	c := &Checker{S3: &mockS3{}, STS: &mockSTS{}}
+	r, err := c.Check(context.Background(), "bucket", "prefix")
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if r.Account != "111122223333" || r.CallerARN == "" {
+		t.Errorf("caller identity not populated: %+v", r)
+	}
+	if w := r.Worst(); w.rank() > SeverityInfo.rank() {
+		t.Errorf("locked-down bucket should have no warn/critical/unknown, got worst=%s", w)
+	}
+	for _, check := range []string{"block-public-access", "bucket-public-status", "bucket-policy", "bucket-acl", "object-ownership"} {
+		f, ok := findingFor(r, check)
+		if !ok {
+			t.Fatalf("missing finding %q", check)
+		}
+		if f.Severity != SeverityOK {
+			t.Errorf("check %q: want ok, got %s (%s)", check, f.Severity, f.Summary)
+		}
+	}
+}
+
+func TestChecker_PerCheckSeverity(t *testing.T) {
+	publicPolicy := `{"Statement":[{"Sid":"Open","Effect":"Allow","Principal":"*","Action":"s3:GetObject"}]}`
+	conditionedPolicy := `{"Statement":[{"Sid":"Scoped","Effect":"Allow","Principal":"*","Action":"s3:GetObject","Condition":{"StringEquals":{"aws:SourceVpce":"vpce-123"}}}]}`
+
+	tests := []struct {
+		name    string
+		s3      *mockS3
+		check   string
+		wantSev Severity
+		wantRem bool // expect a non-empty Remediation
+	}{
+		{
+			name: "partial BPA -> warn",
+			s3: &mockS3{pab: func() (*s3.GetPublicAccessBlockOutput, error) {
+				c := allTrue()
+				c.BlockPublicPolicy = aws.Bool(false)
+				return &s3.GetPublicAccessBlockOutput{PublicAccessBlockConfiguration: c}, nil
+			}},
+			check:   "block-public-access",
+			wantSev: SeverityWarn,
+			wantRem: true,
+		},
+		{
+			name: "no BPA config -> warn",
+			s3: &mockS3{pab: func() (*s3.GetPublicAccessBlockOutput, error) {
+				return nil, apiErr("NoSuchPublicAccessBlockConfiguration")
+			}},
+			check:   "block-public-access",
+			wantSev: SeverityWarn,
+		},
+		{
+			name:    "BPA access denied -> unknown",
+			s3:      &mockS3{pab: func() (*s3.GetPublicAccessBlockOutput, error) { return nil, apiErr("AccessDenied") }},
+			check:   "block-public-access",
+			wantSev: SeverityUnknown,
+			wantRem: true,
+		},
+		{
+			name: "public policy status -> critical",
+			s3: &mockS3{ps: func() (*s3.GetBucketPolicyStatusOutput, error) {
+				return &s3.GetBucketPolicyStatusOutput{PolicyStatus: &types.PolicyStatus{IsPublic: aws.Bool(true)}}, nil
+			}},
+			check:   "bucket-public-status",
+			wantSev: SeverityCritical,
+		},
+		{
+			name: "wildcard bucket policy -> critical",
+			s3: &mockS3{pol: func() (*s3.GetBucketPolicyOutput, error) {
+				return &s3.GetBucketPolicyOutput{Policy: aws.String(publicPolicy)}, nil
+			}},
+			check:   "bucket-policy",
+			wantSev: SeverityCritical,
+		},
+		{
+			name: "conditioned wildcard policy -> ok",
+			s3: &mockS3{pol: func() (*s3.GetBucketPolicyOutput, error) {
+				return &s3.GetBucketPolicyOutput{Policy: aws.String(conditionedPolicy)}, nil
+			}},
+			check:   "bucket-policy",
+			wantSev: SeverityOK,
+		},
+		{
+			name: "public ACL (AllUsers) -> critical",
+			s3: &mockS3{acl: func() (*s3.GetBucketAclOutput, error) {
+				return &s3.GetBucketAclOutput{Grants: []types.Grant{{
+					Grantee:    &types.Grantee{Type: types.TypeGroup, URI: aws.String("http://acs.amazonaws.com/groups/global/AllUsers")},
+					Permission: types.PermissionRead,
+				}}}, nil
+			}},
+			check:   "bucket-acl",
+			wantSev: SeverityCritical,
+		},
+		{
+			name: "authenticated-users ACL -> warn",
+			s3: &mockS3{acl: func() (*s3.GetBucketAclOutput, error) {
+				return &s3.GetBucketAclOutput{Grants: []types.Grant{{
+					Grantee:    &types.Grantee{Type: types.TypeGroup, URI: aws.String("http://acs.amazonaws.com/groups/global/AuthenticatedUsers")},
+					Permission: types.PermissionRead,
+				}}}, nil
+			}},
+			check:   "bucket-acl",
+			wantSev: SeverityWarn,
+		},
+		{
+			name: "ownership not enforced -> info",
+			s3: &mockS3{own: func() (*s3.GetBucketOwnershipControlsOutput, error) {
+				return &s3.GetBucketOwnershipControlsOutput{OwnershipControls: &types.OwnershipControls{
+					Rules: []types.OwnershipControlsRule{{ObjectOwnership: types.ObjectOwnershipObjectWriter}},
+				}}, nil
+			}},
+			check:   "object-ownership",
+			wantSev: SeverityInfo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Checker{S3: tt.s3}
+			r, err := c.Check(context.Background(), "bucket", "")
+			if err != nil {
+				t.Fatalf("Check: %v", err)
+			}
+			f, ok := findingFor(r, tt.check)
+			if !ok {
+				t.Fatalf("missing finding %q", tt.check)
+			}
+			if f.Severity != tt.wantSev {
+				t.Errorf("check %q: want %s, got %s (%s / %s)", tt.check, tt.wantSev, f.Severity, f.Summary, f.Detail)
+			}
+			if tt.wantRem && f.Remediation == "" {
+				t.Errorf("check %q: expected a remediation, got none", tt.check)
+			}
+		})
+	}
+}
+
+func TestChecker_KMS(t *testing.T) {
+	kmsBucket := &mockS3{enc: func() (*s3.GetBucketEncryptionOutput, error) {
+		return &s3.GetBucketEncryptionOutput{ServerSideEncryptionConfiguration: &types.ServerSideEncryptionConfiguration{
+			Rules: []types.ServerSideEncryptionRule{{ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{
+				SSEAlgorithm: types.ServerSideEncryptionAwsKms, KMSMasterKeyID: aws.String("key-abc"),
+			}}},
+		}}, nil
+	}}
+
+	t.Run("no KMS client -> info skipped", func(t *testing.T) {
+		c := &Checker{S3: &mockS3{}}
+		r, _ := c.Check(context.Background(), "b", "")
+		f, _ := findingFor(r, "kms-key-policy")
+		if f.Severity != SeverityInfo {
+			t.Errorf("want info, got %s", f.Severity)
+		}
+	})
+
+	t.Run("wildcard key policy -> warn", func(t *testing.T) {
+		c := &Checker{S3: kmsBucket, KMS: &mockKMS{pol: func() (*kms.GetKeyPolicyOutput, error) {
+			return &kms.GetKeyPolicyOutput{Policy: aws.String(`{"Statement":[{"Effect":"Allow","Principal":"*","Action":"kms:Decrypt"}]}`)}, nil
+		}}}
+		r, _ := c.Check(context.Background(), "b", "")
+		f, _ := findingFor(r, "kms-key-policy")
+		if f.Severity != SeverityWarn {
+			t.Errorf("want warn, got %s (%s)", f.Severity, f.Summary)
+		}
+	})
+
+	t.Run("clean key policy -> ok", func(t *testing.T) {
+		c := &Checker{S3: kmsBucket, KMS: &mockKMS{pol: func() (*kms.GetKeyPolicyOutput, error) {
+			return &kms.GetKeyPolicyOutput{Policy: aws.String(`{"Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111122223333:root"},"Action":"kms:*"}]}`)}, nil
+		}}}
+		r, _ := c.Check(context.Background(), "b", "")
+		f, _ := findingFor(r, "kms-key-policy")
+		if f.Severity != SeverityOK {
+			t.Errorf("want ok, got %s (%s)", f.Severity, f.Summary)
+		}
+	})
+
+	t.Run("no SSE-KMS default -> info", func(t *testing.T) {
+		c := &Checker{S3: &mockS3{}, KMS: &mockKMS{pol: func() (*kms.GetKeyPolicyOutput, error) { t.Fatal("should not call KMS"); return nil, nil }}}
+		r, _ := c.Check(context.Background(), "b", "")
+		f, _ := findingFor(r, "kms-key-policy")
+		if f.Severity != SeverityInfo {
+			t.Errorf("want info, got %s", f.Severity)
+		}
+	})
+}
+
+func TestWildcardPrincipalStatements(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		want   int
+	}{
+		{"empty", "", 0},
+		{"star string", `{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*"}]}`, 1},
+		{"aws star object", `{"Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:*"}]}`, 1},
+		{"aws star in list", `{"Statement":[{"Effect":"Allow","Principal":{"AWS":["arn:x","*"]},"Action":"s3:*"}]}`, 1},
+		{"deny star ignored", `{"Statement":[{"Effect":"Deny","Principal":"*","Action":"s3:*"}]}`, 0},
+		{"conditioned star excluded", `{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*","Condition":{"StringEquals":{"aws:PrincipalOrgID":"o-1"}}}]}`, 0},
+		{"scoped principal ok", `{"Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::1:root"},"Action":"s3:*"}]}`, 0},
+		{"malformed json", `not json`, 0},
+		{"url encoded", `%7B%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%22*%22%2C%22Action%22%3A%22s3%3A*%22%7D%5D%7D`, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := len(wildcardPrincipalStatements(tt.policy)); got != tt.want {
+				t.Errorf("want %d wildcard statements, got %d", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestReportWorst(t *testing.T) {
+	r := &Report{Findings: []Finding{
+		{Severity: SeverityOK}, {Severity: SeverityInfo}, {Severity: SeverityWarn}, {Severity: SeverityUnknown},
+	}}
+	if got := r.Worst(); got != SeverityWarn {
+		t.Errorf("warn(3) outranks unknown(2): want warn, got %s", got)
+	}
+	r.Findings = append(r.Findings, Finding{Severity: SeverityCritical})
+	if got := r.Worst(); got != SeverityCritical {
+		t.Errorf("want critical, got %s", got)
+	}
+	if got := (&Report{}).Worst(); got != SeverityOK {
+		t.Errorf("empty report: want ok, got %s", got)
+	}
+}


### PR DESCRIPTION
## What

Adds **`cargoship access-check s3://bucket/prefix`** — a read-only report on whether a target bucket is exposed. First item of the v0.28.0 milestone (#31).

Deliberately scoped to **user/group access controls**, not a general security audit (that's #323).

## Checks (all bucket-level, read-only)

| Check | Flags |
|-------|-------|
| **Block Public Access** | bucket-level BPA config + `GetBucketPolicyStatus.IsPublic` |
| **Bucket policy** | `Allow` statements with a wildcard `Principal` (`*` / `{"AWS":"*"}`) |
| **Bucket ACL** | grants to `AllUsers` (critical) / `AuthenticatedUsers` (warn) |
| **Object ownership** | `BucketOwnerEnforced` (ACLs disabled) vs ACLs-enabled |
| **KMS key policy** | wildcard-principal grants in the bucket's default SSE-KMS key policy (auto-detected via `GetBucketEncryption`, or `--kms-key-id`) |

A **conditioned** wildcard principal (a `Principal:"*"` with a `Condition`, e.g. `kms:ViaService`, `aws:PrincipalOrgID`) is treated as intentionally scoped and **not** flagged — that's a common legitimate pattern.

## Behavior

- **Graceful degradation:** a check the caller lacks permission for reports `unknown` with the exact IAM action it needs; the rest of the report still runs.
- **Report-only:** exits **0** on findings, exits **1** only when the bucket is unreachable (bad creds / no such bucket), **2** on usage error.
- `--format table` (default) or `--format json`.

## Design

- New `pkg/aws/access` holds the engine behind small **mockable interfaces** (`S3PolicyAPI` / `STSAPI` / `KMSAPI`) — no live SDK in tests.
- Command modeled on `verify.go` (arg/flag parsing) + `analyze.go` (`loadAWSConfig`, `--format json`).
- Table-driven tests cover every severity path, the wildcard/conditioned-principal policy parsing (incl. URL-encoded + list forms), and AccessDenied degradation. `pkg/aws/access` at 83% coverage.

## Not in this PR (deferred)

- `upload --check-access` preflight flag (reuses this engine) and a `--fail-on <severity>` gate — the report-only standalone command was the agreed first slice.
- IAM effective-access (`SimulatePrincipalPolicy`) — a true "who can read/delete" enumeration isn't possible client-side without Access Analyzer.

Refs #529.