### PR TITLE
fix(restore): follow the incremental version chain so unchanged files restore (#552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Incremental-sync restore no longer silently omits unchanged files.** An
+  incremental `sync` uploads only changed files, so the newest manifest is a
+  delta chained to its predecessor via `PreviousManifestID` — but restore read a
+  single manifest and never followed the chain, so any file unchanged since an
+  earlier version was unrestorable from the latest version. Restore now resolves
+  the version chain into an effective full-dataset view (newest-wins per path,
+  each file fetched from the chunk that stores it), fixing already-written
+  incremental archives with no format change. `verify` chain-awareness is a
+  tracked follow-up. (#552)
+
 ### Added
 - **`cargoship access-check s3://bucket/prefix`** — a read-only report on the
   access-control posture of a target bucket: Block Public Access (bucket +

--- a/cmd/cargoship/cmd/restore.go
+++ b/cmd/cargoship/cmd/restore.go
@@ -111,6 +111,22 @@ Examples:
 			}
 			fmt.Printf("✅ Manifest loaded: %d files, %d chunks\n\n", m.TotalFiles, m.TotalChunks)
 
+			// #552: an incremental sync's manifest lists only that run's changed
+			// files, chained to its predecessor via PreviousManifestID. Follow
+			// the chain and merge newest-wins so restore sees the FULL dataset
+			// (otherwise unchanged files are silently unrestorable).
+			if m.PreviousManifestID != "" {
+				fetch := func(ctx context.Context, prevID string) (*manifest.Manifest, error) {
+					return manifest.DownloadFromS3WithDecryption(ctx, s3Client, kmsClient, bucket, actualPrefix, prevID)
+				}
+				merged, err := manifest.ResolveEffective(ctx, m, fetch)
+				if err != nil {
+					return fmt.Errorf("failed to resolve incremental version chain: %w", err)
+				}
+				fmt.Printf("🔗 Resolved incremental version chain: %d files across the full dataset\n\n", merged.TotalFiles)
+				m = merged
+			}
+
 			maxCacheBytes := cacheGB * 1024 * 1024 * 1024
 			// SetBucket: fetch from the bucket the manifest was just read from,
 			// not the stale name recorded inside it, so a copied or replicated

--- a/pkg/manifest/effective.go
+++ b/pkg/manifest/effective.go
@@ -1,0 +1,135 @@
+package manifest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// maxChainDepth bounds how many versions ResolveEffective will walk. A dataset
+// with more incremental versions than this is almost certainly a corrupt or
+// looping chain; refusing to resolve is safer than silently truncating the
+// reconstructed dataset.
+const maxChainDepth = 10000
+
+// ChainFetcher downloads an ancestor manifest by its UploadID, from the same
+// bucket/prefix as the starting manifest. It returns a non-nil error if the
+// ancestor cannot be fetched.
+type ChainFetcher func(ctx context.Context, uploadID string) (*Manifest, error)
+
+// ResolveEffective returns a manifest describing the COMPLETE dataset state as
+// of m, by following the PreviousManifestID chain and merging files
+// newest-wins per path (#552).
+//
+// Incremental `sync` uploads only changed files, so the newest manifest alone
+// describes just that run's delta; unchanged files live in ancestor manifests.
+// Without this, restore/verify of the latest version silently omit every file
+// that hasn't changed since an earlier version. ResolveEffective reconstructs
+// the full logical file set so a single (synthetic) manifest again describes the
+// whole dataset.
+//
+// Merge rules:
+//   - Files are unioned newest-wins by Path: the newest manifest that contains a
+//     path supplies its FileEntry (so a modified file uses its latest bytes).
+//   - Each surviving FileEntry keeps its own S3Key, which still points at the
+//     chunk that physically stores its bytes (S3Keys embed the origin UploadID,
+//     so they are unique across versions — the extractor joins file→chunk by
+//     S3Key, not by (chunk_id, shard_id), so the merge cannot collide).
+//   - Chunks are the union (by S3Key) of every chunk a surviving file references.
+//   - Top-level metadata (UploadID, bucket, encryption, ...) comes from m.
+//
+// If m has no PreviousManifestID it is returned unchanged. A cyclic chain, or
+// one deeper than maxChainDepth, is an error — a corrupt chain must fail loudly
+// rather than return a partial dataset.
+//
+// Limitations (tracked for follow-up): deletes are not persisted by `sync`
+// today, so a file removed in a later version is still reconstructed from an
+// ancestor; and a dataset that mixed direct-upload and chunked uploads across
+// versions is not handled (the merged view assumes a consistent mode).
+func ResolveEffective(ctx context.Context, m *Manifest, fetch ChainFetcher) (*Manifest, error) {
+	if m == nil {
+		return nil, errors.New("resolve effective manifest: nil manifest")
+	}
+	if m.PreviousManifestID == "" {
+		return m, nil
+	}
+	if fetch == nil {
+		return nil, errors.New("resolve effective manifest: nil fetcher")
+	}
+
+	// Walk the chain newest -> oldest.
+	chain := []*Manifest{m}
+	seen := map[string]bool{m.UploadID: true}
+	cur := m
+	for cur.PreviousManifestID != "" {
+		prev := cur.PreviousManifestID
+		if seen[prev] {
+			return nil, fmt.Errorf("resolve effective manifest: chain cycle at upload %q", prev)
+		}
+		if len(chain) >= maxChainDepth {
+			return nil, fmt.Errorf("resolve effective manifest: chain exceeds %d versions; refusing to resolve", maxChainDepth)
+		}
+		anc, err := fetch(ctx, prev)
+		if err != nil {
+			return nil, fmt.Errorf("resolve effective manifest: fetch ancestor %q: %w", prev, err)
+		}
+		if anc == nil {
+			return nil, fmt.Errorf("resolve effective manifest: ancestor %q not found", prev)
+		}
+		seen[prev] = true
+		chain = append(chain, anc)
+		cur = anc
+	}
+
+	// Newest-wins union of files by path (chain[0] is newest).
+	fileByPath := make(map[string]FileEntry)
+	for _, mm := range chain {
+		for _, f := range mm.Files {
+			if _, ok := fileByPath[f.Path]; !ok {
+				fileByPath[f.Path] = f
+			}
+		}
+	}
+
+	// Union of all chunks by S3Key across the chain, then keep only those a
+	// surviving file references.
+	chunkByKey := make(map[string]ChunkEntry)
+	for _, mm := range chain {
+		for _, c := range mm.Chunks {
+			if _, ok := chunkByKey[c.S3Key]; !ok {
+				chunkByKey[c.S3Key] = c
+			}
+		}
+	}
+	needed := make(map[string]bool)
+	for _, f := range fileByPath {
+		needed[f.S3Key] = true
+	}
+
+	eff := *m // copy top-level metadata from the newest manifest
+	eff.Files = make([]FileEntry, 0, len(fileByPath))
+	var totalBytes int64
+	for _, f := range fileByPath {
+		eff.Files = append(eff.Files, f)
+		totalBytes += f.Size
+	}
+	eff.Chunks = make([]ChunkEntry, 0, len(needed))
+	for key := range needed {
+		if c, ok := chunkByKey[key]; ok {
+			eff.Chunks = append(eff.Chunks, c)
+		}
+	}
+
+	// Deterministic ordering so the reconstructed manifest is stable.
+	sort.Slice(eff.Files, func(i, j int) bool { return eff.Files[i].Path < eff.Files[j].Path })
+	sort.Slice(eff.Chunks, func(i, j int) bool { return eff.Chunks[i].S3Key < eff.Chunks[j].S3Key })
+
+	eff.TotalFiles = int64(len(eff.Files))
+	eff.TotalChunks = len(eff.Chunks)
+	eff.TotalBytes = totalBytes
+	// Shard rollups are not recomputed: the effective manifest is for file/chunk
+	// resolution (restore/verify join by S3Key), not shard-level statistics.
+
+	return &eff, nil
+}

--- a/pkg/manifest/effective_test.go
+++ b/pkg/manifest/effective_test.go
@@ -1,0 +1,132 @@
+package manifest
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// chainFetch builds a ChainFetcher backed by an in-memory map of uploadID→manifest.
+func chainFetch(store map[string]*Manifest) ChainFetcher {
+	return func(_ context.Context, id string) (*Manifest, error) {
+		m, ok := store[id]
+		if !ok {
+			return nil, errors.New("not found: " + id)
+		}
+		return m, nil
+	}
+}
+
+func fileEntry(path, s3key string, size int64) FileEntry {
+	return FileEntry{Path: path, S3Key: s3key, Size: size}
+}
+
+// TestResolveEffective_IncrementalChain is the #552 regression: restoring the
+// latest incremental version must recover unchanged files carried in ancestors.
+func TestResolveEffective_IncrementalChain(t *testing.T) {
+	// v1 (full): files a.txt, b.txt in chunk under uploads/v1.
+	v1 := &Manifest{
+		UploadID: "v1",
+		Files: []FileEntry{
+			fileEntry("a.txt", "p/uploads/v1/shard-0/chunk-0.tar.zst", 10),
+			fileEntry("b.txt", "p/uploads/v1/shard-0/chunk-0.tar.zst", 20),
+		},
+		Chunks: []ChunkEntry{{ID: 0, ShardID: 0, S3Key: "p/uploads/v1/shard-0/chunk-0.tar.zst"}},
+	}
+	// v2 (incremental): only a.txt changed → new chunk under uploads/v2.
+	v2 := &Manifest{
+		UploadID:           "v2",
+		PreviousManifestID: "v1",
+		SyncType:           SyncTypeIncremental,
+		Files:              []FileEntry{fileEntry("a.txt", "p/uploads/v2/shard-0/chunk-0.tar.zst", 15)},
+		Chunks:             []ChunkEntry{{ID: 0, ShardID: 0, S3Key: "p/uploads/v2/shard-0/chunk-0.tar.zst"}},
+	}
+
+	eff, err := ResolveEffective(context.Background(), v2, chainFetch(map[string]*Manifest{"v1": v1}))
+	if err != nil {
+		t.Fatalf("ResolveEffective: %v", err)
+	}
+
+	byPath := map[string]FileEntry{}
+	for _, f := range eff.Files {
+		byPath[f.Path] = f
+	}
+	// The whole dataset must be present.
+	if len(eff.Files) != 2 {
+		t.Fatalf("want 2 files in effective view, got %d: %+v", len(eff.Files), eff.Files)
+	}
+	// b.txt (unchanged) must be recovered from v1's chunk — the bug is that it vanishes.
+	b, ok := byPath["b.txt"]
+	if !ok {
+		t.Fatal("b.txt missing from effective manifest — unchanged file was silently lost (#552)")
+	}
+	if b.S3Key != "p/uploads/v1/shard-0/chunk-0.tar.zst" {
+		t.Errorf("b.txt should point at v1's chunk, got %s", b.S3Key)
+	}
+	// a.txt (modified) must be the NEW version from v2.
+	a := byPath["a.txt"]
+	if a.S3Key != "p/uploads/v2/shard-0/chunk-0.tar.zst" || a.Size != 15 {
+		t.Errorf("a.txt should be v2's version (size 15, v2 chunk), got size=%d key=%s", a.Size, a.S3Key)
+	}
+	// Both backing chunks must be present so restore can fetch either file.
+	keys := map[string]bool{}
+	for _, c := range eff.Chunks {
+		keys[c.S3Key] = true
+	}
+	if !keys["p/uploads/v1/shard-0/chunk-0.tar.zst"] || !keys["p/uploads/v2/shard-0/chunk-0.tar.zst"] {
+		t.Errorf("effective chunks must include both v1 and v2 chunks, got %+v", eff.Chunks)
+	}
+	if eff.TotalFiles != 2 || eff.TotalBytes != 35 {
+		t.Errorf("rollups: want TotalFiles=2 TotalBytes=35, got %d/%d", eff.TotalFiles, eff.TotalBytes)
+	}
+	// Metadata comes from the newest manifest.
+	if eff.UploadID != "v2" {
+		t.Errorf("effective UploadID should be the newest (v2), got %s", eff.UploadID)
+	}
+}
+
+func TestResolveEffective_ThreeVersionsNewestWins(t *testing.T) {
+	v1 := &Manifest{UploadID: "v1", Files: []FileEntry{fileEntry("f.txt", "k1", 1)}, Chunks: []ChunkEntry{{S3Key: "k1"}}}
+	v2 := &Manifest{UploadID: "v2", PreviousManifestID: "v1", Files: []FileEntry{fileEntry("f.txt", "k2", 2)}, Chunks: []ChunkEntry{{S3Key: "k2"}}}
+	v3 := &Manifest{UploadID: "v3", PreviousManifestID: "v2", Files: []FileEntry{fileEntry("f.txt", "k3", 3)}, Chunks: []ChunkEntry{{S3Key: "k3"}}}
+
+	eff, err := ResolveEffective(context.Background(), v3, chainFetch(map[string]*Manifest{"v1": v1, "v2": v2}))
+	if err != nil {
+		t.Fatalf("ResolveEffective: %v", err)
+	}
+	if len(eff.Files) != 1 || eff.Files[0].S3Key != "k3" || eff.Files[0].Size != 3 {
+		t.Errorf("newest (v3) must win for f.txt, got %+v", eff.Files)
+	}
+	if len(eff.Chunks) != 1 || eff.Chunks[0].S3Key != "k3" {
+		t.Errorf("only the referenced (k3) chunk should remain, got %+v", eff.Chunks)
+	}
+}
+
+func TestResolveEffective_NoChain(t *testing.T) {
+	m := &Manifest{UploadID: "solo", Files: []FileEntry{fileEntry("x", "k", 1)}}
+	eff, err := ResolveEffective(context.Background(), m, nil) // nil fetcher is fine with no chain
+	if err != nil {
+		t.Fatalf("ResolveEffective: %v", err)
+	}
+	if eff != m {
+		t.Error("a manifest with no PreviousManifestID should be returned unchanged")
+	}
+}
+
+func TestResolveEffective_Cycle(t *testing.T) {
+	// a -> b -> a
+	a := &Manifest{UploadID: "a", PreviousManifestID: "b"}
+	b := &Manifest{UploadID: "b", PreviousManifestID: "a"}
+	_, err := ResolveEffective(context.Background(), a, chainFetch(map[string]*Manifest{"a": a, "b": b}))
+	if err == nil {
+		t.Fatal("expected an error on a cyclic chain")
+	}
+}
+
+func TestResolveEffective_MissingAncestor(t *testing.T) {
+	v2 := &Manifest{UploadID: "v2", PreviousManifestID: "v1", Files: []FileEntry{fileEntry("a", "k", 1)}}
+	_, err := ResolveEffective(context.Background(), v2, chainFetch(map[string]*Manifest{}))
+	if err == nil {
+		t.Fatal("expected an error when an ancestor cannot be fetched (must fail loudly, not truncate)")
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #552. An incremental `cargoship sync` uploads **only changed files**, so the newest manifest is a delta chained to its predecessor via `PreviousManifestID`. Restore read a **single** manifest and never followed the chain (no `PreviousManifestID` consumer in the restore path), so any file **unchanged since an earlier version was silently unrestorable** from the latest version — a correctness/trust bug, since the newest upload looks like "the current dataset" but only contains that run's delta.

## Fix (Model B — chain-merged effective view)

Adds `manifest.ResolveEffective(ctx, m, fetch)`: it walks `PreviousManifestID`, downloads ancestors, and merges files **newest-wins per path** into an effective, full-dataset manifest. `restore` resolves the chain before extracting.

Why it's safe:
- Each surviving `FileEntry` keeps its own `S3Key` (which embeds the origin uploadID and is globally unique), and the merged `Chunks` are the union of every chunk a surviving file references.
- The extractor joins **file → chunk by `S3Key`** (`batch_restore.go:566-583`), not by `(chunk_id, shard_id)`, so merging manifests across versions cannot collide.
- A **cyclic or unfetchable chain is an error** — fail loudly, never return a truncated dataset.

Chosen over the write-side alternative because it **retroactively fixes already-written incremental archives** with **no format change** and lives in one place.

## Scope / follow-ups (noted on #552)

- **`verify` is not yet chain-aware.** Its single-manifest validator enforces invariants (`shard_count == len(shards)`, chunk_id joins) that a merged view intentionally breaks, so feeding it the effective manifest would falsely fail. Making verify chain-aware needs a different approach — tracked.
- **Deletes** aren't persisted by `sync` today, so a file removed in a later version is still reconstructed from an ancestor — tracked.
- **Mixed direct+chunked** across versions in one dataset is not handled (assumes a consistent mode).

## Tests

`ResolveEffective` regression tests: newest-wins incremental chain (the #552 case — asserts an unchanged file is recovered from the ancestor and a modified file uses its latest bytes), three-version chains, no-chain passthrough, cycle detection, missing-ancestor error. All `pkg/manifest` + restore cmd tests pass; staticcheck/vet clean.

Refs #552, #521 (this is its Phase 0 prerequisite).