### PR TITLE
feat(access): upload --check-access preflight + --fail-on gate (#529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exits 0 on findings, exits 1 only if the bucket is unreachable. `--format json`
   for machine output. Scoped to user/group access controls, not a general
   security audit. (#529)
+- **`cargoship upload --check-access`** — runs the same posture report as a
+  preflight before uploading. With `--fail-on <none|unknown|warn|critical>` it
+  aborts the upload when the worst finding meets the threshold (e.g. refuse to
+  write to a bucket whose policy is world-readable). (#529)
 
 ## [0.27.0] - 2026-09-12
 

--- a/cmd/cargoship/cmd/access_check.go
+++ b/cmd/cargoship/cmd/access_check.go
@@ -132,6 +132,53 @@ Exit Codes:
 	return cmd
 }
 
+// runAccessPreflight builds a checker from an already-constructed S3 client
+// (plus STS/KMS clients from a config loaded for the region), runs the posture
+// checks against bucket/prefix, prints the report, and enforces failOn. It is
+// shared by the standalone `access-check` command and `upload --check-access`.
+func runAccessPreflight(ctx context.Context, s3api access.S3PolicyAPI, region, profile, kmsKeyID, bucket, prefix, failOn string) error {
+	cfg, err := loadAWSConfig(ctx, profile, region)
+	if err != nil {
+		return fmt.Errorf("failed to load AWS config for access check: %w", err)
+	}
+	checker := &access.Checker{
+		S3:       s3api,
+		STS:      sts.NewFromConfig(cfg),
+		KMS:      kms.NewFromConfig(cfg),
+		KMSKeyID: kmsKeyID,
+	}
+	report, err := checker.Check(ctx, bucket, prefix)
+	if err != nil {
+		return fmt.Errorf("access check failed: %w", err)
+	}
+	report.Region = region
+	printAccessReport(report)
+	return enforceAccessFailOn(report, failOn)
+}
+
+// enforceAccessFailOn returns a non-nil error when failOn names a severity and
+// the report's worst finding is at least that severe. Accepts "none"/"" (never
+// fails), "unknown", "warn", "critical".
+func enforceAccessFailOn(r *access.Report, failOn string) error {
+	var threshold access.Severity
+	switch strings.ToLower(strings.TrimSpace(failOn)) {
+	case "", "none":
+		return nil
+	case "unknown":
+		threshold = access.SeverityUnknown
+	case "warn", "warning":
+		threshold = access.SeverityWarn
+	case "critical":
+		threshold = access.SeverityCritical
+	default:
+		return fmt.Errorf("invalid --fail-on %q (want none, unknown, warn, or critical)", failOn)
+	}
+	if worst := r.Worst(); worst.AtLeast(threshold) {
+		return fmt.Errorf("access-control posture %q meets --fail-on threshold %q", worst, threshold)
+	}
+	return nil
+}
+
 // printAccessReport renders a posture report as a human-readable table.
 func printAccessReport(r *access.Report) {
 	fmt.Printf("🔐 Access-control posture — s3://%s", r.Bucket)

--- a/cmd/cargoship/cmd/access_check_test.go
+++ b/cmd/cargoship/cmd/access_check_test.go
@@ -55,6 +55,36 @@ func TestPrintAccessReport(t *testing.T) {
 	}
 }
 
+func TestEnforceAccessFailOn(t *testing.T) {
+	rep := func(worst access.Severity) *access.Report {
+		return &access.Report{Findings: []access.Finding{{Severity: worst}}}
+	}
+	tests := []struct {
+		name    string
+		worst   access.Severity
+		failOn  string
+		wantErr bool
+	}{
+		{"none never fails", access.SeverityCritical, "none", false},
+		{"empty never fails", access.SeverityCritical, "", false},
+		{"warn threshold, critical worst -> fail", access.SeverityCritical, "warn", true},
+		{"warn threshold, warn worst -> fail", access.SeverityWarn, "warn", true},
+		{"warn threshold, info worst -> pass", access.SeverityInfo, "warn", false},
+		{"critical threshold, warn worst -> pass", access.SeverityWarn, "critical", false},
+		{"unknown threshold, unknown worst -> fail", access.SeverityUnknown, "unknown", true},
+		{"unknown threshold, ok worst -> pass", access.SeverityOK, "unknown", false},
+		{"invalid threshold -> error", access.SeverityOK, "bogus", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := enforceAccessFailOn(rep(tt.worst), tt.failOn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("failOn=%q worst=%q: wantErr=%v got %v", tt.failOn, tt.worst, tt.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestSeverityIcon(t *testing.T) {
 	for _, s := range []access.Severity{
 		access.SeverityOK, access.SeverityInfo, access.SeverityWarn, access.SeverityCritical, access.SeverityUnknown,

--- a/cmd/cargoship/cmd/upload.go
+++ b/cmd/cargoship/cmd/upload.go
@@ -199,6 +199,16 @@ Examples:
 				return fmt.Errorf("bucket %s is not accessible: %w", bucket, err)
 			}
 
+			// Optional access-control posture preflight (#529): report whether
+			// the target bucket is exposed before writing to it, and (with
+			// --fail-on) abort if the posture is too weak.
+			if checkAccess, _ := cmd.Flags().GetBool("check-access"); checkAccess {
+				failOn, _ := cmd.Flags().GetString("fail-on")
+				if err := runAccessPreflight(ctx, s3Client, region, "", kmsKeyID, bucket, prefix, failOn); err != nil {
+					return err
+				}
+			}
+
 			// Get absolute path for source directory
 			absPath, err := filepath.Abs(sourceDir)
 			if err != nil {
@@ -933,6 +943,10 @@ Examples:
 
 	// Issue #168: Skip confirmation prompts (for automation)
 	cmd.Flags().BoolVarP(&skipConfirmation, "yes", "y", false, "Skip confirmation prompts (auto-accept warnings)")
+
+	// Issue #529: access-control posture preflight
+	cmd.Flags().Bool("check-access", false, "Report the target bucket's access-control posture before uploading (see the 'access-check' command)")
+	cmd.Flags().String("fail-on", "none", "With --check-access, abort if the worst finding is at least this severe: none, unknown, warn, critical")
 
 	// Issue #166: Direct upload optimization (fast path for small files)
 	cmd.Flags().Bool("direct-upload", false, "Enable direct upload mode (bypasses archiving/compression for small files)")

--- a/docs/gen/cli/cargoship_upload.md
+++ b/docs/gen/cli/cargoship_upload.md
@@ -55,6 +55,7 @@ cargoship upload SOURCE_DIR DESTINATION [flags]
 ```
       --auto-tier                        Enable automatic storage tier selection based on file access time
   -b, --bucket string                    S3 bucket name (or use s3:// URL in DESTINATION)
+      --check-access                     Report the target bucket's access-control posture before uploading (see the 'access-check' command)
       --compression-level int            Fixed zstd compression level (1-22), overriding per-chunk content-aware selection. Unset = content-aware (default 3)
       --congestion-control string        Congestion control algorithm: bbr, cubic, auto (default "auto")
       --direct-upload                    Enable direct upload mode (bypasses archiving/compression for small files)
@@ -67,6 +68,7 @@ cargoship upload SOURCE_DIR DESTINATION [flags]
       --dvc-stage string                 DVC pipeline stage name to extract provenance from (reads dvc.yaml + dvc.lock)
       --enable-dedup                     Enable cross-shard file deduplication (10-30% space savings for redundant datasets)
       --encrypt-manifest                 Encrypt manifest with KMS envelope encryption (requires --kms-key-id)
+      --fail-on string                   With --check-access, abort if the worst finding is at least this severe: none, unknown, warn, critical (default "none")
       --force-direct-upload              Force direct upload regardless of thresholds (for benchmarking)
       --force-restart                    Ignore saved state and start fresh upload (bypasses resume detection)
       --frame-size string                Cut compressed chunks into random-access zstd frames every N bytes (e.g. 16MiB, 64MB); 0 disables framing (default "16MiB")

--- a/pkg/aws/access/access.go
+++ b/pkg/aws/access/access.go
@@ -57,6 +57,10 @@ func (s Severity) rank() int {
 	}
 }
 
+// AtLeast reports whether s is at least as severe as o (by rank), so callers
+// can gate on a threshold (e.g. "fail if worst finding is at least warn").
+func (s Severity) AtLeast(o Severity) bool { return s.rank() >= o.rank() }
+
 // Finding is the result of a single posture check.
 type Finding struct {
 	Check       string   `json:"check"`                 // stable machine key, e.g. "block-public-access"


### PR DESCRIPTION
## What

Wires the `pkg/aws/access` posture engine (landed in #550) into the upload path, per the deferred follow-ups on #529:

- **`cargoship upload --check-access`** — runs the same posture report as a preflight, right after the existing HeadBucket accessibility probe, before any bytes are written.
- **`--fail-on <none|unknown|warn|critical>`** — aborts the upload when the report's worst finding meets the threshold. `none` (default) is report-only; `--fail-on critical` refuses to write to a world-readable bucket, `--fail-on warn` is stricter — useful in CI.

## How

- Shared `runAccessPreflight` / `enforceAccessFailOn` helpers in the `cmd` package so the standalone `access-check` command and the upload preflight run **one engine and one renderer** — no duplicated check logic.
- New exported `access.Severity.AtLeast` for the threshold comparison (rank-based).
- The preflight builds STS/KMS clients from a config loaded for the resolved region; the KMS check targets the upload's own `--kms-key-id` when set.

## Tests

Table-driven coverage of the `--fail-on` gate (none/empty never fail; warn/critical/unknown thresholds vs each worst severity; invalid value errors). All existing access + cmd tests still pass.

## Closes the #529 story

With this, #529's original open questions are all answered: on-demand **and** preflight; client-side bucket-exposure + KMS posture; report-only by default with opt-in enforcement. IAM effective-access remains intentionally out of scope (needs Access Analyzer).

Refs #529.