### PR TITLE
fix(access): close policy-exposure false negatives in access-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`access-check` no longer reports a genuinely public bucket/KMS key as "ok".**
+  A focused security pass on the v0.28.0 access checks found false negatives in
+  the policy-exposure detection: a **single-object** `Statement` (valid AWS
+  grammar, not just arrays) failed to parse and was reported clean; **any**
+  `Condition` — even a non-principal one like `aws:SecureTransport` — exempted a
+  wildcard `Principal`; and `NotPrincipal` Allow statements (grant-to-everyone-
+  except) were never inspected. The policy parser now normalizes single-object
+  statements, treats an **unparseable** policy as `unknown` (never `ok`), only
+  credits a wildcard as scoped when the `Condition` carries a principal-narrowing
+  key (`aws:PrincipalOrgID`, `kms:ViaService`, …), and flags `NotPrincipal`
+  Allow. Most impactful for the KMS key-policy check, which has no `IsPublic`
+  backstop. The `ok` wording now notes cross-account grants aren't evaluated, and
+  `upload --fail-on` help clarifies that `warn`/`critical` don't trip on
+  unevaluated checks.
+
 ## [0.28.0] - 2026-09-13
 
 **Access controls & an incremental-restore data-integrity fix.** Adds a

--- a/cmd/cargoship/cmd/upload.go
+++ b/cmd/cargoship/cmd/upload.go
@@ -946,7 +946,7 @@ Examples:
 
 	// Issue #529: access-control posture preflight
 	cmd.Flags().Bool("check-access", false, "Report the target bucket's access-control posture before uploading (see the 'access-check' command)")
-	cmd.Flags().String("fail-on", "none", "With --check-access, abort if the worst finding is at least this severe: none, unknown, warn, critical")
+	cmd.Flags().String("fail-on", "none", "With --check-access, abort if the worst finding is at least this severe: none, unknown, warn, critical (warn/critical do NOT trip on checks that couldn't be evaluated — use 'unknown' to also fail when a check was denied)")
 
 	// Issue #166: Direct upload optimization (fast path for small files)
 	cmd.Flags().Bool("direct-upload", false, "Enable direct upload mode (bypasses archiving/compression for small files)")

--- a/docs/gen/cli/cargoship_upload.md
+++ b/docs/gen/cli/cargoship_upload.md
@@ -68,7 +68,7 @@ cargoship upload SOURCE_DIR DESTINATION [flags]
       --dvc-stage string                 DVC pipeline stage name to extract provenance from (reads dvc.yaml + dvc.lock)
       --enable-dedup                     Enable cross-shard file deduplication (10-30% space savings for redundant datasets)
       --encrypt-manifest                 Encrypt manifest with KMS envelope encryption (requires --kms-key-id)
-      --fail-on string                   With --check-access, abort if the worst finding is at least this severe: none, unknown, warn, critical (default "none")
+      --fail-on string                   With --check-access, abort if the worst finding is at least this severe: none, unknown, warn, critical (warn/critical do NOT trip on checks that couldn't be evaluated — use 'unknown' to also fail when a check was denied) (default "none")
       --force-direct-upload              Force direct upload regardless of thresholds (for benchmarking)
       --force-restart                    Ignore saved state and start fresh upload (bypasses resume detection)
       --frame-size string                Cut compressed chunks into random-access zstd frames every N bytes (e.g. 16MiB, 64MB); 0 disables framing (default "16MiB")

--- a/docs/project/verification-reports.md
+++ b/docs/project/verification-reports.md
@@ -34,7 +34,7 @@ release assets to find the evidence.
 
 | Version | Date | Files | Bytes | Paths | Suites | Result | Report |
 |---------|------|-------|-------|-------|--------|--------|--------|
-| v0.28.0 | 2026-09-13 | — | — | direct, chunked | — | ⏳ Run in progress | Pending — attached by the real-AWS lane after the release publishes. |
+| v0.28.0 | 2026-09-13 | 20 | 61.01 MB | direct, chunked | 48 / 0 | ✅ Passed | [`v0.28.0-2026-09-13.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.28.0/v0.28.0-2026-09-13.md) |
 | v0.27.0 | 2026-09-13 | 20 | 61.01 MB | direct, chunked | 47 / 0 | ✅ Passed | [`v0.27.0-2026-09-13.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.27.0/v0.27.0-2026-09-13.md) |
 | v0.26.0 | 2026-09-12 | 20 | 61.01 MB | direct, chunked | 47 / 0 | ✅ Passed | [`v0.26.0-2026-09-12.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.26.0/v0.26.0-2026-09-12.md) |
 | v0.25.0 | 2026-09-12 | 20 | 61.01 MB | direct, chunked | 47 / 0 | ✅ Passed | [`v0.25.0-2026-09-12.md`](https://github.com/scttfrdmn/cargoship/releases/download/v0.25.0/v0.25.0-2026-09-12.md) |

--- a/pkg/aws/access/access.go
+++ b/pkg/aws/access/access.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -248,17 +247,25 @@ func (c *Checker) checkBucketPolicy(ctx context.Context, bucket string) Finding 
 		}
 		return Finding{Check: check, Severity: SeverityUnknown, Summary: "Bucket policy check failed", Detail: err.Error()}
 	}
-	wildcards := wildcardPrincipalStatements(aws.ToString(out.Policy))
-	if len(wildcards) > 0 {
+	hits, ok := analyzePolicy(aws.ToString(out.Policy))
+	if !ok {
+		return Finding{
+			Check:       check,
+			Severity:    SeverityUnknown,
+			Summary:     "Bucket policy present but could not be parsed",
+			Remediation: "Inspect the bucket policy manually — CargoShip could not evaluate it, so treat its exposure as unknown.",
+		}
+	}
+	if len(hits) > 0 {
 		return Finding{
 			Check:       check,
 			Severity:    SeverityCritical,
-			Summary:     "Bucket policy grants access to a wildcard principal",
-			Detail:      fmt.Sprintf("%d Allow statement(s) with Principal \"*\": %s", len(wildcards), strings.Join(wildcards, ", ")),
-			Remediation: "Scope the bucket policy Principal to specific accounts/roles, or add a Condition that restricts it.",
+			Summary:     "Bucket policy grants broad/public access",
+			Detail:      fmt.Sprintf("%d Allow statement(s) grant to a wildcard or NotPrincipal: %s", len(hits), strings.Join(hits, ", ")),
+			Remediation: "Scope the bucket policy Principal to specific accounts/roles, or gate it with a principal-narrowing Condition (e.g. aws:PrincipalOrgID).",
 		}
 	}
-	return Finding{Check: check, Severity: SeverityOK, Summary: "Bucket policy has no wildcard-principal Allow statements"}
+	return Finding{Check: check, Severity: SeverityOK, Summary: "Bucket policy has no public/wildcard-principal Allow statements (cross-account grants not evaluated)"}
 }
 
 func (c *Checker) checkBucketACL(ctx context.Context, bucket string) Finding {
@@ -369,17 +376,25 @@ func (c *Checker) checkKMS(ctx context.Context, bucket string) Finding {
 		}
 		return Finding{Check: check, Severity: SeverityUnknown, Summary: "KMS key-policy check failed", Detail: err.Error()}
 	}
-	wildcards := wildcardPrincipalStatements(aws.ToString(pol.Policy))
-	if len(wildcards) > 0 {
+	hits, ok := analyzePolicy(aws.ToString(pol.Policy))
+	if !ok {
+		return Finding{
+			Check:       check,
+			Severity:    SeverityUnknown,
+			Summary:     fmt.Sprintf("KMS key %s policy could not be parsed", keyID),
+			Remediation: "Inspect the key policy manually — CargoShip could not evaluate it, so treat its scoping as unknown.",
+		}
+	}
+	if len(hits) > 0 {
 		return Finding{
 			Check:       check,
 			Severity:    SeverityWarn,
-			Summary:     "KMS key policy has wildcard-principal Allow statements",
-			Detail:      fmt.Sprintf("key %s: %d statement(s) with Principal \"*\" — verify a Condition scopes them: %s", keyID, len(wildcards), strings.Join(wildcards, ", ")),
-			Remediation: "Ensure any Principal \"*\" statement in the key policy is constrained by a Condition (e.g. kms:ViaService, aws:PrincipalOrgID).",
+			Summary:     "KMS key policy grants broad access",
+			Detail:      fmt.Sprintf("key %s: %d Allow statement(s) with a wildcard or NotPrincipal not scoped by a principal-narrowing condition: %s", keyID, len(hits), strings.Join(hits, ", ")),
+			Remediation: "Constrain any Principal \"*\" statement in the key policy with a principal-narrowing Condition (e.g. kms:ViaService, aws:PrincipalOrgID), and avoid NotPrincipal Allow.",
 		}
 	}
-	return Finding{Check: check, Severity: SeverityOK, Summary: fmt.Sprintf("KMS key %s policy has no unconditioned wildcard-principal grants", keyID)}
+	return Finding{Check: check, Severity: SeverityOK, Summary: fmt.Sprintf("KMS key %s policy has no broad (wildcard/NotPrincipal) grants", keyID)}
 }
 
 // defaultBucketKMSKey returns the KMS key ID from the bucket's default SSE-KMS
@@ -404,55 +419,116 @@ func (c *Checker) defaultBucketKMSKey(ctx context.Context, bucket string) (strin
 	return "", nil
 }
 
-// policyDocument is the minimal shape of an IAM/S3/KMS policy we parse. The
-// Principal and Action fields are polymorphic in JSON (string or list/object),
-// so they are decoded as json.RawMessage and interpreted by helpers.
-type policyDocument struct {
-	Statement []struct {
-		Sid       string          `json:"Sid"`
-		Effect    string          `json:"Effect"`
-		Principal json.RawMessage `json:"Principal"`
-		Condition json.RawMessage `json:"Condition"`
-	} `json:"Statement"`
+// policyStatement is one statement of an IAM/S3/KMS policy. Principal,
+// NotPrincipal, and Condition are polymorphic JSON, decoded as RawMessage and
+// interpreted by helpers.
+type policyStatement struct {
+	Sid          string          `json:"Sid"`
+	Effect       string          `json:"Effect"`
+	Principal    json.RawMessage `json:"Principal"`
+	NotPrincipal json.RawMessage `json:"NotPrincipal"`
+	Condition    json.RawMessage `json:"Condition"`
 }
 
-// wildcardPrincipalStatements returns the Sid (or index) of every Allow
-// statement whose Principal is the wildcard "*" (or {"AWS":"*"}) AND which
-// carries no Condition. Statements gated by a Condition are treated as
-// intentionally scoped and excluded — a Principal "*" with a Condition is a
-// common, legitimate pattern (e.g. kms:ViaService, aws:SourceArn).
-func wildcardPrincipalStatements(policyJSON string) []string {
+// policyDocument captures the Statement raw because the AWS grammar allows it to
+// be either a single object or an array; analyzePolicy normalizes both.
+type policyDocument struct {
+	Statement json.RawMessage `json:"Statement"`
+}
+
+// narrowingConditionKeys are condition keys that genuinely restrict WHO can act
+// (not merely how or when), so a wildcard Principal gated by one is
+// intentionally scoped rather than public. Compared case-insensitively.
+var narrowingConditionKeys = map[string]bool{
+	"aws:principalorgid":        true,
+	"aws:principalorgpaths":     true,
+	"aws:principalarn":          true,
+	"aws:principalaccount":      true,
+	"aws:sourceaccount":         true,
+	"aws:sourcearn":             true,
+	"aws:sourceowner":           true,
+	"aws:sourcevpc":             true,
+	"aws:sourcevpce":            true,
+	"kms:viaservice":            true,
+	"kms:calleraccount":         true,
+	"s3:dataaccesspointaccount": true,
+}
+
+// analyzePolicy parses a policy document and returns a label for every Allow
+// statement that grants broad/public access: a wildcard Principal ("*" or
+// {"AWS":"*"}) not scoped by a principal-narrowing Condition, or any
+// NotPrincipal Allow (which grants to everyone except the listed principals).
+//
+// ok is false when the policy is present but cannot be parsed at all — callers
+// MUST treat !ok as "unknown", NEVER as "clean". A silently-OK unparseable
+// policy is a false negative that would report a genuinely public target as safe.
+func analyzePolicy(policyJSON string) (hits []string, ok bool) {
 	policyJSON = strings.TrimSpace(policyJSON)
 	if policyJSON == "" {
-		return nil
-	}
-	// Bucket-policy JSON may arrive URL-encoded from some APIs; decode best-effort.
-	if !strings.HasPrefix(policyJSON, "{") {
-		if dec, err := url.QueryUnescape(policyJSON); err == nil {
-			policyJSON = dec
-		}
+		return nil, true // no policy document → no broad grants
 	}
 	var doc policyDocument
 	if err := json.Unmarshal([]byte(policyJSON), &doc); err != nil {
-		return nil
+		return nil, false
 	}
-	var hits []string
-	for i, st := range doc.Statement {
+	// Statement may be a single object or an array in the AWS grammar.
+	var stmts []policyStatement
+	if err := json.Unmarshal(doc.Statement, &stmts); err != nil {
+		var single policyStatement
+		if err2 := json.Unmarshal(doc.Statement, &single); err2 != nil {
+			return nil, false
+		}
+		stmts = []policyStatement{single}
+	}
+	for i, st := range stmts {
 		if !strings.EqualFold(st.Effect, "Allow") {
 			continue
 		}
-		if len(st.Condition) > 0 && string(st.Condition) != "null" && string(st.Condition) != "{}" {
-			continue // conditioned wildcard — treated as intentionally scoped
+		label := st.Sid
+		if label == "" {
+			label = fmt.Sprintf("statement[%d]", i)
+		}
+		// Allow + NotPrincipal grants to everyone EXCEPT the listed principals —
+		// effectively public and almost never intended.
+		if hasContent(st.NotPrincipal) {
+			hits = append(hits, label+" (NotPrincipal)")
+			continue
 		}
 		if principalIsWildcard(st.Principal) {
-			label := st.Sid
-			if label == "" {
-				label = fmt.Sprintf("statement[%d]", i)
+			// A wildcard is only truly scoped by a Condition that narrows WHO;
+			// a condition of only transport/time keys (e.g. aws:SecureTransport)
+			// leaves the object world-readable and must still be reported.
+			if hasContent(st.Condition) && conditionNarrowsPrincipal(st.Condition) {
+				continue
 			}
 			hits = append(hits, label)
 		}
 	}
-	return hits
+	return hits, true
+}
+
+// hasContent reports whether a RawMessage is present and not JSON null or {}.
+func hasContent(raw json.RawMessage) bool {
+	s := strings.TrimSpace(string(raw))
+	return len(s) > 0 && s != "null" && s != "{}"
+}
+
+// conditionNarrowsPrincipal reports whether a Condition block contains at least
+// one principal-narrowing key (see narrowingConditionKeys). An unparseable
+// condition is NOT credited as scoping (safer to over-report).
+func conditionNarrowsPrincipal(raw json.RawMessage) bool {
+	var cond map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &cond); err != nil {
+		return false
+	}
+	for _, kv := range cond {
+		for key := range kv {
+			if narrowingConditionKeys[strings.ToLower(key)] {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // principalIsWildcard reports whether a policy Principal is the unrestricted

--- a/pkg/aws/access/access_test.go
+++ b/pkg/aws/access/access_test.go
@@ -293,26 +293,46 @@ func TestChecker_KMS(t *testing.T) {
 	})
 }
 
-func TestWildcardPrincipalStatements(t *testing.T) {
+func TestAnalyzePolicy(t *testing.T) {
 	tests := []struct {
-		name   string
-		policy string
-		want   int
+		name    string
+		policy  string
+		wantHit int
+		wantOK  bool
 	}{
-		{"empty", "", 0},
-		{"star string", `{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*"}]}`, 1},
-		{"aws star object", `{"Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:*"}]}`, 1},
-		{"aws star in list", `{"Statement":[{"Effect":"Allow","Principal":{"AWS":["arn:x","*"]},"Action":"s3:*"}]}`, 1},
-		{"deny star ignored", `{"Statement":[{"Effect":"Deny","Principal":"*","Action":"s3:*"}]}`, 0},
-		{"conditioned star excluded", `{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*","Condition":{"StringEquals":{"aws:PrincipalOrgID":"o-1"}}}]}`, 0},
-		{"scoped principal ok", `{"Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::1:root"},"Action":"s3:*"}]}`, 0},
-		{"malformed json", `not json`, 0},
-		{"url encoded", `%7B%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%22*%22%2C%22Action%22%3A%22s3%3A*%22%7D%5D%7D`, 1},
+		{"empty", "", 0, true},
+		{"star string", `{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*"}]}`, 1, true},
+		{"aws star object", `{"Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:*"}]}`, 1, true},
+		{"aws star in list", `{"Statement":[{"Effect":"Allow","Principal":{"AWS":["arn:x","*"]},"Action":"s3:*"}]}`, 1, true},
+		{"deny star ignored", `{"Statement":[{"Effect":"Deny","Principal":"*","Action":"s3:*"}]}`, 0, true},
+		{"scoped principal ok", `{"Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::1:root"},"Action":"s3:*"}]}`, 0, true},
+
+		// F1: a SINGLE-OBJECT Statement (not an array) with a wildcard must be
+		// detected — previously it failed to parse and reported clean.
+		{"single object statement wildcard", `{"Statement":{"Effect":"Allow","Principal":"*","Action":"s3:GetObject"}}`, 1, true},
+		{"single object statement scoped", `{"Statement":{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::1:root"},"Action":"s3:*"}}`, 0, true},
+
+		// F1: an unparseable policy must be reported as UNKNOWN (ok=false), never clean.
+		{"not json -> not ok", `not json`, 0, false},
+		{"statement wrong type -> not ok", `{"Statement": 42}`, 0, false},
+
+		// F2: a wildcard gated only by a NON-narrowing condition is still public.
+		{"secure-transport-only condition still flagged", `{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Condition":{"Bool":{"aws:SecureTransport":"true"}}}]}`, 1, true},
+		// F2: a principal-narrowing condition genuinely scopes the wildcard.
+		{"org-id condition excluded", `{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:*","Condition":{"StringEquals":{"aws:PrincipalOrgID":"o-1"}}}]}`, 0, true},
+		{"kms viaservice condition excluded", `{"Statement":[{"Effect":"Allow","Principal":"*","Action":"kms:*","Condition":{"StringEquals":{"kms:ViaService":"s3.us-west-2.amazonaws.com"}}}]}`, 0, true},
+
+		// F3: an Allow with NotPrincipal grants to everyone-except and is flagged.
+		{"not-principal allow flagged", `{"Statement":[{"Effect":"Allow","NotPrincipal":{"AWS":"arn:aws:iam::1:root"},"Action":"s3:*"}]}`, 1, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := len(wildcardPrincipalStatements(tt.policy)); got != tt.want {
-				t.Errorf("want %d wildcard statements, got %d", tt.want, got)
+			hits, ok := analyzePolicy(tt.policy)
+			if ok != tt.wantOK {
+				t.Errorf("ok: want %v, got %v", tt.wantOK, ok)
+			}
+			if len(hits) != tt.wantHit {
+				t.Errorf("want %d broad-grant statements, got %d (%v)", tt.wantHit, len(hits), hits)
 			}
 		})
 	}


### PR DESCRIPTION
A focused security pass on the v0.28.0 `access-check` feature (agent-assisted, read-only) found **false negatives in the policy-exposure detection** — the one thing this feature must never do is report a genuinely public bucket/KMS key as "ok". This closes them.

## Findings fixed

- **F1 (Medium, confirmed) — single-object `Statement`.** AWS policy grammar allows `Statement` to be a single object, not just an array. That shape failed `json.Unmarshal`, the check found no hits, and reported **OK**. Worst for **KMS**, which has no `GetBucketPolicyStatus` backstop.
- **F2 (Medium, confirmed) — any `Condition` exempted a wildcard.** A `Principal:"*"` gated only by `aws:SecureTransport` (transport, not *who*) was treated as "scoped" and cleared, though the object is world-readable over HTTPS.
- **F3 (Medium, confirmed) — `NotPrincipal` Allow.** Grant-to-everyone-except statements were never parsed.
- **F4 (Low) — wording.** The `ok` summary now states cross-account grants aren't evaluated (they're out of scope, but the old wording invited over-trust).
- **F6 (Low) — URL-decode fallback** dropped (near-dead, and `+`→space could corrupt a policy → false OK).
- **F5 (Low) — `--fail-on` help** clarifies `warn`/`critical` don't trip on checks that couldn't be evaluated (use `unknown`).

## The fix

`analyzePolicy` now: normalizes single-object → one-element slice; returns `ok=false` on an unparseable policy so callers emit **`unknown`, never `ok`**; only credits a wildcard as scoped when the `Condition` carries a **principal-narrowing** key (`aws:PrincipalOrgID`/`PrincipalArn`/`SourceArn`/…, `kms:ViaService`/`CallerAccount`, …); and flags `NotPrincipal` Allow.

## Confirmed sound (not changed)

The same review adversarially verified restore path-traversal defense (#282 lexical + #341 `os.Root` openat) and that the **#552 chain-merge does not bypass it** — ancestor-supplied paths get the same unconditional sanitization. No secret logging; `enforceAccessFailOn` fails closed on bad input; AccessDenied classification never maps a non-permission error to OK.

Tests cover single-object, unparseable→unknown, `NotPrincipal`, and narrowing-vs-non-narrowing conditions.